### PR TITLE
Update sec-showing-separability.ptx

### DIFF
--- a/source/c4-sov/sec-showing-separability.ptx
+++ b/source/c4-sov/sec-showing-separability.ptx
@@ -120,7 +120,7 @@
 		</example>
 
 		<p>
-			The next set of examples require a bit more work to show separability.
+			The next set of examples requires more work to demonstrate separability.
 		</p>
 
 	</subsection>
@@ -240,7 +240,7 @@
 						is separable.
 					</p>
 					<p>
-						Match the scrambled tasks (on the left) to the order that it should be performed to show it is separable.
+						Match the scrambled tasks (on the left) to the order in which they should be performed to show separability.
 					</p>
 				</statement>
 				<cardsort>
@@ -269,10 +269,10 @@
 
 				<statement>
 					<p>
-						Match the technique needed to show each equation is separable.
+						Match the technique required to demonstrate that each equation is separable.
 					</p>
 					<p>
-						Drag the technique, on the left, to the equation, on the right.
+						Drag the technique from the left to the equation on the right.
 					</p>
 				</statement>
 				<feedback>
@@ -289,19 +289,19 @@
 						</premise>
 						<response>
 							<p>
-								<m>\quad\ds w' = w e^{t+w} </m>
+								<m>\quad w' = w e^{t+w} </m>
 							</p>
 						</response>
 					</match>
 					<match>
 						<premise>
 							<p>
-								<m>\quad\ds\dfrac{A\cdot B}{C\cdot D} = \dfrac{A}{C} \cdot \dfrac{B}{D}</m>
+								<m>\quad\dfrac{A\cdot B}{C\cdot D} = \dfrac{A}{C} \cdot \dfrac{B}{D}</m>
 							</p>
 						</premise>
 						<response>
 							<p>
-								<m>\quad\ds\dfrac{dy}{d\theta} = \dfrac{3y}{(y+9)\theta} </m>
+								<m>\quad\dfrac{dy}{d\theta} = \dfrac{3y}{(y+9)\theta} </m>
 							</p>
 						</response>
 					</match>
@@ -313,7 +313,7 @@
 						</premise>
 						<response>
 							<p>
-								<m>\quad\ds xr' + 2r = 0 </m>
+								<m>\quad xr' + 2r = 0 </m>
 							</p>
 						</response>
 					</match>
@@ -337,7 +337,7 @@
 						</premise>
 						<response>
 							<p>
-								<m>\quad\ds w' = e^Q e^{x}</m>
+								<m>\quad w' = e^Q e^{x}</m>
 							</p>
 						</response>
 					</match>
@@ -347,7 +347,7 @@
 			<task label="showing-separability-cyu-1-task-3">
 				<statement>
 					<p>
-						How can the equation, below, be rewritten in separable form?
+						How can the equation below be rewritten in separable form?
 						<me>
 							\dfrac{dy}{dx} = \dfrac{y}{x+y}.
 						</me>	
@@ -358,19 +358,19 @@
 					<choice>
 						<statement>
 							<p>
-								<m>\quad\ds\dfrac{dy}{dx} = y\left(\dfrac{1}{x} + \dfrac{1}{y}\right)</m>
+								<m>\quad\dfrac{dy}{dx} = y\left(\dfrac{1}{x} + \dfrac{1}{y}\right)</m>
 							</p>
 						</statement>
 						<feedback>
 							<p>
-								Incorrect. This rewriting does not separate the variables effectively.
+								Incorrect. This rewriting does not effectively separate the variables.
 							</p>
 						</feedback>
 					</choice>
 					<choice>
 						<statement>
 							<p>
-								<m>\quad\ds\dfrac{dy}{dx} = \dfrac{1}{x}\left(y + 1\right)</m>
+								<m>\quad\dfrac{dy}{dx} = \dfrac{1}{x}\left(y + 1\right)</m>
 							</p>
 						</statement>
 						<feedback>
@@ -382,7 +382,7 @@
 					<choice>
 						<statement>
 							<p>
-								<m>\quad\ds\dfrac{dy}{dx} = \dfrac{1}{x}\cdot y - \dfrac{1}{x}</m>
+								<m>\quad\dfrac{dy}{dx} = \dfrac{1}{x}\cdot y - \dfrac{1}{x}</m>
 							</p>
 						</statement>
 						<feedback>
@@ -482,13 +482,13 @@
 				</p>
 
 				<p>
-					This equation is first-order, but it is not separable. To see this, we can rearrange the equation to isolate the derivative:
+					This equation is first-order but not separable. To see this, we can rearrange the equation to isolate the derivative:
 					<md>
 						<mrow> xy' + 3x = y </mrow>
 						<mrow> xy' = y - 3x </mrow>
 						<mrow> y' = \dfrac{y - 3x}{x} </mrow>
 					</md>.
-					Since there is no common factor of <m>x</m> or <m>y</m> in the numerator, the variables cannot be separated and the equation is not separable.
+					Since there is no common factor of <m>x</m> or <m>y</m> in the numerator, the variables cannot be separated, and the equation is not separable.
 				</p>
 			</solution>
 		</example>

--- a/source/c4-sov/sec-showing-separability.ptx
+++ b/source/c4-sov/sec-showing-separability.ptx
@@ -66,7 +66,7 @@
 
 			<solution>
 				<p>
-					To show this equation is seperable, we convert <xref ref="sums-to-products" text="title"/> by factoring out the common <m>y</m>:
+					To show this equation is separable, we convert <xref ref="sums-to-products" text="title"/> by factoring out the common <m>y</m>:
 					<me>
 						y' = \ub{y \cdot (x^2 - 1)}_{f(x)\ \cdot\ g(y)} \quad\leftarrow\text{separable}.
 					</me>
@@ -387,7 +387,7 @@
 						</statement>
 						<feedback>
 							<p>
-								Correct! This form separates the variables, making it possible to identify whether the equation is separable.
+								Incorrect. This rewriting is not equivalent and does not separate the variables.
 							</p>
 						</feedback>
 					</choice>


### PR DESCRIPTION
# sec-showing-separability_MC-edit — Notes (Looser Direct PTX)

Date: 2026-01-14  
File: sec-showing-separability.ptx  
Totals: VR=0 | M=1 | C=1  

## VERIFY-REQUIRED (applied)
(none)

## Math/logic (applied)
M-001 | task “How can the equation… be rewritten in separable form?” | changed feedback for option “dy/dx = (1/x)·y − 1/x” from “Correct!” → “Incorrect … not equivalent / not separable” | why: fix key/feedback mismatch

## Copy edits (applied)
C-001 | “To show this equation is seperable” | seperable → separable

## References
(none — V0 only)