### PR TITLE
Update exercises-sov.ptx

### DIFF
--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -902,7 +902,7 @@
 					<p>
 						So the (approximate) particular solution is:
 						<me>
-							z = 	an\!ig(t + 	an^{-1}(9) - 4ig)
+							z = \tan(t + 79.66)
 						</me>
 					</p>
 				</solution>

--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -1364,7 +1364,7 @@
 								<row><cell><m>_{}</m></cell></row>
 							</tabular>
 
-							<p><em>Don't forget the constants of integration.</em></p>
+							<p><em>Don't forget the absolute value on the left antiderivative.</em></p>
 
 							<p>Combine constants and use <m>c</m> for the final combined constant.</p>
 
@@ -1456,7 +1456,7 @@
 								<row><cell><m>_{}</m></cell></row>
 							</tabular>
 
-							<p><em>Don't forget the constants of integration.</em></p>
+							<p><em>Don't forget the absolute value on the left antiderivative.</em></p>
 
 							<p>Combine constants and use <m>c</m> for the final combined constant.</p>
 

--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -11,7 +11,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section label="sov-exercises"> 
+<section label="c3-exercises">
 	<title>Exercises</title>
 
 	<subsection label="sov-concept-quiz">
@@ -47,7 +47,7 @@
 					</statement>
 					<feedback>
 						<p>
-							False. Only first-order ordinary differential equation that are <term>separable</term> can be solved using the method of separation of variables.
+							False. Only first-order ordinary differential equations that are <term>separable</term> can be solved using the method of separation of variables.
 						</p>
 					</feedback>
 				</task>
@@ -61,7 +61,7 @@
 					</statement>
 					<feedback>
 						<p>
-							False. The solution to a separable differential equation is sometimes implicit function of the independent variable.
+							False. The solution to a separable differential equation is sometimes an implicit function of the independent variable.
 						</p>
 					</feedback>
 				</task>
@@ -70,7 +70,7 @@
 					<title>👍👎</title>
 					<statement correct="no">
 						<p>
-							The method of separation of variables can be applied to some second order differential equations, but not all of them.
+							The method of separation of variables can be applied to some second-order differential equations, but not all of them.
 						</p>
 					</statement>
 					<feedback>
@@ -115,6 +115,7 @@
 							</me>
 						</p>
 					</statement>
+					<feedback>
 						<p>
 							The correct answer is:
 						</p>
@@ -128,7 +129,7 @@
 							</me>,
 							which shows that the equation is separable since the function of <m>y</m> can be constant.
 						</p>
-					<feedback>
+					
 						<p>
 							The equation is separable because it is first-order and can be written in the separable form
 							<me>
@@ -137,7 +138,7 @@
 						</p>
 					</feedback>
 				</task>
-				
+
 				<task label="sov-cq-tf-06">
 					<title>👍👎</title>
 					<statement correct="yes">
@@ -157,7 +158,7 @@
 						</p>
 					</feedback>
 				</task>
-					
+
 				<task label="sov-cq-tf-07">
 					<title>👍👎</title>
 					<statement correct="yes">
@@ -231,7 +232,7 @@
 						<p>
 							The differential equation,
 							<me>
-								\frac{dz^2}{d^2t} = \cos^2(z)
+								\frac{d^2z}{dt^2} = \cos^2(z)
 							</me>,
 							can be solved using the separation of variables method.
 						</p>
@@ -422,7 +423,7 @@
 						<choice>
 							<statement>
 								<p>
-									It is not a valid equation because it does have a <m>y</m> term.
+									It is not a valid equation because it does not have a <m>y</m> term.
 								</p>
 							</statement>
 						</choice>
@@ -517,7 +518,7 @@
 							</statement>
 							<feedback>
 								<p>
-									Correct! The separation of variables method applies only to first-order differential equations thatare separable.
+									Correct! The separation of variables method applies only to first-order differential equations that are separable.
 								</p>
 							</feedback>
 						</choice>
