### PR TITLE
Update sec-completing-the-product-rule.ptx

### DIFF
--- a/source/c5-if/sec-completing-the-product-rule.ptx
+++ b/source/c5-if/sec-completing-the-product-rule.ptx
@@ -51,7 +51,7 @@
 	</p>
 
 	<p>
-		Applying the product rule in reverse, gives a single derivative on the left:
+		Applying the product rule in reverse gives a single derivative on the left:
 		<me>
 			\frac{d}{dx} \left[ e^{6x} y \right] = -e^{6x}
 		</me>.
@@ -168,7 +168,7 @@
 		</task>
 
 		<task label="completing-prod-rule-cyu-1-task-2">
-			<title><e component="emoji">📖❓</e>  Purpose of Multiply <m>e^{6x}</m></title>
+			<title><e component="emoji">📖❓</e>  Purpose of Multiplying <m>e^{6x}</m></title>
 			<statement>
 				<p>
 					Why do we multiply both sides of
@@ -223,7 +223,7 @@
 					</statement>
 					<feedback>
 						<p>
-							Incorrect. The equation already linear. Moreover, multiplying by any function of <m>x</m> will not change the equation's linearity.
+							Incorrect. The equation is already linear. Moreover, multiplying by any function of <m>x</m> will not change the equation's linearity.
 						</p>
 					</feedback>
 				</choice>
@@ -407,7 +407,7 @@
 				</me>
 
 				<p>
-					What function would you think to multiply onto the equation
+					What function would you think to multiply the equation by
 				</p>
 
 				<me>
@@ -452,7 +452,7 @@
 					</statement>
 					<feedback>
 						<p>
-							That's correct! Multiplying by <m>e^{8x}</m> will allow you to complete the product rule on the left side of the equation.
+							That's correct! Multiplying by <m>e^{-8x}</m> will allow you to complete the product rule on the left side of the equation.
 						</p>
 					</feedback>
 				</choice>

--- a/source/c5-if/sec-completing-the-product-rule.ptx
+++ b/source/c5-if/sec-completing-the-product-rule.ptx
@@ -60,7 +60,7 @@
 	<p>This new form makes solving easier since direct integration can be used.</p>
 
 	<p>
-		This process of multiplying by the right function to complete the product rule is the heart of the <term>integrating factor method</term> and it raises an important question:
+		This process of multiplying by the right function to complete the product rule is the heart of the <term>integrating factor method</term>, and it raises an important question:
 	</p>
 
 	<p><em>How do we know what function to multiply by?</em> That's what we'll figure out in the next section.</p>
@@ -155,7 +155,7 @@
 				<choice>
 					<statement>
 						<p>
-							A randomly chosen constant added to balance the equation.
+							A randomly chosen constant is added to balance the equation.
 						</p>
 					</statement>
 					<feedback>
@@ -250,14 +250,14 @@
 					</statement>
 					<feedback>
 						<p>
-							Correct! The equation is missing an essential function that would allow it to be rewritten using the product rule.
+							Correct! The equation lacks an essential function that would enable it to be rewritten using the product rule.
 						</p>
 					</feedback>
 				</choice>
 				<choice>
 					<statement>
 						<p>
-							Because we haven't used the product rule yet.
+							Because we have not yet used the product rule.
 						</p>
 					</statement>
 					<feedback>
@@ -369,11 +369,11 @@
 				</choice>
 				<choice>
 					<statement>It computes the derivative of a product of two functions.</statement>
-					<feedback>Incorrect. In this situation, the product rule is not used to take a derivative of a product of two functions.</feedback>
+					<feedback>Incorrect. In this situation, the product rule is not used to differentiate a product of two functions.</feedback>
 				</choice>
 				<choice>
 					<statement>It solves the differential equation directly.</statement>
-					<feedback>Incorrect. The product rule can help solve some differential equations, but it does not solve them alone.</feedback>
+					<feedback>Incorrect. The product rule can help solve certain differential equations, but it does not solve them on its own.</feedback>
 				</choice>
 				<choice correct="yes">
 					<statement>It allows it to be easily solved by direct integration.</statement>


### PR DESCRIPTION
sec-completing-the-product-rule | 2026-01-14 | VR:0 M:1 C:4

VERIFY-REQUIRED (applied)
(none)

Math/logic (applied)
M-001 | That's correct! Multiplying by | feedback: <m>e^{8x}</m>→<m>e^{-8x}</m> | why:sign matches product rule

Copy edits (applied)
C-001 | Applying the product rule in reverse, | removed comma after “reverse” C-002 | Purpose of Multiply | title: Multiply→Multiplying C-003 | The equation already linear. | add “is”
C-004 | multiply onto the equation | rephrase: multiply the equation by

References
(none)