### PR TITLE
Update sec-visualizing-solns.ptx

### DIFF
--- a/source/c2-solns/sec-visualizing-solns.ptx
+++ b/source/c2-solns/sec-visualizing-solns.ptx
@@ -12,20 +12,17 @@
 -->
 <section label="visualizing-solutions">
 	<title>Visualizing Solutions</title>
+	<aside component="web"><title>🎧 Listen</title><p><audio component="readings" source="audio/readings/c2/solution-types.mp3" width="100%" /></p></aside>
 	
-	<introduction>
-		<aside component="web"><title>🎧 Listen</title><p><audio component="readings" source="audio/readings/c2/solution-types.mp3" width="100%" /></p></aside>
+	<p>
+		An effective way to deepen your understanding of solutions is through visualization. Even though a family of solutions includes infinitely many curves, plotting just a few helps reveal how the general solution, particular solutions, and initial conditions are related.
+	</p>
 
-		<p>
-			An effective way to deepen your understanding of solutions is through visualization. Even though a family of solutions includes infinitely many curves, plotting just a few helps reveal how the general solution, particular solutions, and initial conditions are related.
-		</p>
+	<p>
+		Think of a family of solutions like a map full of side-by-side paths. The map shows all possible routes a traveler could take, each one representing a particular solution. The general solution defines the layout of all these paths, and choosing an initial condition is like dropping a pin on the map: the curve that passes through that point is the specific path (or solution) you follow.
+	</p>
 
-		<p>
-			Think of a family of solutions like a map full of side-by-side paths. The map shows all possible routes a traveler could take, each one representing a particular solution. The general solution defines the layout of all these paths, and choosing an initial condition is like dropping a pin on the map: the curve that passes through that point is the specific path (or solution) you follow.
-		</p>
-	</introduction>
-
-	<subsection label="visualizing-solutions-interactive">
+	<paragraphs label="visualizing-solutions-interactive">
 		<title><e component="emoji">📈</e> Interactive: Visualizing Solutions</title>
 		<p>
 			Consider the differential equation:
@@ -53,9 +50,7 @@
 			</sidebyside>
 		</figure>
 
-		<p>
-			
-		</p>
+		<p></p>
 
 		<exercise label="c2-4-cyu-1">
 			<title>Interactive Follow-up Questions</title>
@@ -108,15 +103,15 @@
 					</choice>
 					<choice>
 						<statement><m>\quad y(0)=5</m></statement>
-						<feedback>Incorrect. <em>Hint: move <m>y(0)</m> around until you see the particular solution above.</em>.</feedback>
+						<feedback>Incorrect. <em>Hint: move <m>y(0)</m> around until you see the particular solution above.</em></feedback>
 					</choice>
 					<choice>
 						<statement><m>\quad y(0)=1.3</m></statement>
-						<feedback>Incorrect. <em>Hint: move <m>y(0)</m> around until you see the particular solution above.</em>.</feedback>
+						<feedback>Incorrect. <em>Hint: move <m>y(0)</m> around until you see the particular solution above.</em></feedback>
 					</choice>
 					<choice>
 						<statement><m>\quad y(1)=-1.7</m></statement>
-						<feedback>Incorrect. <em>Hint: move <m>y(0)</m> around until you see the particular solution above.</em>.</feedback>
+						<feedback>Incorrect. <em>Hint: move <m>y(0)</m> around until you see the particular solution above.</em></feedback>
 					</choice>
 				</choices>
 			</task>
@@ -135,15 +130,15 @@
 					</choice>
 					<choice>
 						<statement><m>\quad c = -2</m></statement>
-						<feedback>Incorrect. <em>Hint: identify the point <m>(1,1)</m> and move <m>y(0)</m> until the blue curve intersect with this point.</em></feedback>
+						<feedback>Incorrect. <em>Hint: identify the point <m>(1,1)</m> and move <m>y(0)</m> until the blue curve intersects with this point.</em></feedback>
 					</choice>
 					<choice> 
 						<statement><m>\quad c = 0.5</m></statement>
-						<feedback>Incorrect. <em>Hint: identify the point <m>(1,1)</m> and move <m>y(0)</m> until the blue curve intersect with this point.</em></feedback>
+						<feedback>Incorrect. <em>Hint: identify the point <m>(1,1)</m> and move <m>y(0)</m> until the blue curve intersects with this point.</em></feedback>
 					</choice>
 					<choice>
 						<statement><m>\quad c = -1</m></statement>
-						<feedback>Incorrect. <em>Hint: identify the point <m>(1,1)</m> and move <m>y(0)</m> until the blue curve intersect with this point.</em></feedback>
+						<feedback>Incorrect. <em>Hint: identify the point <m>(1,1)</m> and move <m>y(0)</m> until the blue curve intersects with this point.</em></feedback>
 					</choice>
 				</choices>
 			</task>
@@ -156,8 +151,8 @@
 						<statement>They determine the general form of the solution.</statement>
 						<feedback>Incorrect. Initial conditions are not used to find the general solution.</feedback>
 					</choice>
-					<choice correct="yes">
-						<statement>They used to determine the constants in the general solution.</statement>
+					<choice correct="no">
+						<statement>They are used to determine the constants in the general solution.</statement>
 						<feedback>Correct! Initial conditions are used to find specific values for constants in the general solution.</feedback>
 					</choice>
 					<choice correct="yes">
@@ -174,6 +169,6 @@
 
 		</exercise>
 		
-	</subsection>
+	</paragraphs>
 
 </section>


### PR DESCRIPTION
T4 checklist (for PR description)

 c2-4-cyu-1-chkpt-4 (Role of Initial Conditions): <answer>C</answer> indicates a single correct option, but the second choice is also marked correct="yes" and has a grammar error (“They used…”). Flip that second choice to correct="no" and fix to “They are used …”. 

sec-visualizing-solns