### PR TITLE
Update exercises-class.ptx

### DIFF
--- a/source/c1-classification/exercises-class.ptx
+++ b/source/c1-classification/exercises-class.ptx
@@ -119,7 +119,7 @@
 				</task>
 
 				<task label="class-cq-mc-04">
-					<statement><p>	Which of the following describes an example of a <term>nonlinear</term> term?</p></statement>
+					<statement><p>Which of the following describes an example of a <term>nonlinear</term> term?</p></statement>
 					<choices randomize="yes">
 						<choice correct="yes">
 							<statement><p>A dependent variable inside another function.</p></statement>
@@ -167,7 +167,7 @@
 						</match>
 						<match>
 							<premise><m>7e^y</m></premise>
-							<response>Non-Linear Term</response>
+							<response>Nonlinear</response>
 						</match>
 						<match>
 							<premise><m>2</m></premise>
@@ -460,7 +460,7 @@
 				</task>
 
 				<task label="class-drill-5-06">
-					<statement><p>Click-on all the linear differential equations.</p></statement>
+					<statement><p>Click on all the linear differential equations.</p></statement>
 					
 					<areas>
 						<tabular>
@@ -490,7 +490,7 @@
 				</task>
 
 				<task label="class-drill-5-07">
-					<statement><p>Click-on all the nonlinear differential equations</p></statement>
+					<statement><p>Click on all the nonlinear differential equations.</p></statement>
 					<areas>
 						<tabular>
 							<row><cell><m/></cell></row>

--- a/source/c1-classification/exercises-class.ptx
+++ b/source/c1-classification/exercises-class.ptx
@@ -473,7 +473,7 @@
 							<row><cell><m/></cell></row>
 							<row>
 								<cell><area correct="no"><m> y'' + y^2 = 17t					</m></area></cell>
-								<cell><area correct="yes"><m> y'' + \dfrac{y'}{t} + y = 17t	</m></area></cell>
+								<cell><area correct="yes"><m> y'' + \dfrac{y'}{t} + y = 17t		</m></area></cell>
 								<cell><area correct="yes"><m> y = y'							</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
@@ -495,28 +495,28 @@
 						<tabular>
 							<row><cell><m/></cell></row>
 							<row>
-								<cell><area correct="yes">	<m> \dfrac{dx}{ds} = x^2 - 4						</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dx}{ds} = x^2 - 4											</m></area></cell>
 								<cell><area correct="no">	<m> \dfrac{d^2u}{dz^2} - 5 \dfrac{du}{dz} + 6u = 0	</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dp}{d\tau} + \sin(p) = \tau^2			</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dp}{d\tau} + \sin(p) = \tau^2					</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 							<row>
 								<cell><area correct="no">	<m> \dfrac{dw}{dv} + 2vw = \cos(v)				</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dr}{d\theta} + r^3 = \theta			</m></area></cell>
-								<cell><area correct="no">	<m> \dfrac{dN}{dt} = -N							</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dr}{d\theta} + r^3 = \theta	</m></area></cell>
+								<cell><area correct="no">	<m> \dfrac{dN}{dt} = -N										</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 							<row>
-								<cell><area correct="yes">	<m> \dfrac{dm}{dq} = m^3 - q^2					</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dz}{dt} + z\dfrac{dz}{dt} = t^3			</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dy}{dx} = y \ln(y)						</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dm}{dq} = m^3 - q^2							</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dz}{dt} + z\dfrac{dz}{dt} = t^3	</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dy}{dx} = y \ln(y)								</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 						</tabular>
 					</areas>
 					<hint>
 						<p>
-							First identify the dependent variable, then carefully look at each term to determine if it is nonlinear.
+							First, identify the dependent variable, then carefully examine each term to determine whether it is nonlinear.
 						</p>
 					</hint>
 					<feedback><p>Nonlinear equations often have terms where the dependent variable or its derivatives are raised to powers other than one, or are inside functions like sine, logarithms, or are multiplied by each other.</p></feedback>
@@ -703,69 +703,69 @@
 							<col width="13%"/>
 							<row>
 								<cell/>
