### PR TITLE
Update sec-sov-implicit-solns.ptx

### DIFF
--- a/source/c4-sov/sec-sov-implicit-solns.ptx
+++ b/source/c4-sov/sec-sov-implicit-solns.ptx
@@ -70,7 +70,7 @@
 
 			<statement>
 				<p>
-					Let <m>y</m> be a function of the independent variable, <m>t</m>, and <m>c</m> is an integration constant. If each expression below is a general solution to some DE, Click on the <em>implicit solutions</em>.
+					Let <m>y</m> be a function of the independent variable, <m>t</m>, and let <m>c</m> be an integration constant. If each expression below is a general solution to some DE, click on the <em>implicit solutions</em>.
 				</p>
 			</statement>
 
@@ -177,12 +177,12 @@
 
 					<sidebyside>
 						<p>
-							u-sub 
+							u-sub
 							<m>
 								\quad\left.
 								\begin{array}{c}
 									u = 3-5y\\
-									du = -5dx
+									du = -5dy
 								\end{array}
 								\right| \rightarrow
 							</m>
@@ -262,8 +262,8 @@
 				<p>
 					Explicitly solving for <m>y</m>, shows our general solution has two branches:
 					<me>
-						y(x) 
-						= \pm\sqrt{2\sin(x) + c} 
+						y(x)
+						= \pm\sqrt{2\sin(x) + c}
 						= \left\{
 							\begin{array}{c}
 							 	-\sqrt{2\sin(x) + c} \\

--- a/source/c4-sov/sec-sov-implicit-solns.ptx
+++ b/source/c4-sov/sec-sov-implicit-solns.ptx
@@ -16,7 +16,7 @@
 	<introduction>
 		<p>
 			Notice that <xref ref="sov-step-3" text="custom">Step 3</xref> of the SOV method states: <q>If possible, explicitly solve for <m>y</m>. If not, leave the solution in implicit form.</q>
-			In the examples we've seen, it was always possible to explicitly isolate <m>y</m> after integrating. However, in some cases, this is not possible (or practical) and we call such solutions <em>implicit solutions</em>.
+			In the examples we've seen, it was always possible to explicitly isolate <m>y</m> after integrating. However, in some cases, this is not possible (or practical), and we call such solutions <em>implicit solutions</em>.
 		</p>
 	</introduction>
 
@@ -231,7 +231,7 @@
 		<title>IVPs with <q><m>\pm</m></q> in the General Solution</title>
 
 		<p>
-			For some initial-value problems, the particular solution can be expressed explicitly even when there is an implicit general solution. To see this, consider the following example:
+			For some initial-value problems, the particular solution can be expressed explicitly even when the general solution is implicit. To see this, consider the following example:
 		</p>
 
 		<example label="implicit-solution-with-initial-condition">


### PR DESCRIPTION
# sec-sov-implicit-solns — Looser Direct PTX (2026-01-14)

Totals: VR=1, M=1, C=2

## VERIFY-REQUIRED (applied) — FIRST
VR-001 | abs value solutions | confirm if “±14” and “-14” both marked correct is intended | conf(M) | verify: scoring accepts “±” form

## Math/logic (applied)
M-001 | u-sub (u = 3-5y) | du = -5dx → du = -5dy | why: u-sub variable

## Copy edits (applied)
C-001 | cyu-1 statement | “and c is …” → “and let c be …” (grammar) C-002 | cyu-1 statement | “Click on …” → “click on …”

## References
None (V0 only)