### PR TITLE
Update sec-di-method.ptx

### DIFF
--- a/source/c3-di/sec-di-method.ptx
+++ b/source/c3-di/sec-di-method.ptx
@@ -160,7 +160,7 @@
 				</p>
 
 				<p>
-					Now, we integrate both sides with respect to <m>x</m>, releasing <m>y</m> from the derivative and allowing us to isolate the general solution.
+					We now integrate both sides with respect to <m>x</m>, thereby eliminating <m>y</m> from the derivative and allowing us to isolate the general solution.
 					<md>
 						<mrow>
 							\int \frac{d}{dx}\Big[y\sin(2x)\Big]dx \amp = \int \left(\cos x + 1\right) \ dx
@@ -211,7 +211,7 @@
 		</example>
 
 		<p>
-			Direct integration is a simple way of solving differential equations, provided the structure allows it. If your equation can be written as
+			Direct integration is a simple method for solving differential equations, provided the structure permits it. If your equation can be written as
 			<me>
 				\frac{d}{dx}[x\ \text{and}\ y\ \text{terms}] = \text{only}\ x\ \text{terms}
 			</me>,

--- a/source/c3-di/sec-di-method.ptx
+++ b/source/c3-di/sec-di-method.ptx
@@ -65,7 +65,7 @@
 		</p>
 		
 		<p>
-			The constants of integration are combined into a single constant <m>c</m>. This merging constants like this is standard way to simplify the solution.
+			The constants of integration are combined into a single constant <m>c</m>. Merging constants like this is a standard way to simplify the solution.
 		</p>
 
 	</subsection>
@@ -160,7 +160,7 @@
 				</p>
 
 				<p>
-					Now, we integrate by sides with respect to <m>x</m>, releasing <m>y</m> from the derivative and allowing us to isolate the general solution.
+					Now, we integrate both sides with respect to <m>x</m>, releasing <m>y</m> from the derivative and allowing us to isolate the general solution.
 					<md>
 						<mrow>
 							\int \frac{d}{dx}\Big[y\sin(2x)\Big]dx \amp = \int \left(\cos x + 1\right) \ dx
@@ -233,7 +233,7 @@
 				<choices randomize="yes">
 					<choice correct="yes">
 						<statement><p>Isolate <m>\frac{dy}{dx}</m> &amp; integrate both sides with respect to <m>x</m>.</p></statement>
-						<feedback><p> Correct! </p></feedback>
+						<feedback><p>Correct!</p></feedback>
 					</choice>
 					<choice>
 						<statement><p>Differentiate both sides with respect to <m>x</m>.</p></statement>
@@ -256,7 +256,7 @@
 					<p>
 						The solution to the differential equation
 						<me>
-							\frac13 y'- 7x + x^2 = 1
+							\frac13 y' - 7x + x^2 = 1
 						</me>
 						is the integral of which function?
 					</p>
@@ -304,11 +304,11 @@
 				</statement>
 				<choices>
 					<choice correct="yes">
-						<statement><p> True </p></statement>
-						<feedback><p> Correct! </p></feedback>
+						<statement><p>True</p></statement>
+						<feedback><p>Correct!</p></feedback>
 					</choice>
 					<choice>
-						<statement><p> False </p></statement>
+						<statement><p>False</p></statement>
 						<feedback><p>Incorrect. This equation is in the form <xref ref="direct-integration-equation"/>.</p></feedback>
 					</choice>
 				</choices>
@@ -350,11 +350,11 @@
 				<statement><p>Combining constants is a common practice in differential equations.</p></statement>
 				<choices randomize="yes">
 					<choice correct="yes">
-						<statement><p> True</p></statement>
+						<statement><p>True</p></statement>
 						<feedback><p>Correct! Combining constants is an easy way to simplify a solution and is a standard practice in differential equations.</p></feedback>
 					</choice>
 					<choice>
-						<statement><p> False </p></statement>
+						<statement><p>False</p></statement>
 						<feedback><p>Incorrect, revisit the examples above.</p></feedback>
 					</choice>
 				</choices>


### PR DESCRIPTION
File: sec-di-method | Date: 2026-01-13
Copy edits: 9 | Math/logic edits: 0 | VERIFY-REQUIRED: 0

VERIFY-REQUIRED (applied) — FIRST
(none)

Math/logic (applied)
(none)

Copy edits (applied)
C-001 | ex2 solution (“Now, we integrate …”) | “integrate by sides” → “integrate both sides” C-002 | after first <md> example | “This merging … is standard way …” → “Merging … is a standard way …” C-003 | chkpt-2 equation | “\frac13 y'- 7x + x^2 = 1” → “\frac13 y' - 7x + x^2 = 1” C-004 | chkpt-1 feedback | “ Correct! ” → “Correct!” C-005 | chkpt-3 feedback | “ Correct! ” → “Correct!” C-006 | chkpt-3 True choice | “ True ” → “True”
C-007 | chkpt-3/5 False choice (2×) | “ False ” → “False” C-008 | chkpt-5 True choice | “ True” → “True”

References
(none)