### PR TITLE
Update exercises-solns.ptx

### DIFF
--- a/source/c2-solns/exercises-solns.ptx
+++ b/source/c2-solns/exercises-solns.ptx
@@ -602,7 +602,7 @@
 								</li>
 								<li>
 									<p>
-										Are there any differences in how you verify solutions to differentials equations compared to algebraic equations? Explain.
+										Are there any differences in how you verify solutions to differential equations compared to algebraic equations? Explain.
 									</p>
 								</li>
 							</ol>
@@ -615,7 +615,7 @@
 					<title>Explain the Difference</title>
 					<statement>
 						<p>
-							In few sentences, explain the difference between a general solution, family of solutions, and a particualr solution.
+							In a few sentences, explain the difference between a general solution, a family of solutions, and a particular solution.
 						</p>
 						<p/>
 					</statement>
@@ -668,7 +668,7 @@
 								</li>
 								<li>
 									<p>
-										The process of verifying solutions to differential equations is exactly the same. However, with differential equations, we have to be more careful about confirming a <q>true statement</q>. With numbers, it is easy to see if <m>21=21</m> is true, but with functions, its a bit more tricky. We have to be sure that the functions are equal for all values of <m>x</m> (or the independent variable). For example, the statement
+										The process of verifying solutions to differential equations is exactly the same. However, with differential equations, we have to be more careful about confirming a <q>true statement</q>. With numbers, it is easy to see if <m>21=21</m> is true, but with functions, it's a bit trickier. We have to be sure that the functions are equal for all values of <m>x</m> (or the independent variable). For example, the statement
 										<me>
 											e^x + \sin^2 x + \cos^2 x = e^x + 1
 										</me>
@@ -953,7 +953,7 @@
 							<md>
 								<mrow>	y	\amp = 3\sin(t^2) </mrow>
 								<mrow>	y' 	\amp = 3\cos(t^2) \cdot 2t = 6t\cos(t^2) </mrow>
-								<mrow>	y'' \amp = 6\cos(t^2) - 6t\sin(t^2)(2t)	= 6\cos(t^2) </mrow>
+								<mrow>	y'' \amp = 6\cos(t^2) - 12t^2\sin(t^2) </mrow>
 							</md>
 							and plug them in:
 							<md>
@@ -1051,11 +1051,11 @@
 				</exercise>
 
 				<exercise label="solns-problems-verification-03">
-					<statement><p><m>y = 3\sin(x^2)</m>, <m>\quad y' - xy'' = 12x^2\sin(x^2)</m></p></statement>
+					<statement><p><m>y = 3\sin(x^2)</m>, <m>\quad y' - xy'' = 12x^3\sin(x^2)</m></p></statement>
 					<p>
 						<answer>
 							<p>
-								?
+								Yes.
 							</p>
 						</answer>
 					
@@ -1065,7 +1065,7 @@
 								<md>
 									<mrow>	y	\amp =  3\sin(x^2)									</mrow>
 									<mrow>	y' 	\amp =  3\cos(x^2) \cdot 2x	=	6x\cos(x^2)	</mrow>
-									<mrow>	y'' \amp = 6\cos(x^2) - 12x\sin(x^2)	=	6\cos(x^2) - 12x\sin(x^2)	</mrow>
+									<mrow>	y'' \amp = 6\cos(x^2) - 12x^2\sin(x^2)	</mrow>
 								</md>
 							</p>
 
@@ -1073,22 +1073,22 @@
 								Plug in <m>y, y',</m> and <m>y''</m> and simplify.
 								<md>
 									<mrow> 												
-										y' - xy'' - 12x^2\sin(x^2) 	
+										y' - xy'' - 12x^3\sin(x^2) 	
 											\amp = 0	
 									</mrow>
 									<mrow>
-										6x\cos(x^2) - x\left( 6\cos(x^2) - 12x\sin(x^2) \right) - 12x^2\sin(x^2)
+										6x\cos(x^2) - x\left( 6\cos(x^2) - 12x^2\sin(x^2) \right) - 12x^3\sin(x^2)
 											\amp = 0																
 									</mrow>
 									<mrow>
