### PR TITLE
Update exercises-di.ptx

### DIFF
--- a/source/c3-di/exercises-di.ptx
+++ b/source/c3-di/exercises-di.ptx
@@ -87,7 +87,7 @@
 								<p>
 									Correct, integrating both sides gives
 									<me>
-										y = \int \ln(3x+1)\ dx \quad \leftarrow \text{anti-derivative of } \ln(3x+1)
+										y = \int \ln(3x+1)\ dx \quad \leftarrow \text{antiderivative of } \ln(3x+1)
 									</me>.
 								</p>
 							</feedback>
@@ -255,7 +255,7 @@
 						<choice correct="yes">
 							<statement>
 								<p>
-									Isolate <m>\frac{dy}{dx}</m> and integrating both sides with respect to <m>x</m>.
+									Isolate <m>\frac{dy}{dx}</m> and integrate both sides with respect to <m>x</m>.
 								</p>
 							</statement>
 							<feedback>
@@ -267,7 +267,7 @@
 						<choice>
 							<statement>
 								<p>
-									Isolate <m>\frac{dy}{dx}</m> and integrating both sides with respect to <m>y</m>.
+									Isolate <m>\frac{dy}{dx}</m> and integrate both sides with respect to <m>y</m>.
 								</p>
 							</statement>
 							<feedback>
@@ -298,7 +298,7 @@
 						<p>
 							The solution to the differential equation
 							<me>
-								\frac13 y'- 7x + x^2 = 1
+								\frac13 y' - 7x + x^2 = 1
 							</me>
 							is the antiderivative of which function?
 						</p>
@@ -646,7 +646,7 @@
 
 				<introduction>
 					<p>
-						For each differential equation, select the functions that are solution to that equation.
+						For each differential equation, select the functions that are solutions to that equation.
 					</p>
 				</introduction>
 
@@ -792,7 +792,7 @@
 							<md>
 								<mrow>	y	\amp = 3\sin(t^2) </mrow>
 								<mrow>	y' 	\amp = 3\cos(t^2) \cdot 2t = 6t\cos(t^2) </mrow>
-								<mrow>	y'' \amp = 6\cos(t^2) - 6t\sin(t^2)(2t)	= 6\cos(t^2) </mrow>
+								<mrow>	y'' \amp = 6\cos(t^2) - 6t\sin(t^2)(2t)	= 6\cos(t^2) - 12t^2\sin(t^2) </mrow>
 							</md>
 							and plug them in:
 							<md>
@@ -880,7 +880,7 @@
 					<statement><p><m>\ds \left[y\sin x\right]^\prime = \cos^2 x</m></p></statement>
 					<answer>
 						<p>
-							<m> \ds y = \frac{\sin(x)}{2} + \frac{C}{\sin(x)} </m>
+							<m> \ds y = \frac{x}{2\sin(x)} + \frac{\cos(x)}{2} + \frac{C}{\sin(x)} </m>
 						</p>
 					</answer>
 				</exercise>
@@ -898,7 +898,7 @@
 					<statement><p><m>\ds \frac{d}{dP}\left[e^P Q\right] = P</m></p></statement>
 					<answer>
 						<p>
-							<m> \ds Q = e^{-P} \left(\frac{P}{e^P} + C \right) </m>
+							<m> \ds Q = e^{-P}\left(\frac{P^2}{2} + C\right) </m>
 						</p>
 					</answer>
 				</exercise>
@@ -1010,7 +1010,7 @@
 					<statement><p><m>\left[y\tan(x)\right]^{\prime} = \sec^2(x),\ y\left(\dfrac{\pi}{4}\right) = 1</m></p></statement>
 					<answer>
 						<p>
-							<m> \ds y = \frac{x \sec^2(x)}{\tan(x)} + \frac{\pi/4 - 1}{\tan(x)} </m>
+							<m> \ds y = 1 </m>
 						</p>
 					</answer>
 				</exercise>

--- a/source/c3-di/exercises-di.ptx
+++ b/source/c3-di/exercises-di.ptx
@@ -149,38 +149,16 @@
 				<task label="c3-cq-tf-04">
 					<title><em>True-or-False</em></title>
 
-					<statement>
+					<statement correct="no">
 						<p>
 							Solving a differential equation by direct integration involves computing a derivative.
 						</p>
 					</statement>
-
-					<choices>
-						<choice>
-							<statement>
-								<p>
-									True
-								</p>
-							</statement>
-							<feedback>
-								<p>
-									Incorrect, review <xref ref="di-method" text="title"/>.
-								</p>
-							</feedback>
-						</choice>
-						<choice correct="yes">
-							<statement>
-								<p>
-									False
-								</p>
-							</statement>
-							<feedback>
-								<p>
-									Correct! Direct integration involves integrating both sides of the equation, not computing a derivative.
-								</p>
-							</feedback>
-						</choice>
-					</choices>
+					<feedback>
+						<p>
+							Direct integration involves integrating both sides of the equation, not computing a derivative.
+						</p>
+					</feedback>
 				</task>
 
 				<task label="c3-cq-tf-05">
