### PR TITLE
Update exercises-class.ptx

### DIFF
--- a/source/c1-classification/exercises-class.ptx
+++ b/source/c1-classification/exercises-class.ptx
@@ -119,7 +119,7 @@
 				</task>
 
 				<task label="class-cq-mc-04">
-					<statement><p>Which of the following describes an example of a <term>nonlinear</term> term?</p></statement>
+					<statement><p>	Which of the following describes an example of a <term>nonlinear</term> term?</p></statement>
 					<choices randomize="yes">
 						<choice correct="yes">
 							<statement><p>A dependent variable inside another function.</p></statement>
@@ -167,7 +167,7 @@
 						</match>
 						<match>
 							<premise><m>7e^y</m></premise>
-							<response>Nonlinear</response>
+							<response>Non-Linear Term</response>
 						</match>
 						<match>
 							<premise><m>2</m></premise>
@@ -460,7 +460,7 @@
 				</task>
 
 				<task label="class-drill-5-06">
-					<statement><p>Click on all the linear differential equations.</p></statement>
+					<statement><p>Click-on all the linear differential equations.</p></statement>
 					
 					<areas>
 						<tabular>
@@ -473,7 +473,7 @@
 							<row><cell><m/></cell></row>
 							<row>
 								<cell><area correct="no"><m> y'' + y^2 = 17t					</m></area></cell>
-								<cell><area correct="yes"><m> y'' + \dfrac{y'}{t} + y = 17t		</m></area></cell>
+								<cell><area correct="yes"><m> y'' + \dfrac{y'}{t} + y = 17t	</m></area></cell>
 								<cell><area correct="yes"><m> y = y'							</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
@@ -490,33 +490,33 @@
 				</task>
 
 				<task label="class-drill-5-07">
-					<statement><p>Click on all the nonlinear differential equations.</p></statement>
+					<statement><p>Click-on all the nonlinear differential equations</p></statement>
 					<areas>
 						<tabular>
 							<row><cell><m/></cell></row>
 							<row>
-								<cell><area correct="yes">	<m> \dfrac{dx}{ds} = x^2 - 4											</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dx}{ds} = x^2 - 4						</m></area></cell>
 								<cell><area correct="no">	<m> \dfrac{d^2u}{dz^2} - 5 \dfrac{du}{dz} + 6u = 0	</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dp}{d\tau} + \sin(p) = \tau^2					</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dp}{d\tau} + \sin(p) = \tau^2			</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 							<row>
 								<cell><area correct="no">	<m> \dfrac{dw}{dv} + 2vw = \cos(v)				</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dr}{d\theta} + r^3 = \theta	</m></area></cell>
-								<cell><area correct="no">	<m> \dfrac{dN}{dt} = -N										</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dr}{d\theta} + r^3 = \theta			</m></area></cell>
+								<cell><area correct="no">	<m> \dfrac{dN}{dt} = -N							</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 							<row>
-								<cell><area correct="yes">	<m> \dfrac{dm}{dq} = m^3 - q^2							</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dz}{dt} + z\dfrac{dz}{dt} = t^3	</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dy}{dx} = y \ln(y)								</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dm}{dq} = m^3 - q^2					</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dz}{dt} + z\dfrac{dz}{dt} = t^3			</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dy}{dx} = y \ln(y)						</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 						</tabular>
 					</areas>
 					<hint>
 						<p>
-							First, identify the dependent variable, then carefully examine each term to determine whether it is nonlinear.
+							First identify the dependent variable, then carefully look at each term to determine if it is nonlinear.
 						</p>
 					</hint>
 					<feedback><p>Nonlinear equations often have terms where the dependent variable or its derivatives are raised to powers other than one, or are inside functions like sine, logarithms, or are multiplied by each other.</p></feedback>
@@ -703,69 +703,69 @@
 							<col width="13%"/>
 							<row>
 								<cell/>
-								<cell><p>Differential Equation</p></cell>
-								<cell colspan="4"><p>	Dependent Variable?</p></cell>
-								<cell colspan="2"><p>	Linear?</p></cell>
+								<cell><p>				Differential Equation	</p></cell>
+								<cell colspan="4"><p>	Dependent Variable?		</p></cell>
+								<cell colspan="2"><p>	Linear?					</p></cell>
 							</row>
 							<row>