-								<cell><p>				Differential Equation	</p></cell>
-								<cell colspan="4"><p>	Dependent Variable?		</p></cell>
-								<cell colspan="2"><p>	Linear?					</p></cell>
+								<cell><p>Differential Equation</p></cell>
+								<cell colspan="4"><p>	Dependent Variable?</p></cell>
+								<cell colspan="2"><p>	Linear?</p></cell>
 							</row>
 							<row>
-								<cell>	(a)	</cell>
-								<cell>	<m> \dfrac{d^2u}{dr^2} + \dfrac{du}{dr} + u = \cos(r+u) </m>	</cell>
+								<cell>(a)</cell>
+								<cell><m>\dfrac{d^2u}{dr^2} + \dfrac{du}{dr} + u = \cos(r+u)</m></cell>
 								<cell/>
-								<cell><area correct="no">	<m>\ r\ </m>	</area></cell>
-								<cell><area correct="yes">	<m>\ u\ </m>	</area></cell>
+								<cell><area correct="no">	<m>\ r\ </m></area></cell>
+								<cell><area correct="yes">	<m>\ u\ </m></area></cell>
 								<cell/>
 								<cell><area correct="no">	yes	</area></cell>
 								<cell><area correct="yes">	no	</area></cell>
 							</row>
 							<row>
-								<cell>	(b)	</cell>
-								<cell>	<m> x \dfrac{d^3y}{dx^3} - \left( \dfrac{dy}{dx} \right)^4 + y = 0 </m>	</cell>
+								<cell>(b)</cell>
+								<cell><m> x \dfrac{d^3y}{dx^3} - \left( \dfrac{dy}{dx} \right)^4 + y = 0 </m></cell>
 								<cell/>
-								<cell><area correct="no">	<m>\ x\ </m>	</area></cell>
-								<cell><area correct="yes">	<m>\ y\ </m>	</area></cell>
-								<cell/>
-								<cell><area correct="no">	yes	</area></cell>
-								<cell><area correct="yes">	no	</area></cell>
-							</row>
-							<row>
-								<cell>	(c)	</cell>
-								<cell>	<m>\vphantom{\dfrac11} t^5 x^{(4)} - t^3 x'' + 6x = 0 </m>	</cell>
-								<cell/>
-								<cell><area correct="yes">	<m>\ x\ </m>	</area></cell>
-								<cell><area correct="no">	<m>\ t\ </m>	</area></cell>
-								<cell/>
-								<cell><area correct="yes">	yes	</area></cell>
-								<cell><area correct="no">	no	</area></cell>
-							</row>
-							<row>
-								<cell>	(d)	</cell>
-								<cell>	<m> \dfrac{d^2x}{dy^2} = \sqrt{1 + \dfrac{dx}{dy}} </m>	</cell>
-								<cell/>
-								<cell><area correct="yes">	<m>\ x\ </m>	</area></cell>
-								<cell><area correct="no">	<m>\ y\ </m>	</area></cell>
+								<cell><area correct="no">	<m>\ x\ </m></area></cell>
+								<cell><area correct="yes">	<m>\ y\ </m></area></cell>
 								<cell/>
 								<cell><area correct="no">	yes	</area></cell>
 								<cell><area correct="yes">	no	</area></cell>
 							</row>
 							<row>
-								<cell>	(e)	</cell>
-								<cell>	<m>\dfrac{d^2R}{dt^2} = -\dfrac{k}{R^2}</m>	</cell>
+								<cell>(c)</cell>
+								<cell><m>\vphantom{\dfrac11} t^5 x^{(4)} - t^3 x'' + 6x = 0 </m></cell>
 								<cell/>
-								<cell><area correct="yes">	<m>\ R\ </m>	</area></cell>
-								<cell><area correct="no">	<m>\ t\ </m>	</area></cell>
+								<cell><area correct="yes"><m>\ x\ </m></area></cell>
+								<cell><area correct="no"><m>\ t\ </m></area></cell>
 								<cell/>
-								<cell><area correct="no">	yes	</area></cell>
-								<cell><area correct="yes">	no	</area></cell>
+								<cell><area correct="yes">yes</area></cell>
+								<cell><area correct="no">no</area></cell>
 							</row>
 							<row>