@@ -384,7 +362,7 @@
 							</statement>
 							<feedback>
 								<p>
-									Incorrect, direct integration doesn't care about fractions.
+									The expression in the derivative can be any function of <m>x</m> and <m>y</m>.
 								</p>
 							</feedback>
 						</choice>
@@ -420,7 +398,7 @@
 							</statement>
 							<feedback>
 								<p>
-									Correct! Direct integration only works when the right-hand side contains only the independent variable, in this case <m>x</m>.
+									Correct! Direct integration is valid only when the right-hand side depends only on the independent variable, in this case <m>x</m>.
 								</p>
 							</feedback>
 						</choice>
@@ -608,7 +586,7 @@
 						</solution>
 						<solution><title>(b)</title>
 							<p>
-								A general solution represents the form of all possible solutions to a differential equation, typically with one or more arbitrary constants. A family of solutions is an infinite set of solutions, one for each possible combination of constant values in the general solution. A particular solution is a single solution that satisfies the differential equation with specific values for the constants.
+								A general solution represents the form of all possible solutions to a differential equation, typically with one or more arbitrary constants. A family of solutions is an infinite set of solutions, one for each possible combination of constant values in the general solution. A particular solution is a single solution to a differential equation that satisfies the differential equation for specific values of the constants.
 							</p>
 						</solution>
 						<solution><title>(c)</title>
@@ -625,7 +603,7 @@
 									<mrow> 					y + C_1	\amp = \frac12 x^2 + C_2 + \int y\ dx	</mrow>
 									<mrow> 			y - \int y\ dx	\amp = \frac12 x^2 + C_2 - C_1  		</mrow>
 								</md>
-								Without knowing <m>y</m>, we cannot simplify <m>\int y\ dx</m>. So the obstacle is that we are unable to combine these <m>y</m> variables into a single <m>y</m> on the left side.
+								Without knowing <m>y</m>, we cannot simplify <m>\int y\ dx</m>. The obstacle is that we cannot combine these <m>y</m> variables into a single <m>y</m> on the left-hand side.
 							</p>
 						</solution>
 					</p>
@@ -750,7 +728,7 @@
 
 				<introduction>
 					<p>
-						For each given <m>y(t)</m>, assume it is a solution to the differential equation with hidden right side. Give the function that must be on the right for <m>y</m> to be a solution to the equation.
+						For each given <m>y(t)</m>, assume it is a solution to the differential equation with a hidden right side. Give the function that must be on the right for <m>y</m> to be a solution to the equation.
 					</p>
 				</introduction>
 			
@@ -1098,7 +1076,7 @@
 				<me>
 					\left[x^7 y \right]^{\prime} = e^x
 				</me>.
-				The problem is that most equations do not start in this form. Instead, they start in another form and then, after some algebra, are put into this nice form and solved. The process off rewriting an equation in this way is the basis for another technique called the integrating factor method. The question we want to answer here is <q>what type of equations can be written in this form?</q>
+				The problem is that most equations do not start in this form. Instead, they start in another form and, after some algebra, are put into this convenient form and solved. The process of rewriting an equation in this way forms the basis of another technique, the integrating factor method. The question we want to answer here is <q>what type of equations can be written in this form?</q>
 			</p>
 
 			<exercise label="c3-piss-medium"><title>Give the equation that can be rewritten in the form <m>\ds\left[x^7 y \right]^{\prime} = e^x</m></title>


### PR DESCRIPTION
# PTX Direct Edit Notes (Looser)
- File: exercises-di.txt → exercises-di.ptx
- Date: 2026-01-13
- Totals: VERIFY-REQUIRED=1 (not applied), Math=4, Copy=5 ## VERIFY-REQUIRED (not applied)
- VR-001 | label="c3-piss-medium" | profanity in label; NOT changed (xref risk) | conf(H) | verify: repo-wide rename w/ grep ## Math/logic (applied)
- M-001 | "[y\sin x]' = \cos^2 x" | corrected general solution for y | why: integrate cos^2
- M-002 | "d/dP[e^P Q] = P" | corrected Q(P) | why: integrate RHS
- M-003 | "[y\tan(x)]' = \sec^2(x)" | corrected particular solution to y=1 | why: integrate tan
- M-004 | "y'' = ..." in WebWork solution | fixed y'' expression | why: product/chain rule ## Copy edits (applied)
- C-001 | "and integrating" | → "and integrate" (2×)
- C-002 | "\frac13 y'-" | → "\frac13 y' -" (spacing)
- C-003 | "anti-derivative" | → "antiderivative"
- C-004 | "are solution" | → "are solutions" ## References
- None (V0 only; all changes verified in-file).