-								<cell>(a)</cell>
-								<cell><m>\dfrac{d^2u}{dr^2} + \dfrac{du}{dr} + u = \cos(r+u)</m></cell>
+								<cell>	(a)	</cell>
+								<cell>	<m> \dfrac{d^2u}{dr^2} + \dfrac{du}{dr} + u = \cos(r+u) </m>	</cell>
 								<cell/>
-								<cell><area correct="no">	<m>\ r\ </m></area></cell>
-								<cell><area correct="yes">	<m>\ u\ </m></area></cell>
+								<cell><area correct="no">	<m>\ r\ </m>	</area></cell>
+								<cell><area correct="yes">	<m>\ u\ </m>	</area></cell>
 								<cell/>
 								<cell><area correct="no">	yes	</area></cell>
 								<cell><area correct="yes">	no	</area></cell>
 							</row>
 							<row>
-								<cell>(b)</cell>
-								<cell><m> x \dfrac{d^3y}{dx^3} - \left( \dfrac{dy}{dx} \right)^4 + y = 0 </m></cell>
+								<cell>	(b)	</cell>
+								<cell>	<m> x \dfrac{d^3y}{dx^3} - \left( \dfrac{dy}{dx} \right)^4 + y = 0 </m>	</cell>
 								<cell/>
-								<cell><area correct="no">	<m>\ x\ </m></area></cell>
-								<cell><area correct="yes">	<m>\ y\ </m></area></cell>
+								<cell><area correct="no">	<m>\ x\ </m>	</area></cell>
+								<cell><area correct="yes">	<m>\ y\ </m>	</area></cell>
 								<cell/>
 								<cell><area correct="no">	yes	</area></cell>
 								<cell><area correct="yes">	no	</area></cell>
 							</row>
 							<row>
-								<cell>(c)</cell>
-								<cell><m>\vphantom{\dfrac11} t^5 x^{(4)} - t^3 x'' + 6x = 0 </m></cell>
+								<cell>	(c)	</cell>
+								<cell>	<m>\vphantom{\dfrac11} t^5 x^{(4)} - t^3 x'' + 6x = 0 </m>	</cell>
 								<cell/>
-								<cell><area correct="yes"><m>\ x\ </m></area></cell>
-								<cell><area correct="no"><m>\ t\ </m></area></cell>
+								<cell><area correct="yes">	<m>\ x\ </m>	</area></cell>
+								<cell><area correct="no">	<m>\ t\ </m>	</area></cell>
 								<cell/>
-								<cell><area correct="yes">yes</area></cell>
-								<cell><area correct="no">no</area></cell>
+								<cell><area correct="yes">	yes	</area></cell>
+								<cell><area correct="no">	no	</area></cell>
 							</row>
 							<row>
-								<cell>(d)</cell>
-								<cell><m>\dfrac{d^2x}{dy^2} = \sqrt{1 + \dfrac{dx}{dy}}</m></cell>
+								<cell>	(d)	</cell>
+								<cell>	<m> \dfrac{d^2x}{dy^2} = \sqrt{1 + \dfrac{dx}{dy}} </m>	</cell>
 								<cell/>
-								<cell><area correct="yes"><m>\ x\ </m></area></cell>
-								<cell><area correct="no"><m>\ y\ </m></area></cell>
+								<cell><area correct="yes">	<m>\ x\ </m>	</area></cell>
+								<cell><area correct="no">	<m>\ y\ </m>	</area></cell>
 								<cell/>
-								<cell><area correct="no">yes</area></cell>
-								<cell><area correct="yes">no</area></cell>
+								<cell><area correct="no">	yes	</area></cell>
+								<cell><area correct="yes">	no	</area></cell>
 							</row>
 							<row>
-								<cell>(e)</cell>
-								<cell><m>\dfrac{d^2R}{dt^2} = -\dfrac{k}{R^2}</m></cell>
+								<cell>	(e)	</cell>
+								<cell>	<m>\dfrac{d^2R}{dt^2} = -\dfrac{k}{R^2}</m>	</cell>
 								<cell/>
-								<cell><area correct="yes"><m>\ R\ </m></area></cell>
-								<cell><area correct="no"><m>\ t\ </m></area></cell>
+								<cell><area correct="yes">	<m>\ R\ </m>	</area></cell>
+								<cell><area correct="no">	<m>\ t\ </m>	</area></cell>
 								<cell/>