-								<cell>	(f)	</cell>
-								<cell>	<m>\vphantom{\dfrac11} (\sin \theta)y''' - (\cos \theta)y' = 2</m>	</cell>
+								<cell>(d)</cell>
+								<cell><m>\dfrac{d^2x}{dy^2} = \sqrt{1 + \dfrac{dx}{dy}}</m></cell>
 								<cell/>
-								<cell><area correct="no">	<m>\ \theta\ </m>	</area></cell>
-								<cell><area correct="yes">	<m>\ y\ </m>		</area></cell>
+								<cell><area correct="yes"><m>\ x\ </m></area></cell>
+								<cell><area correct="no"><m>\ y\ </m></area></cell>
 								<cell/>
-								<cell><area correct="yes">	yes	</area></cell>
-								<cell><area correct="no">	no	</area></cell>
+								<cell><area correct="no">yes</area></cell>
+								<cell><area correct="yes">no</area></cell>
+							</row>
+							<row>
+								<cell>(e)</cell>
+								<cell><m>\dfrac{d^2R}{dt^2} = -\dfrac{k}{R^2}</m></cell>
+								<cell/>
+								<cell><area correct="yes"><m>\ R\ </m></area></cell>
+								<cell><area correct="no"><m>\ t\ </m></area></cell>
+								<cell/>
+								<cell><area correct="no">yes</area></cell>
+								<cell><area correct="yes">no</area></cell>
+							</row>
+							<row>
+								<cell>(f)</cell>
+								<cell><m>\vphantom{\dfrac11} (\sin \theta)y''' - (\cos \theta)y' = 2</m></cell>
+								<cell/>
+								<cell><area correct="no"><m>\ \theta\ </m></area></cell>
+								<cell><area correct="yes"><m>\ y\ </m></area></cell>
+								<cell/>
+								<cell><area correct="yes">yes</area></cell>
+								<cell><area correct="no">no</area></cell>
 							</row>
 							<row><cell colspan="2"><m>\phantom{Extra Vertical Space}</m></cell></row>
 						</tabular>
