### PR TITLE
Update sec-general-particular-solns.ptx

### DIFF
--- a/source/c2-solns/sec-general-particular-solns.ptx
+++ b/source/c2-solns/sec-general-particular-solns.ptx
@@ -46,7 +46,7 @@
 		<me>
 			x^2y'' - xy' = 2
 		</me>.
-		In this case, the general solution contains two arbitrary constants. To get a particular solution, we need to assign specific values to both <m>c_1</m> and <m>c_2</m>. <xref ref="general-to-particular-solutions"/> shows how some particular solutions are generated from the general solution by selecting different values for the constants.
+		In this case, the general solution contains two arbitrary constants. To obtain a particular solution, we must assign specific values to both <m>c_1</m> and <m>c_2</m>. <xref ref="general-to-particular-solutions"/> shows how some particular solutions are generated from the general solution by selecting different values for the constants.
 	</p>
 
 	<table xml:id="general-to-particular-solutions">

--- a/source/c2-solns/sec-general-particular-solns.ptx
+++ b/source/c2-solns/sec-general-particular-solns.ptx
@@ -18,7 +18,7 @@
 			<me>
 				y' - 2y = 0
 			</me>
-			has multiple solutions, all which differ by a constant factor:
+			has multiple solutions, all of which differ by a constant factor:
 			<me>
 				y = e^{2x},\quad y = 3e^{2x},\quad y = -5e^{2x},\quad y = \pi e^{2x}, \quad\text{ etc. } 
 			</me>
@@ -46,7 +46,7 @@
 		<me>
 			x^2y'' - xy' = 2
 		</me>.
-		In this case, the general solution contains two arbtrary constants. To get a particular solution, we need to assign specific values to both <m>c_1</m> and <m>c_2</m>. <xref ref="general-to-particular-solutions"/> shows how some particular solutions are generated from the general solution by selecting different values for the constants.
+		In this case, the general solution contains two arbitrary constants. To get a particular solution, we need to assign specific values to both <m>c_1</m> and <m>c_2</m>. <xref ref="general-to-particular-solutions"/> shows how some particular solutions are generated from the general solution by selecting different values for the constants.
 	</p>
 
 	<table xml:id="general-to-particular-solutions">
@@ -97,12 +97,12 @@
 
 	<warning xml:id="general-solution-warning">
 		<title>Not all solutions with constants are general solutions</title>
-		<p> 
+		<p>
 			Keep in mind, solutions with arbitrary constants are not general solutions by default. For example, both of the functions
 			<me>
 				y = \frac{1}{2}x^2 + c_1 x \quad \text{and} \quad y = \frac{1}{2}x^2 + c_1 x + c_2
 			</me>
-			are solutions to the equation <m>y'' = 1</m>, but only the second is general solution. The first is a special case of the second, obtained when <m>c_2 = 0</m>.
+			are solutions to the equation <m>y'' = 1</m>, but only the second is the general solution. The first is a special case of the second, obtained when <m>c_2 = 0</m>.
 		</p>
 	</warning>
 
@@ -129,14 +129,14 @@
 					<row><cell></cell></row>
 					<row>
 						<cell><area correct="yes"><m>y = \dfrac{3}{4} - \dfrac{1}{t^2}</m></area></cell><cell/>
-						<cell><area correct="no">	<m>y = \dfrac{2}{t^2}</m></area> </cell><cell/>
+						<cell><area correct="no"><m>y = \dfrac{2}{t^2}</m></area></cell><cell/>
 						<cell><area correct="yes"><m>y = \dfrac{3}{4} + \dfrac{\pi}{t^2}</m></area></cell>
 					</row>
 					<row><cell><m/></cell></row>
 					<row>
 						<cell><area correct="yes"><m>y = \dfrac{3}{4} + \dfrac{1.6}{t^2}</m></area></cell><cell/>
 						<cell><area correct="yes"><m>y = \dfrac{3}{4}</m></area></cell><cell/>
-						<cell><area correct="no"> <m>y = \dfrac{1}{4} + \dfrac{3}{t^2}</m></area></cell>
+						<cell><area correct="no"><m>y = \dfrac{1}{4} + \dfrac{3}{t^2}</m></area></cell>
 					</row>
 					<row><cell><m/></cell></row>
 				</tabular>
@@ -144,7 +144,7 @@
 		</task>
 
 		<task label="c2-2-cyu-1-chkpt-2">
-			<title><e component="emoji">📖❓</e>  General or Particular</title>
+			<title><e component="emoji">📖❓</e> General or Particular</title>
 			<statement>
 				<p>
 					Fill in the following blanks, below, with one of the following terms:
@@ -229,7 +229,7 @@
 		</task>
 
 		<task label="c2-2-cyu-1-chkpt-3">
-			<title><e component="emoji">📖❓</e>  Describe a Family of Solutions</title>
+			<title><e component="emoji">📖❓</e> Describe a Family of Solutions</title>
 			<statement>
 				<p>
 					If a solution to a differential equation contains an arbitrary constant, it is a general solution. 
@@ -243,7 +243,7 @@
 							<me>
 								y = \frac{1}{2}x^2 + c_1 x \quad \text{and} \quad y = \frac{1}{2}x^2 + c_1 x + c_2
 							</me>
-							are solutions to the equation <m>y'' = 1</m>, but only the second is general solution. The first is a special case of the second, obtained when <m>c_2 = 0</m>.
+							are solutions to the equation <m>y'' = 1</m>, but only the second is the general solution. The first is a special case of the second, obtained when <m>c_2 = 0</m>.
 						</p>
 					</feedback>
 				</choice>


### PR DESCRIPTION
T4 checklist for PR description

None. (No meaning/math/key changes were auto-applied.)

Quick manual-review flag (not auto-fixed)

<definition xml:id="def-"> looks like an incomplete/placeholder xml:id. This is an attribute issue, so it’s reported only (no JSON edit) per the “no tag/attribute edits” rule. 

UPL_Universal_Ruleset_V1.10