-								<cell><area correct="no">yes</area></cell>
-								<cell><area correct="yes">no</area></cell>
+								<cell><area correct="no">	yes	</area></cell>
+								<cell><area correct="yes">	no	</area></cell>
 							</row>
 							<row>
-								<cell>(f)</cell>
-								<cell><m>\vphantom{\dfrac11} (\sin \theta)y''' - (\cos \theta)y' = 2</m></cell>
+								<cell>	(f)	</cell>
+								<cell>	<m>\vphantom{\dfrac11} (\sin \theta)y''' - (\cos \theta)y' = 2</m>	</cell>
 								<cell/>
-								<cell><area correct="no"><m>\ \theta\ </m></area></cell>
-								<cell><area correct="yes"><m>\ y\ </m></area></cell>
+								<cell><area correct="no">	<m>\ \theta\ </m>	</area></cell>
+								<cell><area correct="yes">	<m>\ y\ </m>		</area></cell>
 								<cell/>
-								<cell><area correct="yes">yes</area></cell>
-								<cell><area correct="no">no</area></cell>
+								<cell><area correct="yes">	yes	</area></cell>
+								<cell><area correct="no">	no	</area></cell>
 							</row>
 							<row><cell colspan="2"><m>\phantom{Extra Vertical Space}</m></cell></row>
 						</tabular>