@@ -540,11 +541,11 @@
 								<m>
 									\quad \left\{
 									\begin{align}
-										|y|	\amp = e^{2x + c_1}\\ 
-										y	\amp = c_2 e^{2x} 
+										|y|	\amp = e^{2x + c_1}\\
+										y	\amp = c_2 e^{2x}
 									\end{align}
 									\right.\qquad
-								</m> 
+								</m>
 								where <m>c_2=\pm e^{c_1}</m>.
 							</statement>
 							<feedback>
@@ -564,11 +565,11 @@
 								<m>
 									\quad \left\{
 									\begin{align}
-										\frac{y^2}{2} \amp = \sin(x) + c_1\\ 
-										y^2 \amp = 2\sin(x) + c_2 
+										\frac{y^2}{2} \amp = \sin(x) + c_1\\
+										y^2 \amp = 2\sin(x) + c_2
 									\end{align}
 									\right.\qquad
-								</m> 
+								</m>
 								where <m>c_2 = 2c_1</m>.
 							</statement>
 							<feedback>
@@ -576,7 +577,7 @@
 									Correct, since
 									<md>
 										<mrow>	\frac{y^2}{2}	\amp =,	\sin(x) + c_1									</mrow>
-										<mrow>	y^2				\amp =,	\sin(x) + 2c_1									</mrow>
+										<mrow>	y^2				\amp =,	2\sin(x) + 2c_1									</mrow>
 										<mrow>	y^2				\amp =,	2\sin(x) + c_2	\quad \text{where } c_2 = 2c_1	</mrow>
 									</md>
 								</p>
@@ -587,11 +588,11 @@
 								<m>
 									\quad \left\{
 									\begin{align}
-										y^2	\amp = 2\sin(x) + c_2\\ 
-										y	\amp = \pm\sqrt{2\sin(x)} + c_3 
+										y^2	\amp = 2\sin(x) + c_2\\
+										y	\amp = \pm\sqrt{2\sin(x)} + c_3
 									\end{align}
 									\right.\qquad
-								</m> 
+								</m>
 								where <m>c_3=\pm \sqrt{c_2}</m>.
 							</statement>
 							<feedback>
@@ -613,15 +614,15 @@
 								<m>
 									\quad \left\{
 									\begin{align}
-										e^y	\amp =	3y + c_1\\ 
-										y	\amp =	\ln(3y) + c_2 
+										e^y	\amp =	3y + c_1\\
+										y	\amp =	\ln(3y) + c_2
 									\end{align}
 									\right.\qquad
-								</m> 
+								</m>
 								where <m>c_2= \ln(c_1)</m>.
 							</statement>
 							<feedback>
-								
+
 								<p>
 									Incorrect, you should not combine constants here since <m>\ln(A + B) \neq \ln(A) + \ln(B)</m>.
 								</p>
@@ -640,11 +641,11 @@
 								<m>
 									\quad \left\{
 									\begin{align}
-										xy	\amp =	e^x + c_1\\ 
-										y	\amp =	\frac{e^x}{x} + c_2 
+										xy	\amp =	e^x + c_1\\
+										y	\amp =	\frac{e^x}{x} + c_2
 									\end{align}
 									\right.\qquad
-								</m> 
+								</m>
 								where <m>c_2=\frac{c_1}{x}</m>.
 							</statement>
 							<feedback>
@@ -663,11 +664,11 @@
 								<m>
 									\quad \left\{
 									\begin{align}
-										\sqrt{y}	\amp =	c_1e^{3x}\\ 
-										y			\amp =	c_2\, e^{6x} 
+										\sqrt{y}	\amp =	c_1e^{3x}\\
+										y			\amp =	c_2\, e^{6x}
 									\end{align}
 									\right.\qquad
-								</m> 
+								</m>
 								where <m>c_2= c_1^2</m>.
 							</statement>
 							<feedback>
@@ -708,7 +709,7 @@
 					</feedback>
 
 				</task>
-			
+
 				<task label="sov-cq-sa-02">
 					<title>Where Does <q>Separation of Variables</q> Come From?</title>
 
@@ -725,7 +726,7 @@
 							The method of separation of variables is named as such because it involves isolating all terms involving <m>y</m> to one side and all terms involving <m>x</m> to the other. This effectively separates the variables <m>y</m> and <m>x</m> onto different sides of the equation, allowing for the integration of each side independently. The name "separation of variables" reflects the process of isolating the variables onto different sides of the equation.
 						</p>
 					</feedback>
-					
+
 				</task>
 
 				<task label="sov-cq-sa-03">
@@ -857,7 +858,7 @@
 							</ol>
 						</p>
 					</solution>
-					
+
 				</task>
 
 			</exercise>
@@ -878,7 +879,7 @@
 					<p>
 						Verify that <m>z = \tan(t+C)</m> is a solution to the initial value problem
 						<me>z' - 1 = z^2, \quad z(4) = 9</me>
-						then find the paticular solution.
+						then find the particular solution.
 					</p>
 				</statement>
 
@@ -888,11 +889,11 @@
 							<mrow> z' - 1 \amp = z^2</mrow>
 							<mrow> \frac{d}{dt}\Big( \tan(t+C) \Big) - 1 \amp = \Big( \tan(t+C) \Big)^2</mrow>
 							<mrow> \sec^2(t+C)\cdot \frac{d}{dt}(t+C) - 1 \amp = \tan^2(t+C)</mrow>
-							<mrow> \sec^2(t+C)\cdot (1+0) - 1 \amp = \sec^2 t - 1</mrow>
-							<mrow> \sec^2(t+C) - 1 \amp = \sec^2 t - 1 \quad ✅️</mrow>
+							<mrow> \sec^2(t+C)\cdot (1+0) - 1 \amp = \sec^2(t+C) - 1</mrow>
+							<mrow> \sec^2(t+C) - 1 \amp = \tan^2(t+C) \quad ✅️</mrow>
 						</md>
 					</p>
-			
+
 					<p>
 						Now, let's find <m>C</m> with the initial condition <m>z(4) = 9</m>:
 						<me>9 = z(4) = \tan(4+C)\quad\Rightarrow\quad C = tan^{-1}(9) - 4 \approx 79.66</me>
@@ -901,19 +902,19 @@
 					<p>
 						So the (approximate) particular solution is:
 						<me>
-							z = \tan(t + 79.66) 
+							z = 	an\!ig(t + 	an^{-1}(9) - 4ig)
 						</me>
 					</p>
 				</solution>
 			</exercise>
 
 			<exercise label="sov-drills-2">
-				<title>Show the differential equations is separable</title>
+				<title>Show the differential equation is separable</title>
 
 				<statement>
 					<p><me>t - ss' = - s</me></p>
 				</statement>
-				
+
 				<solution>
 					<p>
 						To see that this equation is separable, we need to check that it can be rearranged in <xref ref="separable" text="custom">separable form</xref>. Isolating <m> s' </m> we get
@@ -936,7 +937,7 @@
 					<statement><m>\dfrac{dz}{dt} = \sin(z+t)</m></statement>
 					<solution>
 						<p>
-							<alert>not</alert> separable; there's no way to separate th <m> \ds z </m> an <m> \ds t </m> inside the sine term.
+							<alert>not</alert> separable; there's no way to separate the <m> \ds z </m> and <m> \ds t </m> inside the sine term.
 						</p>
 					</solution>
 					<answer>
@@ -1052,7 +1053,7 @@
 					</p>
 				</introduction>
 
-				<exercise label="sov-warm-ups-ww-1">
+				<exercise label="c3-warm-ups-ww-1">
 					<title>Determine the Separable Form</title>
 
 					<introduction>
@@ -1064,13 +1065,13 @@
 							<em>Type your answer for <m>f(x)</m> into the left box and <m>g(y)</m> into the right box.</em>
 						</p>
 					</introduction>
-						
+
 					<webwork xml:id="c2-cr-ww-01-id">
 
 						<description>
 							Show a differential equation is separable.
 						</description>
-				
+
 						<pg-code>
 							Context()->variables->add(y => 'Real');
 							$f1 = Formula("1 + cos(x)");
@@ -1080,9 +1081,9 @@
 							$f3 = Formula("e^(x)/x");
 							$g3 = Formula("(y^2 - 1)/y");
 						</pg-code>
-				
+
 						<statement>
-							
+
 							<ol>
 								<li>
 									<p>
@@ -1117,7 +1118,7 @@
 							</ol>
 
 						</statement>
-						
+
 					</webwork>
 
 					<solution>
@@ -1155,8 +1156,8 @@
 					</solution>
 
 				</exercise>
-				
-				<exercise label="sov-warm-ups-ordering-1">
+
+				<exercise label="c3-warm-ups-ordering-1">
 					<title>Reorder the Steps</title>
 
 					<statement>
@@ -1181,7 +1182,7 @@
 
 				</exercise>
 
-				<exercise label="sov-warm-ups-click-2">
+				<exercise label="c3-warm-ups-click-2">
 					<title>Step-By-Step Initial-Valued Problem</title>
 
 					<statement>
@@ -1296,19 +1297,19 @@
 					</areas>
 				</exercise>
 
-				<exercise label="sov-warm-ups-ww-2">
-					<title><m>\ds y'= e^{2x} - 5x</m></title>
+				<exercise label="c3-warm-ups-ww-2">
+					<title><m>\ds y'= e^{2x} - 4x</m></title>
 
 					<introduction/>
 
-					<webwork xml:id="sov-step-by-step-03-ww">
+					<webwork xml:id="c3-step-by-step-03-ww">
 						<description>
 							Solve a separable DE using separation of variables.
 						</description>
 
 						<pg-code>
 							Context()->variables->add(y => 'Real');
-							
+
 							$f =Formula("e^{2 x} - 4 x");
 							$order = 1;
 							$f = Formula("e^{2 x} - 4 x");
@@ -1363,7 +1364,7 @@
 								<row><cell><m>_{}</m></cell></row>
 							</tabular>
 
-							<p><em>Don't forget the absolute value on the left antiderivative.</em></p>
+							<p><em>Don't forget the constants of integration.</em></p>
 
 							<p>Combine constants and use <m>c</m> for the final combined constant.</p>
 
@@ -1387,12 +1388,12 @@
 					</hint>
 
 				</exercise>
-			
-				<exercise label="sov-warm-ups-ww-3"><title><m>\dfrac{dy}{dx} = xy^2</m></title>
+
+				<exercise label="c3-warm-ups-ww-3"><title><m>\dfrac{dy}{dx} = xy^2</m></title>
 
 					<introduction/>
 
-					<webwork xml:id="sov-step-by-step-04-ww">
+					<webwork xml:id="c3-step-by-step-04-ww">
 
 						<description>
 							Solve a separable DE using separation of variables.
@@ -1401,7 +1402,7 @@
 						<pg-code>
 							Context()->variables->add(y => 'Real');
 							Context()->variables->add(c => 'Real');
-							
+
 							$order = 1;
 							$f = Formula("x");
 							$g = Formula("y^2");
@@ -1455,7 +1456,7 @@
 								<row><cell><m>_{}</m></cell></row>
 							</tabular>
 
-							<p><em>Don't forget the absolute value on the left antiderivative.</em></p>
+							<p><em>Don't forget the constants of integration.</em></p>
 
 							<p>Combine constants and use <m>c</m> for the final combined constant.</p>
 
@@ -1480,11 +1481,11 @@
 
 				</exercise>
 
-				<exercise label="sov-warm-ups-ww-4"><title><m>\ds\frac{dy}{dx} - y\cos(x) = y</m></title>
+				<exercise label="c3-warm-ups-ww-4"><title><m>\ds\frac{dy}{dx} - y\cos(x) = y</m></title>
 
 					<introduction/>
-						
-					<webwork xml:id="sov-step-by-step-02-ww">
+
+					<webwork xml:id="c3-step-by-step-02-ww">
 						<description>
 							Solve a separable DE using separation of variables.
 						</description>
@@ -1650,7 +1651,7 @@
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = \frac{1}{xy}</m></statement>
 				</exercise>
-				
+
 			</exercisegroup>
 
 			<exercisegroup cols="2"><title>Level 2</title>
@@ -1757,7 +1758,7 @@
 								<mrow>  \frac{dv}{dx}	 \amp =  \frac{1-4v^2}{3v}\cdot \frac{1}{x} </mrow>
 								<mrow>  \frac{3v}{1-4v^2} dv	 \amp =  \frac{1}{x} dx </mrow>
 								<mrow>  \int \frac{3v}{1-4v^2} dv	 \amp =  \int \frac{1}{x} dx </mrow>
-			
+
 							</md>
 							For the integral on the left hand side, we will need to do a substitution.  If we le <m> \ds u = 1-4v^2, </m> the <m> \ds du = -8vdv, </m> and therefor <m> \ds -\frac{1}{8}du = vdv. </m>  Then we have the following:
 							<md>
@@ -1777,9 +1778,9 @@
 								<mrow>  1 - 4v^2	 \amp =  \pm e^{-\frac{8}{3}C_1}\cdot x^{-8/3} </mrow>
 								<mrow>  1 - 4v^2	 \amp =  \underbrace{\pm e^{-\frac{8}{3}C_1}}_{\scriptsize = C_2}\cdot x^{-8/3} </mrow>
 								<mrow>  1 - 4v^2	 \amp =  C_2x^{-8/3} </mrow>
-			
+
 							</md>
-			
+
 							<md>
 								<mrow>  - 4v^2	 \amp =  C_2x^{-8/3} - 1 </mrow>
 								<mrow>  v^2	 \amp =  \frac{C_2}{-4}x^{-8/3} + \frac{1}{4} </mrow>
@@ -1854,13 +1855,13 @@
 							<me>\ln|y|=-3x^2+C</me>
 							<me>|y|=e^{-3x^2+C}</me>
 							<me>y=\pm e^C e^{-3x^2}</me>
-			
+
 							and hence
-			
+
 							<me>y(x) = Ae^{-3x^2} \qquad (A = \pm e^C)</me>
-			
+
 							The condition <m>y(0) = 7</m> yields <m>A =7</m>, so the desired solution is
-			
+
 							<me>y(x) = 7e^{-3x^2}</me>
 
 						</p>
@@ -1884,7 +1885,7 @@
 								<mrow>  -\frac{1}{z}	 \amp =  t^2 + C_1 </mrow>
 								<mrow>  z	 \amp =  -\frac{1}{t^2 + C_1} </mrow>
 							</md>
-			
+
 							Using the initial condition <m>z(1) = 2</m>:
 							<md>
 								<mrow>  2	 \amp =  -\frac{1}{1^2 + C_1} </mrow>
@@ -1892,7 +1893,7 @@
 								<mrow>  C_1	 \amp =  -\frac{1}{2} - 1 </mrow>
 								<mrow>  C_1	 \amp =  -\frac{3}{2} </mrow>
 							</md>
-			
+
 							So the solution to the initial value problem is:
 							<md>
 								<mrow>  z(t)	 \amp =  -\frac{1}{t^2 - \frac{3}{2}} </mrow>
@@ -1930,7 +1931,7 @@
 								<mrow>   \amp =  C_2e </mrow>
 								<mrow>  -\frac{3}{e}	 \amp =  C_2, \mbox{ or} </mrow>
 								<mrow>  C_2	 \amp =  -3e^{-1} </mrow>
-			
+
 							</md>
 							Hence, the solution i <m> \ds y = -3e^{-1}e^{-\cos\theta} </m> , or <m> \ds y = -3e^{-\cos\theta-1} </m> .
 						</p>
@@ -1961,7 +1962,7 @@
 								<mrow>   \amp =  \frac{1}{2}\ln(4x^4 + C_2), \mbox{ or} </mrow>
 								<mrow>   \amp =  \ln\Big[(4x^4 + C_2)^{1/2}\Big], \mbox{ or} </mrow>
 								<mrow>   \amp =  \ln\Big[\sqrt{4x^4 + C_2}\Big] </mrow>
-			
+
 							</md>
 							Then we use the initial conditio <m> \ds y(1) = 0 </m> .
 							<md>
@@ -1973,7 +1974,7 @@
 								<mrow>  1^2	 \amp =  \Big[\sqrt{4 + C_2}\Big]^2 </mrow>
 								<mrow>  1	 \amp =  4+C_2 </mrow>
 								<mrow>  -3	 \amp =  C_2 </mrow>
-			
+
 							</md>
 							Hence, the solution i <m> \ds y = \frac{1}{2}\ln(4x^4 - 3) </m> , or <m> \ds y = \ln\Big[\sqrt{4x^4 - 3}\Big] </m>.
 						</p>
@@ -1988,7 +1989,7 @@
 			</exercisegroup>
 
 			<exercisegroup><title>Nested Differential Equations</title>
-			
+
 				<introduction>
 					<p>
 						Find a non-zero function <m>\mu(x)</m> that satisfies each of the following differential equations.
@@ -2016,7 +2017,7 @@
 							<me>
 								\frac{d\mu}{dx} \sin x = 6 \mu \sin x
 							</me>,
-							which implies that 
+							which implies that
 							<me>
 								\frac{d\mu}{dx} = 6 \mu.
 							</me>
@@ -2114,14 +2115,14 @@
 					</solution>
 
 				</exercise>
-			
+
 			</exercisegroup>
 
 			<exercisegroup><title>Applications</title>
 
 				<exercise>
 					<statement>Cooking Temperature</statement>
-				
+
 					<statement>
 						A 4-lb roast, initially at <m>50^{\circ}F</m>, is placed in a <m>375^{\circ} F</m> oven at 5:00 PM After 75 minutes it is found that the temperature <m>T(t)</m> of the roast is <m>125^{\circ}</m> F. When will the roast be <m>150^{\circ}F</m> (medium rate)?
 					</statement>
@@ -2135,15 +2136,15 @@
 								<mrow>				y(x)\amp = \ds 1+(x^2+C)^3</mrow>
 								<mrow>			-\ln(375-T)=\amp kt+C</mrow>
 							</md>
-			
+
 							Now <m>T(0)=50</m>, implies that <m>B = 325</m>, so <m>T(t) = 375-325e^{kt}</m>. We also know that <m>T = 125</m> when <m>t = 75</m>. Substitution of these values in the preceding equation yields
-			
+
 							<me> k=-\frac{1}{75}\ln\left(\frac{250}{325}\right)\approx 0.0035.</me>
-			
+
 							Hence we finally solve the equation
-			
+
 							<me>150=375-325e^{(-0.0035)t}</me>
-			
+
 							for <m>t = -[\ln(225/325)]/[0.0035] \approx 105</m> (min), the total cooking time required.Because the roast was placed in the oven at 5:00 PM, it it should be removed at about 6:45 PM
 						</p>
 					</solution>

--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -11,7 +11,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section label="c3-exercises">
+<section label="sov-exercises">
 	<title>Exercises</title>
 
 	<subsection label="sov-concept-quiz">
@@ -1053,7 +1053,7 @@
 					</p>
 				</introduction>
 
-				<exercise label="c3-warm-ups-ww-1">
+				<exercise label="sov-warm-ups-ww-1">
 					<title>Determine the Separable Form</title>
 
 					<introduction>
@@ -1157,7 +1157,7 @@
 
 				</exercise>
 
-				<exercise label="c3-warm-ups-ordering-1">
+				<exercise label="sov-warm-ups-ordering-1">
 					<title>Reorder the Steps</title>
 
 					<statement>
@@ -1182,7 +1182,7 @@
 
 				</exercise>
 
-				<exercise label="c3-warm-ups-click-2">
+				<exercise label="sov-warm-ups-click-2">
 					<title>Step-By-Step Initial-Valued Problem</title>
 
 					<statement>
@@ -1297,12 +1297,12 @@
 					</areas>
 				</exercise>
 
-				<exercise label="c3-warm-ups-ww-2">
+				<exercise label="sov-warm-ups-ww-2">
 					<title><m>\ds y'= e^{2x} - 4x</m></title>
 
 					<introduction/>
 
-					<webwork xml:id="c3-step-by-step-03-ww">
+					<webwork xml:id="sov-step-by-step-03-ww">
 						<description>
 							Solve a separable DE using separation of variables.
 						</description>
@@ -1389,11 +1389,11 @@
 
 				</exercise>
 
-				<exercise label="c3-warm-ups-ww-3"><title><m>\dfrac{dy}{dx} = xy^2</m></title>
+				<exercise label="sov-warm-ups-ww-3"><title><m>\dfrac{dy}{dx} = xy^2</m></title>
 
 					<introduction/>
 
-					<webwork xml:id="c3-step-by-step-04-ww">
+					<webwork xml:id="sov-step-by-step-04-ww">
 
 						<description>
 							Solve a separable DE using separation of variables.
@@ -1481,11 +1481,11 @@
 
 				</exercise>
 
-				<exercise label="c3-warm-ups-ww-4"><title><m>\ds\frac{dy}{dx} - y\cos(x) = y</m></title>
+				<exercise label="sov-warm-ups-ww-4"><title><m>\ds\frac{dy}{dx} - y\cos(x) = y</m></title>
 
 					<introduction/>
 
-					<webwork xml:id="c3-step-by-step-02-ww">
+					<webwork xml:id="sov-step-by-step-02-ww">
 						<description>
 							Solve a separable DE using separation of variables.
 						</description>


### PR DESCRIPTION
# exercises-sov_MC-edit.md

## Applied edits (math/logic)
- M-001 | sov-cq-tf-05 | Moved existing <feedback> to immediately after </statement> so the explanation paragraphs are properly contained. | why:fix invalid PTX structure
- M-002 | sov-cq-tf-10 | \frac{dz^2}{d^2t} → \frac{d^2z}{dt^2} | why:correct second-derivative notation
- M-003 | c_2 = 2c_1 | In feedback derivation, corrected multiply-by-2 step: y^2 = 2\sin(x) + 2c_1. | why:fix algebra consistency
- M-004 | Verify that z = \tan(t+C) | Corrected verification steps to keep (t+C) dependence and use identity sec^2(u)-1=tan^2(u). | why:fix trig verification
- M-005 | z(4) = 9 | Fixed C computation (arctan) and updated particular solution. | why:correct numeric evaluation
- M-006 | c3-warm-ups-ww-2 title | Updated title to match pg-code (−4x). | why:fix title/code mismatch

## Applied edits (copy)
- C-001 | Only first-order ordinary | pluralized equation→equations
- C-002 | sometimes implicit function | added missing article
- C-003 | some second order differential | second order → second-order (statement)
- C-004 | does have a y term | fixed does/does not
- C-005 | thatare separable | fixed missing space
- C-007 | paticular solution | fixed spelling
- C-008 | sov-drills-3-1 | fixed the/and typos
- C-009 | Show the differential | equations → equation
- C-010 | c3-warm-ups-ww-2 | Don't forget the absolute value on the left antiderivative. → Don't forget the constants of integration.
- C-011 | c3-warm-ups-ww-3 | Don't forget the absolute value on the left antiderivative. → Don't forget the constants of integration.

## VERIFY-REQUIRED
- (none)

## References
- (none)