@@ -817,9 +817,9 @@
 									<cell bottom="none">(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\dfrac{d^2u}{dr^2}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>\dfrac{du}{dr}</m>		</area>	<m>\quad</m>
-										<area correct="yes">	<m>u</m>					</area>	<m>\quad</m>
-										<area correct="yes">	<m>\cos(r)</m>				</area>
+										<area correct="yes">	<m>\dfrac{du}{dr}</m>			</area>	<m>\quad</m>
+										<area correct="yes">	<m>u</m>									</area>	<m>\quad</m>
+										<area correct="yes">	<m>\cos(r)</m>						</area>
 									</cell>
 								</row>
 								<row>
@@ -864,8 +864,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>(1 - x)y''</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m> -4xy'</m>		</area>	<m>\quad</m>
-										<area correct="yes">	<m>5y</m>				</area>	<m>\quad</m>
+										<area correct="yes">	<m> -4xy'</m>			</area>	<m>\quad</m>
+										<area correct="yes">	<m>5y</m>					</area>	<m>\quad</m>
 										<area correct="yes">	<m>\cos x</m>			</area>
 									</cell>
 								</row>
@@ -910,10 +910,10 @@
 								<row>
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
-										<area correct="yes">	<m> x \dfrac{d^3y}{dx^3}</m>				</area>	<m>\quad</m>
+										<area correct="yes">	<m> x \dfrac{d^3y}{dx^3}</m>							</area>	<m>\quad</m>
 										<area correct="no">		<m> -\left( \dfrac{dy}{dx} \right)^4</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>y</m>									</area>	<m>\quad</m>
-										<area correct="yes">	<m>0</m>									</area>
+										<area correct="yes">	<m>y</m>																	</area>	<m>\quad</m>
+										<area correct="yes">	<m>0</m>																	</area>
 									</cell>
 								</row>
 								<row>
@@ -958,8 +958,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>t^5 y^{(4)}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>t^3 y''</m>		</area>	<m>\quad</m>
-										<area correct="yes">	<m>6y</m>			</area>	<m>\quad</m>
+										<area correct="yes">	<m>t^3 y''</m>			</area>	<m>\quad</m>
+										<area correct="yes">	<m>6y</m>						</area>	<m>\quad</m>
 									</cell>
 								</row>
 								<row>
@@ -1049,7 +1049,7 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\dfrac{d^2R}{dt^2}</m>	</area>	<m>\quad</m>
-										<area correct="no">		<m> -\dfrac{k}{R}</m>		</area>
+										<area correct="no">		<m> -\dfrac{k}{R}</m>			</area>
 									</cell>
 								</row>
 								<row>
@@ -1094,8 +1094,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\sin \theta y'''</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>-\cos \theta y'</m>		</area>	<m>\quad</m>
-										<area correct="yes">	<m>2</m>					</area>
+										<area correct="yes">	<m>-\cos \theta y'</m>	</area>	<m>\quad</m>
+										<area correct="yes">	<m>2</m>								</area>
 									</cell>
 								</row>
 								<row>
@@ -1140,8 +1140,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>y\dfrac{dy}{dx}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>4y</m>				</area>	<m>\quad</m>
-										<area correct="yes">	<m>x^6e^x</m>			</area>
+										<area correct="yes">	<m>4y</m>								</area>	<m>\quad</m>
+										<area correct="yes">	<m>x^6e^x</m>						</area>
 									</cell>
 								</row>
 								<row>
@@ -1186,8 +1186,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\sin(x)\dfrac{dy}{dx}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>3y</m>					</area>	<m>\quad</m>
-										<area correct="yes">	<m>0</m>					</area>
+										<area correct="yes">	<m>3y</m>											</area>	<m>\quad</m>
+										<area correct="yes">	<m>0</m>											</area>
 									</cell>
 								</row>
 								<row>
@@ -1232,9 +1232,9 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\dfrac{dP}{dt}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>2tP</m>			</area>	<m>\quad</m>
-										<area correct="yes">	<m>P</m>				</area>	<m>\quad</m>
-										<area correct="yes">	<m>4t-2</m>			</area>
+										<area correct="yes">	<m>2tP</m>						</area>	<m>\quad</m>
+										<area correct="yes">	<m>P</m>							</area>	<m>\quad</m>
+										<area correct="yes">	<m>4t-2</m>						</area>
 									</cell>
 								</row>
 								<row>
@@ -1324,9 +1324,9 @@
 								<row>
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
-										<area correct="yes">	<m>r\ln(p)</m>	</area>	<m>\quad</m>
+										<area correct="yes">	<m>r\ln(p)</m>			</area>	<m>\quad</m>
 										<area correct="yes">	<m>p^2 r^{(5)}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>r'''</m>	</area>
+										<area correct="yes">	<m>r'''</m>					</area>
 									</cell>
 								</row>
 								<row>


### PR DESCRIPTION
# PR Notes — exercises-class

## T4 checklist (paste into PR description)
> These are **not** auto-applied because they require changing PTX attribute values (e.g., `correct="yes"`), which is disallowed by the LAW files.

- [ ] **class-classification-05**: “Solves for” appears marked as **r** but equation solves for **x** (would require changing `<area correct="...">`).
- [ ] **class-classification-07**: “Solves for” appears marked as **θ** but equation solves for **y** (would require changing `<area correct="...">`).
- [ ] **class-classification-08**: “Order” appears marked as **4th** but equation is **1st** order (would require changing `<area correct="...">`).
- [ ] **class-classification-09**: “Order” appears marked as **3rd** but equation is **1st** order (would require changing `<area correct="...">`).
- [ ] **class-classification-10**: “Order” appears marked as **3rd** but equation is **1st** order (would require changing `<area correct="...">`).
- [ ] **class-classification-11**: “Solves for” appears marked as **u** and “Order” as **4th**, but equation is for **x** and is **3rd** order (would require changing `<area correct="...">`).
- [ ] **class-classification-12**: “Order” appears marked as **4th** but equation includes **r^(5)** so order is **5th** (would require changing `<area correct="...">`).

## Manual-review candidates (not auto-applied)
- See checklist above.