### PR TITLE
Update sec-initial-valued-problems.ptx

### DIFF
--- a/source/c2-solns/sec-initial-valued-problems.ptx
+++ b/source/c2-solns/sec-initial-valued-problems.ptx
@@ -14,7 +14,7 @@
 	<title>Initial-Value Problems (IVPs)</title>
 
 	<p>
-		<xref ref="general-to-particular-solutions"/> illustrates how particular solutions can be generated from the general solution. However, in real-world problems, these constants are not selected. Instead, they are determined from known or assumed information about the initial state of the problem. These known values are called <term>initial conditions</term> and when a differential equation is paired with initial conditions that equation becomes an <term>initial-value problem</term> (IVP). 
+		<xref ref="general-to-particular-solutions"/> illustrates how particular solutions can be generated from the general solution. However, in real-world problems, these constants are not selected. Instead, they are determined from known or assumed information about the initial state of the problem. These known values are called <term>initial conditions</term>, and when a differential equation is paired with initial conditions, that equation becomes an <term>initial-value problem</term> (IVP). 
 	</p>
 
 	<p>
@@ -191,7 +191,7 @@
 		<title>Check your Understanding</title>
 
 		<task label="c2-3-cyu-1-chkpt-1">
-			<title><e component="emoji">📖❓</e>  Initial Condition Meaning</title>
+			<title><e component="emoji">📖❓</e> Initial Condition Meaning</title>
 			<statement>
 				<p>
 					Assume we have a differential equation with dependent variable <m>y</m> and independent variable <m>x</m>.
@@ -233,7 +233,7 @@
 					</statement>
 					<feedback>
 						<p>
-							Incorrect. An initial condition is not just any point; it's a specific point referring to a known value of <m>y</m> or one of it's derivatives
+							Incorrect. An initial condition is not just any point; it's a specific point referring to a known value of <m>y</m> or one of its derivatives.
 						</p>
 					</feedback>
 				</choice>
@@ -253,7 +253,7 @@
 		</task>
 		
 		<task label="c2-3-cyu-1-chkpt-2">
-			<title><e component="emoji">📖❓</e>  Is it an IVP</title>
+			<title><e component="emoji">📖❓</e> Is it an IVP</title>
 			<statement>
 				<p>
 					The differential equation
@@ -284,7 +284,7 @@
 		</task>
 
 		<task label="c2-3-cyu-1-chkpt-3">
-			<title><e component="emoji">📖❓</e>  When is your Answer a Particular Solution</title>
+			<title><e component="emoji">📖❓</e> When is your Answer a Particular Solution</title>
 			<statement>
 				<p>
 					In which case would you need to find a particular solution rather than just a general solution?
@@ -318,7 +318,7 @@
 				<choice>
 					<statement>
 						<p>
-							When the differential equation is has a general solution.
+							When the differential equation has a general solution.
 						</p>
 					</statement>
 					<feedback>
@@ -342,5 +342,7 @@
 			</choices>
 		</task>
 	</exercise>
+
+
 
 </section>

--- a/source/c2-solns/sec-initial-valued-problems.ptx
+++ b/source/c2-solns/sec-initial-valued-problems.ptx
@@ -14,11 +14,11 @@
 	<title>Initial-Value Problems (IVPs)</title>
 
 	<p>
-		<xref ref="general-to-particular-solutions"/> illustrates how particular solutions can be generated from the general solution. However, in real-world problems, these constants are not selected. Instead, they are determined from known or assumed information about the initial state of the problem. These known values are called <term>initial conditions</term>, and when a differential equation is paired with initial conditions, that equation becomes an <term>initial-value problem</term> (IVP). 
+		<xref ref="general-to-particular-solutions"/> illustrates how particular solutions can be generated from the general solution. However, in real-world problems, these constants are not selected. Instead, they are determined from known or assumed information about the problem's initial state. These known values are called <term>initial conditions</term>, and when a differential equation is coupled with initial conditions, the resulting problem is an <term>initial-value problem</term> (IVP). 
 	</p>
 
 	<p>
-		For example, suppose you are modeling an object in free fall and you know the following about the object:
+		For example, suppose you are modeling an object in free fall, and you know the following about the object:
 		<ol marker="(1)">
 			<li>The object falls under constant acceleration <m>32\ \mathrm{ft/s^2}</m>.</li>
 			<li>The object is dropped from <m>100\ \mathrm{ft}</m>.</li>
@@ -62,7 +62,7 @@
 	</p>
 
 	<p>
-		To summarize, solutions to differential equations lead to general solutions, whereas solutions to initial-value problems lead to particular solutions.
+		To summarize, solutions to differential equations yield general solutions, whereas solutions to initial-value problems yield particular solutions.
 	</p>
 
 	<example xml:id="example-initial-conditions-1" label="solving-for-a-constant">
@@ -276,7 +276,7 @@
 					<statement>False</statement>
 					<feedback>
 						<p>
-							Correct! This is just a differential equation, without initial conditions, it is not an initial-value problem.
+							Correct! This is just a differential equation; without initial conditions, it is not an initial-value problem.
 						</p>
 					</feedback>
 				</choice>
@@ -311,7 +311,7 @@
 					</statement>
 					<feedback>
 						<p>
-							Correct! A particular solution is found when you need to satisfy initial conditions.
+							Correct! A particular solution is obtained when the initial conditions are satisfied.
 						</p>
 					</feedback>
 				</choice>


### PR DESCRIPTION
Report-only flags (RO) — not auto-applied

In the free-fall constants derivation list, the first bullet is <li label="2"> while the next is unlabeled; if that numbering is unintentional, it’s an attribute-level issue (forbidden to auto-edit). 

sec-initial-valued-problems