### PR TITLE
Update sec-verifying-solns.ptx

### DIFF
--- a/source/c2-solns/sec-verifying-solns.ptx
+++ b/source/c2-solns/sec-verifying-solns.ptx
@@ -14,7 +14,7 @@
 	<title>Verifying Solutions</title>
 
 	<p>
-		Verifying that a given function is a solution to a differential equation amounts to showing that it satisfies the equation. This typically involves taking any necessary derivatives of the function, substituting it into the equation, and simplifying both sides to see if they match. Here are some examples to illustrate this process.
+		Verifying that a given function is a solution to a differential equation amounts to showing that it satisfies the equation. This typically involves taking any necessary derivatives of the function, substituting them into the equation, and simplifying both sides to determine whether they match. Here are some examples to illustrate this process.
 	</p>
 
 	<example>

--- a/source/c2-solns/sec-verifying-solns.ptx
+++ b/source/c2-solns/sec-verifying-solns.ptx
@@ -30,7 +30,7 @@
 				<md>
 					<mrow> x\left( 4x \right) - 2x^2	\amp= \left( 2x^2 \right) </mrow>
 					<mrow> 								4x^2 - 2x^2	\amp= 2x^2 </mrow>
-					<mrow>											2x^2	\amp= 2x^2	\quad✅ </mrow>
+					<mrow>											2x^2	\amp= 2x^2	\quad✅</mrow>
 				</md>
 				This shows that <m>y = 2x^2</m> satisfies the equation and proves it is a solution.
 			</p>
@@ -59,15 +59,15 @@
 						2\left( -\sin t \right) + \left( \sin t \right)	\amp = \sin t
 					</mrow>
 					<mrow>													-2\sin t + \sin t	\amp = \sin t </mrow>
-					<mrow>																		-\sin t	\amp \ne \sin t \quad❌ </mrow>
+					<mrow>																		-\sin t	\amp \ne \sin t \quad❌</mrow>
 				</md>
-				Since the function on the left is different than the function on the right, <m>P = \sin t</m> does <term>not</term> satisfy the equation and is <term>not</term> a solution.
+				Since the function on the left is different from the function on the right, <m>P = \sin t</m> does <term>not</term> satisfy the equation and is <term>not</term> a solution.
 			</p>
 		</solution>
 	</example>
 
 	<p>
-		As you will soon learn, differential equations have many solutions and each of them share a common form, as the next example shows.
+		As you will soon learn, differential equations have many solutions and all of them share a common form, as the next example shows.
 	</p>
 
 	<example xml:id="example-whats-a-soln-1">
@@ -105,7 +105,7 @@
 	<example xml:id="example-whats-a-soln-2">
 		<statement>
 			<p>
-				Verify that <m>\ y = c_1\ x^2 + c_2 + \ln x\ </m> is a solution to
+				Verify that <m>\ y = c_1\ x^2 + c_2 - \ln x\ </m> is a solution to
 				<me>x^2y'' - xy' = 2</me>.
 			</p>
 		</statement>
@@ -131,7 +131,7 @@
 						2	\amp = 2 \quad✅
 					</mrow>
 				</md>
-				Thus, <m>\ y = c_1\ x^2 + c_2 + \ln x\ </m> is a solution to <m>y'' - y = -x^2</m>.
+				Thus, <m>\ y = c_1\ x^2 + c_2 - \ln x\ </m> is a solution to <m>x^2y'' - xy' = 2</m>.
 			</p>
 		</solution>
 	</example>


### PR DESCRIPTION
High-impact catch (math/correctness)

In example-whats-a-soln-2, the statement says + \ln x but the worked derivatives and substitution use - \ln x. 

sec-verifying-solns

Also, the final “Thus…” sentence incorrectly claims it’s a solution to y'' - y = -x^2, which doesn’t match the example’s equation. 

sec-verifying-solns

Your JSON fixes both (and keeps the example internally consistent).

Other improvements included

Grammar: “each of them share” → “all of them share” 

sec-verifying-solns

Usage: “different than” → “different from” 

sec-verifying-solns

PTX-safe cleanup: removed the extra space before </mrow> after ✅ / ❌ to match your newer exception rule style 

sec-verifying-solns

sec-verifying-solns

Follow-up note (outside this file, but important)

Since sec-general-particular-solns.txt references this same “example-whats-a-soln-2” result using + \ln x repeatedly (including in a table of particular solutions), it will become inconsistent after this fix. 

sec-general-particular-solns

sec-general-particular-solns

So you’ll probably want to update that file too when you reach it.