-										\cancel{6x\cos(x^2)} - \cancel{6x\cos(x^2)} - \cancel{12x^2\sin(x^2)} - \cancel{12x^2\sin(x^2)}	
+										\cancel{6x\cos(x^2)} - \cancel{6x\cos(x^2)} + \cancel{12x^3\sin(x^2)} - \cancel{12x^3\sin(x^2)}	
 											\amp = 0
 										</mrow>
 									<mrow>
 										0	\amp = 0
 									</mrow>
 								</md>
-								Therefore, <m>y= 3\sin(x^2)</m> is a solution to <m>y' - 12x^2\sin(x^2) = xy''.</m>
+								Therefore, <m>y= 3\sin(x^2)</m> is a solution to <m>y' - 12x^3\sin(x^2) = xy''.</m>
 							</p>
 						</solution>
 					</p>
@@ -1099,7 +1099,7 @@
 					<p>
 						<answer>
 							<p>
-								?
+								Yes.
 							</p>
 						</answer>
 					
@@ -1172,7 +1172,7 @@
 										+ 6 \frac{dy}{dx} + 5y	\amp = 0							</mrow>
 									<mrow>\Big[ m^2 e^{mx} \Big] + 6\Big[ m e^{mx} \Big]
 										+ 5\Big[ e^{mx} \Big]	\amp = 0							</mrow>
-									<mrow>	e^{mx} \Big[ m^2 + 6m + 5 Big]	\amp = 0							</mrow>
+									<mrow>	e^{mx} \Big[ m^2 + 6m + 5 \Big]	\amp = 0							</mrow>
 									<mrow>				e^{mx} (m+5)(m+1)	\amp = 0							</mrow>	
 								</md>
 								Recall that <m>e^{mx} \ne 0,</m> no matter the value of <m>x</m> or <m>m.</m>
@@ -1191,7 +1191,7 @@
 					<statement><p><m>y'' - 10y' + 24y = 0</m></p></statement>
 					<answer>
 						<p>
-							<m>r = 0, 6, 4</m>
+							<m>r = 4, 6</m>
 						</p>
 					</answer>
 				</exercise>
@@ -1209,7 +1209,7 @@
 					<statement><p><m>7y'' = 8y</m></p></statement>
 					<answer>
 						<p>
-							<m>r = 8/7</m>
+							<m>r = \pm\sqrt{\frac{8}{7}}</m>
 						</p>
 					</answer>
 				</exercise>
@@ -1265,7 +1265,7 @@
 					<statement><p><m>t^{2}y''- 11ty' + 32y = 0</m></p></statement>
 					<answer>
 						<p>
-							<m>r = 4, 8</m>
+							<m>k = 4, 8</m>
 						</p>
 					</answer>
 				</exercise>
@@ -1309,7 +1309,7 @@
 							</m>
 						</p>
 					</statement>
-					<answer><p><m>m = 2.5</m></p></answer>
+					<answer><p><m>m = \pm 3</m></p></answer>
 				</exercise>
 
 				<exercise label="solns-problems-find-m-03">
@@ -1418,7 +1418,7 @@
 					<title>Verifying Particular Solutions of Initial-Valued Problems Takes 2-Steps</title>
 					<statement>
 						<p>
-							To verifying that a function (e.g., <m>y = -3e^{x^2} + 3</m>) is a particular solution to an initial-value problem, there is an extra step beyond showing that it satisfies the differential equation. What else must this function satisfy?
+							To verify that a function (e.g., <m>y = -3e^{x^2} + 3</m>) is a particular solution to an initial-value problem, there is an extra step beyond showing that it satisfies the differential equation. What else must this function satisfy?
 						</p>
 					</statement>
 					<solution>
@@ -1529,7 +1529,7 @@
 					</statement>
 					<answer>
 						<p>
-							?
+							Yes.
 						</p>
 					</answer>
 					<solution>

--- a/source/c2-solns/exercises-solns.ptx
+++ b/source/c2-solns/exercises-solns.ptx
@@ -45,7 +45,7 @@
 					</statement>
 					<feedback>
 						<p>
-							True. In general, differential equations have infinitely-many solutions.
+							True. In general, differential equations have infinitely many solutions.
 						</p>
 					</feedback>
 				</task>