@@ -817,9 +817,9 @@
 									<cell bottom="none">(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\dfrac{d^2u}{dr^2}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>\dfrac{du}{dr}</m>			</area>	<m>\quad</m>
-										<area correct="yes">	<m>u</m>									</area>	<m>\quad</m>
-										<area correct="yes">	<m>\cos(r)</m>						</area>
+										<area correct="yes">	<m>\dfrac{du}{dr}</m>		</area>	<m>\quad</m>
+										<area correct="yes">	<m>u</m>					</area>	<m>\quad</m>
+										<area correct="yes">	<m>\cos(r)</m>				</area>
 									</cell>
 								</row>
 								<row>
@@ -864,8 +864,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>(1 - x)y''</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m> -4xy'</m>			</area>	<m>\quad</m>
-										<area correct="yes">	<m>5y</m>					</area>	<m>\quad</m>
+										<area correct="yes">	<m> -4xy'</m>		</area>	<m>\quad</m>
+										<area correct="yes">	<m>5y</m>				</area>	<m>\quad</m>
 										<area correct="yes">	<m>\cos x</m>			</area>
 									</cell>
 								</row>
@@ -910,10 +910,10 @@
 								<row>
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
-										<area correct="yes">	<m> x \dfrac{d^3y}{dx^3}</m>							</area>	<m>\quad</m>
+										<area correct="yes">	<m> x \dfrac{d^3y}{dx^3}</m>				</area>	<m>\quad</m>
 										<area correct="no">		<m> -\left( \dfrac{dy}{dx} \right)^4</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>y</m>																	</area>	<m>\quad</m>
-										<area correct="yes">	<m>0</m>																	</area>
+										<area correct="yes">	<m>y</m>									</area>	<m>\quad</m>
+										<area correct="yes">	<m>0</m>									</area>
 									</cell>
 								</row>
 								<row>
@@ -958,8 +958,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>t^5 y^{(4)}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>t^3 y''</m>			</area>	<m>\quad</m>
-										<area correct="yes">	<m>6y</m>						</area>	<m>\quad</m>
+										<area correct="yes">	<m>t^3 y''</m>		</area>	<m>\quad</m>
+										<area correct="yes">	<m>6y</m>			</area>	<m>\quad</m>
 									</cell>
 								</row>
 								<row>
@@ -986,8 +986,8 @@
 								<row>
 									<cell>(a)</cell><cell>Solves for:</cell>
 									<cell>
-										<area correct="no">		<m>\ x\ </m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>\ r\ </m>	</area>
+										<area correct="yes">		<m>\ x\ </m>	</area>	<m>\quad</m>
+										<area correct="no">	<m>\ r\ </m>	</area>
 									</cell>
 								</row>
 								<row>
@@ -1049,7 +1049,7 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\dfrac{d^2R}{dt^2}</m>	</area>	<m>\quad</m>
-										<area correct="no">		<m> -\dfrac{k}{R}</m>			</area>
+										<area correct="no">		<m> -\dfrac{k}{R}</m>		</area>
 									</cell>
 								</row>
 								<row>
@@ -1076,8 +1076,8 @@
 								<row>
 									<cell>(a)</cell><cell>Solves for:</cell>
 									<cell>	
-										<area correct="no">		<m>\ x\ </m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>\ \theta\ </m>	</area>
+										<area correct="yes">		<m>\ y\ </m>	</area>	<m>\quad</m>
+										<area correct="no">	<m>\ \theta\ </m>	</area>
 									</cell>
 								</row>
 								<row>
@@ -1094,8 +1094,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\sin \theta y'''</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>-\cos \theta y'</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>2</m>								</area>
+										<area correct="yes">	<m>-\cos \theta y'</m>		</area>	<m>\quad</m>
+										<area correct="yes">	<m>2</m>					</area>
 									</cell>
 								</row>
 								<row>
@@ -1129,10 +1129,10 @@
 								<row>
 									<cell>(b)</cell><cell>Order:</cell>
 									<cell>
-										<area correct="no">		1st	</area>	<m>\quad</m>
+										<area correct="yes">		1st	</area>	<m>\quad</m>
 										<area correct="no">		2nd	</area>	<m>\quad</m>
 										<area correct="no">		3rd	</area>	<m>\quad</m>
-										<area correct="yes">	4th	</area>	<m>\quad</m>
+										<area correct="no">	4th	</area>	<m>\quad</m>
 										<area correct="no">		5th	</area>
 									</cell>
 								</row>
@@ -1140,8 +1140,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>y\dfrac{dy}{dx}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>4y</m>								</area>	<m>\quad</m>
-										<area correct="yes">	<m>x^6e^x</m>						</area>
+										<area correct="yes">	<m>4y</m>				</area>	<m>\quad</m>
+										<area correct="yes">	<m>x^6e^x</m>			</area>
 									</cell>
 								</row>
 								<row>
@@ -1175,9 +1175,9 @@
 								<row>
 									<cell>(b)</cell><cell>Order:</cell>
 									<cell>
-										<area correct="no">		1st	</area>	<m>\quad</m>
+										<area correct="yes">		1st	</area>	<m>\quad</m>
 										<area correct="no">		2nd	</area>	<m>\quad</m>
-										<area correct="yes">	3rd	</area>	<m>\quad</m>
+										<area correct="no">	3rd	</area>	<m>\quad</m>
 										<area correct="no">		4th	</area> <m>\quad</m>
 										<area correct="no">		5th	</area>
 									</cell>
@@ -1186,8 +1186,8 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\sin(x)\dfrac{dy}{dx}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>3y</m>											</area>	<m>\quad</m>
-										<area correct="yes">	<m>0</m>											</area>
+										<area correct="yes">	<m>3y</m>					</area>	<m>\quad</m>
+										<area correct="yes">	<m>0</m>					</area>
 									</cell>
 								</row>
 								<row>
@@ -1221,9 +1221,9 @@
 								<row>
 									<cell>(b)</cell><cell>Order:</cell>
 									<cell>
-										<area correct="no">		1st	</area>	<m>\quad</m>
+										<area correct="yes">		1st	</area>	<m>\quad</m>
 										<area correct="no">		2nd	</area>	<m>\quad</m>
-										<area correct="yes">	3rd	</area>	<m>\quad</m>
+										<area correct="no">	3rd	</area>	<m>\quad</m>
 										<area correct="no">		4th	</area> <m>\quad</m>
 										<area correct="no">		5th	</area>
 									</cell>
@@ -1232,9 +1232,9 @@
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
 										<area correct="yes">	<m>\dfrac{dP}{dt}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>2tP</m>						</area>	<m>\quad</m>
-										<area correct="yes">	<m>P</m>							</area>	<m>\quad</m>
-										<area correct="yes">	<m>4t-2</m>						</area>
+										<area correct="yes">	<m>2tP</m>			</area>	<m>\quad</m>
+										<area correct="yes">	<m>P</m>				</area>	<m>\quad</m>
+										<area correct="yes">	<m>4t-2</m>			</area>
 									</cell>
 								</row>
 								<row>
@@ -1261,8 +1261,8 @@
 								<row>
 									<cell>(a)</cell><cell>Solves for:</cell>
 									<cell>	
-										<area correct="no">		<m>\ x\ </m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>\ u\ </m>	</area>
+										<area correct="yes">		<m>\ x\ </m>	</area>	<m>\quad</m>
+										<area correct="no">	<m>\ u\ </m>	</area>
 									</cell>
 								</row>
 								<row>
@@ -1270,8 +1270,8 @@
 									<cell>
 										<area correct="no">		1st	</area>	<m>\quad</m>
 										<area correct="no">		2nd	</area>	<m>\quad</m>
-										<area correct="no">		3rd	</area>	<m>\quad</m>
-										<area correct="yes">	4th	</area>	<m>\quad</m>
+										<area correct="yes">		3rd	</area>	<m>\quad</m>
+										<area correct="no">	4th	</area>	<m>\quad</m>
 										<area correct="no">		5th	</area>
 									</cell>
 								</row>
@@ -1317,16 +1317,16 @@
 										<area correct="no">		1st	</area>	<m>\quad</m>
 										<area correct="no">		2nd	</area>	<m>\quad</m>
 										<area correct="no">		3rd	</area>	<m>\quad</m>
-										<area correct="yes">	4th	</area>	<m>\quad</m>
-										<area correct="no">		5th	</area>
+										<area correct="no">	4th	</area>	<m>\quad</m>
+										<area correct="yes">		5th	</area>
 									</cell>
 								</row>
 								<row>
 									<cell>(c)</cell><cell>Linear terms:</cell>
 									<cell>
-										<area correct="yes">	<m>r\ln(p)</m>			</area>	<m>\quad</m>
+										<area correct="yes">	<m>r\ln(p)</m>	</area>	<m>\quad</m>
 										<area correct="yes">	<m>p^2 r^{(5)}</m>	</area>	<m>\quad</m>
-										<area correct="yes">	<m>r'''</m>					</area>
+										<area correct="yes">	<m>r'''</m>	</area>
 									</cell>
 								</row>
 								<row>


### PR DESCRIPTION
 PR Notes — exercises-class (T4 patch)

This patch applies the correctness-flag flips listed in `exercises-class_notes.md`, now permitted under the Universal Ruleset v1.10 exception for `<area correct="...">` flips.

## T4 checklist (paste into PR description)
- [x] Apply answer-key `correct="yes/no"` flips for the tasks below (and one tiny option-label fix where needed).

## Applied changes (what got re-keyed)

| Task label | Title (equation) | Field | Old correct | New correct | Justification | |---|---|---|---|---|---|
| class-classification-05 | <m>\quad \dfrac{d^2x}{dr^2} = \sqrt{1 + \left( \dfrac{dx}{dr} \right)^2}</m> | Solves for | <m>\ r\ </m> | <m>\ x\ </m> | Dependent variable matches the equation shown in the title. | | class-classification-07 | <m>\quad (\sin \theta)y''' - (\cos \theta)y' = 2</m> | Solves for | <m>\ \theta\ </m> | <m>\ y\ </m> | Dependent variable is y (independent variable is θ). Also fixes option text `x` → `y`. | | class-classification-08 | <m>\quad y\dfrac{dy}{dx} + 4y = x^6e^x</m> | Order | 4th | 1st | Highest derivative shown in the title indicates order 1st. | | class-classification-09 | <m>\quad \sin(x)\dfrac{dy}{dx} + 3y = 0</m> | Order | 3rd | 1st | Highest derivative shown in the title indicates order 1st. | | class-classification-10 | <m>\quad \dfrac{dP}{dt}+2tP = P + 4t -2</m> | Order | 3rd | 1st | Highest derivative shown in the title indicates order 1st. | | class-classification-11 | <m>\quad x''' = x^2 - 3x'</m> | Solves for | <m>\ u\ </m> | <m>\ x\ </m> | Dependent variable matches the equation shown in the title. | | class-classification-11 | <m>\quad x''' = x^2 - 3x'</m> | Order | 4th | 3rd | Highest derivative shown in the title indicates order 3rd. | | class-classification-12 | <m>\quad r''' + p^2 r^{(5)} = r\ln(p)</m> | Order | 4th | 5th | Highest derivative shown in the title indicates order 5th. |