@@ -71,12 +71,12 @@
 				<task label="solns-cq-tf-03">
 					<statement correct="no">
 						<p>
-							A single initial condition always gives you a particular solution?
+							A single initial condition always yields a particular solution?
 						</p>
 					</statement>
 					<feedback>
 						<p>
-							False. This would only be true when there is one constant in the general solution. When there is more than one constant, then you need multiple initial conditions.
+							False. This would be true only if there is one constant in the general solution. When there are multiple constants, multiple initial conditions are required.
 							<aside>
 								<p>
 									It does, however, limit the possible values of the constants.
@@ -150,7 +150,7 @@
 							</statement>
 							<feedback>
 								<p>
-									Incorrect. An initial value problem includes specific initial conditions, which are not provided in this equation.
+									Incorrect. An initial value problem specifies initial conditions that are not provided in this equation.
 								</p>
 							</feedback>
 						</choice>
@@ -162,7 +162,7 @@
 							</statement>
 							<feedback>
 								<p>
-									Correct! The equation is a differential equation without initial conditions, so it is not an initial value problem.
+									Correct! The equation is a differential equation without initial conditions; therefore, it is not an initial-value problem.
 								</p>
 							</feedback>
 						</choice>
@@ -303,7 +303,7 @@
 					<title>Select-the-Best-Answer</title>
 					<statement>
 						<p>
-							Consider the differential equation with missing right side:
+							Consider the differential equation with a missing right side:
 							<me>y'' - \frac{4}{x}y' = <fillin characters="5" /></me>.
 							If <m>y = 2x^3</m> is a solution to this equation, what must the right side be?
 						</p>
@@ -476,7 +476,7 @@
 							</statement>
 							<feedback>
 								<p>
-									Incorrect. Solving a differential equation is very similar to two other tasks in this list.
+									Incorrect. Solving a differential equation is closely related to two other tasks on this list.
 								</p>
 							</feedback>
 						</choice>
@@ -512,7 +512,7 @@
 						</statement>
 						<feedback>
 							<p>
-								Correct! Verifying a solution is much different than the other tasks that seek to find a solution.
+								Correct! Verifying a solution is very different from tasks that seek to find a solution.
 							</p>
 						</feedback>
 						</choice>
@@ -528,7 +528,7 @@
 					<title>Fill in the Blanks</title>
 					<statement>
 						<p>
-							The words, on the left, have been removed from the statements, on the right.
+							The words on the left have been removed from the statements on the right.
 						</p>
 						<p>
 							Drag each word to the panel that contains the statement it was removed from.
@@ -592,7 +592,7 @@
 								</li>
 								<li>
 									<p>
-										Show how you would verify that <m>x = 3</m> is a solution. <em> Do not solve for <m>x</m>.</em>
+										Show how you would verify that <m>x = 3</m> is a solution. <em>Do not solve for <m>x</m>.</em>
 									</p>
 								</li>
 								<li>
@@ -668,7 +668,7 @@
 								</li>
 								<li>
 									<p>
-										The process of verifying solutions to differential equations is exactly the same. However, with differential equations, we have to be more careful about confirming a <q>true statement</q>. With numbers, it is easy to see if <m>21=21</m> is true, but with functions, it's a bit trickier. We have to be sure that the functions are equal for all values of <m>x</m> (or the independent variable). For example, the statement
+										The process of verifying solutions to differential equations is exactly the same. However, with differential equations, we have to be more careful about confirming a <q>true statement</q>. With numbers, it is easy to see if <m>21=21</m> is true, but with functions, it's a bit trickier. We must ensure that the functions are equal for all values of <m>x</m> (the independent variable). For example, the statement
 										<me>
 											e^x + \sin^2 x + \cos^2 x = e^x + 1
 										</me>
@@ -734,7 +734,7 @@
 						</solution>
 						<solution><title>(b)</title>
 							<p>
-								A general solution represents the form of all possible solutions to a differential equation, typically with one or more arbitrary constants. A family of solutions is an infinite set of solutions, one for each possible combination of constant values in the general solution. A particular solution is a single solution that satisfies the differential equation with specific values for the constants.
+								A general solution represents the form of all possible solutions to a differential equation, typically with one or more arbitrary constants. A family of solutions is an infinite set of solutions, one for each possible combination of constant values in the general solution. A particular solution is a single solution to a differential equation that satisfies the differential equation for specific values of the constants.
 							</p>
 						</solution>
 						<solution><title>(c)</title>
@@ -751,7 +751,7 @@
 									<mrow> 					y + C_1	\amp = \frac12 x^2 + C_2 + \int y\ dx	</mrow>
 									<mrow> 			y - \int y\ dx	\amp = \frac12 x^2 + C_2 - C_1  		</mrow>
 								</md>
-								Without knowing <m>y</m>, we cannot simplify <m>\int y\ dx</m>. So the obstacle is that we are unable to combine these <m>y</m> variables into a single <m>y</m> on the left side.
+								Without knowing <m>y</m>, we cannot simplify <m>\int y\ dx</m>. The obstacle is that we cannot combine these <m>y</m> variables into a single <m>y</m> on the left-hand side.
 							</p>
 						</solution>
 					</p>
@@ -805,7 +805,7 @@
 
 				<introduction>
 					<p>
-						For each differential equation, select the functions that are solution to that equation.
+						For each differential equation, select the functions that are solutions to that equation.
 					</p>
 				</introduction>
 
@@ -911,7 +911,7 @@
 
 				<introduction>
 					<p>
-						For each given <m>y(t)</m>, assume it is a solution to the differential equation with hidden right side. Give the function that must be on the right for <m>y</m> to be a solution to the equation.
+						For each given <m>y(t)</m>, assume it is a solution to the differential equation with a hidden right side. Give the function that must be on the right for <m>y</m> to be a solution to the equation.
 					</p>
 				</introduction>
 			
@@ -1000,7 +1000,7 @@
 						</answer>
 						<solution>
 							<p>
-								We need to substitute into the differential equation. In order to substitute into the left hand side, we need to know the second derivative. So we begin by finding that.
+								We need to substitute into the differential equation. To substitute for the left-hand side, we need the second derivative. So we begin by finding that.
 							
 								<md>
 									<mrow>						y	\amp = c_1 \sin x + c_2 \cos x			</mrow>
@@ -1061,7 +1061,7 @@
 					
 						<solution>
 							<p>
-								Find <m>y'</m> and <m>y''</m> since they appear in the equation and move all terms to the left-side.
+								Find <m>y'</m> and <m>y''</m> since they appear in the equation and move all terms to the left side.
 								<md>
 									<mrow>	y	\amp =  3\sin(x^2)									</mrow>
 									<mrow>	y' 	\amp =  3\cos(x^2) \cdot 2x	=	6x\cos(x^2)	</mrow>
@@ -1105,7 +1105,7 @@
 					
 						<solution>
 							<p>
-								Working out the left and right hand sides of this DE, we have:
+								Working out the left and right-hand sides of this DE, we have:
 					
 								<sidebyside widths="45% 55%" margins="auto" valign="top" halign="center">
 									<p>
@@ -1160,7 +1160,7 @@
 						</answer>
 						<solution>
 							<p>
-								First we take derivatives so that we can substitute into the differential equation.
+								First, we take derivatives to substitute into the differential equation.
 								<md>
 									<mrow>						y	\amp = e^{mx}							</mrow>
 									<mrow>	\Rightarrow \quad   y'	\amp = me^{mx}							</mrow>
@@ -1176,7 +1176,7 @@
 									<mrow>				e^{mx} (m+5)(m+1)	\amp = 0							</mrow>	
 								</md>
 								Recall that <m>e^{mx} \ne 0,</m> no matter the value of <m>x</m> or <m>m.</m>
-								Thus we have:
+								Thus, we have:
 								<md>
 									<mrow>	m+5 = 0 \amp \text{ or } m+1 = 0								</mrow>
 									<mrow>	m = -5,	\amp \text{ or } m = -1									</mrow>	
@@ -1228,7 +1228,7 @@
 					<statement><p><m>3t^2 y^{\prime\prime} = -11t y^{\prime} + 3y</m></p></statement>
 					<solution>
 						<p>
-							We proceed as in the previous question. First we take derivatives so that we can substitute into the differential equation.
+							We proceed as in the previous question. First, we take derivatives to substitute into the differential equation.
 							<md>
 								<mrow>						y	\amp = t^k				</mrow>
 								<mrow>	\Rightarrow \quad   y'	\amp = kt^{k-1}			</mrow>
@@ -1276,7 +1276,7 @@
 		
 				<introduction>
 					<p>
-						Find the all the values of <m>m</m> that makes <m>y</m> a solution to the given equation.
+						Find all the values of <m>m</m> that make <m>y</m> a solution to the given equation.
 					</p>
 				</introduction>
 
@@ -1384,7 +1384,7 @@
 									</p>
 
 									<p>
-										Now, we will compute <m>y^\prime</m> and plug it and <m>y</m> into the left hand side (LHS) of the equation to see if it simplifies to zero.
+										Now, we will compute <m>y^\prime</m> and plug it and <m>y</m> into the left-hand side (LHS) of the equation to see if it simplifies to zero.
 									</p>
 
 									<p>
@@ -1425,8 +1425,8 @@
 						<p>
 							To verify that the function <m>y = -3e^{x^2} + 3</m> is a particular solution to the initial-value problem
 							<me>
-								\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0
-							</me>,
+								\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0,
+							</me>
 							we must show the following two things:
 						</p>
 
@@ -1513,7 +1513,7 @@
 							</md>
 						</p>
 						<p>
-							Since <m>y = 3x^2 - 2x + 1</m> satisfies both the differential equation and the initial condition, it is a particular solution to the initial-valued problem.
+							Since <m>y = 3x^2 - 2x + 1</m> satisfies both the differential equation and the initial condition, it is a particular solution to the initial-value problem.
 						</p>
 					</solution>
 				</exercise>
@@ -1636,7 +1636,7 @@
 									</p>
 
 									<p>
-										For each of the functions above, we will compute <m>y^\prime</m> and plug it and <m>y</m> into the left hand side (LHS) of the equation to see if it simplifies to zero.
+										For each of the functions above, we will compute <m>y^\prime</m> and plug it and <m>y</m> into the left-hand side (LHS) of the equation to see if it simplifies to zero.
 									</p>
 
 									<ol type="i.">


### PR DESCRIPTION
# Notes — exercises-solns

## T4 checklist (paste into PR description)
- [ ] Fix characteristic-root answer for `solns-problems-find-r-02` (remove stray `r=0`; keep `r=4,6`).
- [ ] Fix characteristic-root answer for `solns-problems-find-r-04` (use `r = \pm\sqrt{8/7}`).
- [ ] Fix variable mismatch in `solns-problems-find-k-02` (answer should be `k = 4, 8`, not `r = 4, 8`).
- [ ] Fix parameter answer for `solns-problems-find-m-02` (should be `m = \pm 3`).
- [ ] Fix missing LaTeX backslash in `\Big]` (expression `m^2+6m+5` line).
- [ ] Fix derivative simplification in Warm-Up `solns-drills-05` (`y''` needs the `-12t^2\sin(t^2)` term).
- [ ] Fix Verification #3 prompt/solution consistency:
  - prompt should be `y' - xy'' = 12x^3\sin(x^2)`
  - `y''` should be `6\cos(x^2) - 12x^2\sin(x^2)`
  - algebra/cancellation line updated accordingly
- [ ] Fill missing answer placeholders (`?`) with `Yes.` for Verification #3, Verification #4, and IVP #4.

## Summary of changes
- Changes by tier: T2=4, T4=15
- T2: small grammar/typo fixes (“In a few…”, “differential”, “it’s”, “To verify…”).
- T4: math/content corrections + missing-answer fills (see checklist).

## Report-only flags (RO) — not auto-applied
- The conceptual IVP question `solns-ex-ivp-02` has no `<answer>` block (only `<statement>` + `<solution>`). If you want a short answer shown to readers, that requires a manual edit (adding tags) and is outside the JSON-only constraints.

## Command used (dry-run)
```bat
py apply_findreplace.py --source "exercises-solns.txt" --rules "exercises-solns_findreplace.json" --output "exercises-solns.ptx" --dry-run
```