### PR TITLE
Update exercises-solns.ptx

### DIFF
--- a/source/c2-solns/exercises-solns.ptx
+++ b/source/c2-solns/exercises-solns.ptx
@@ -971,6 +971,9 @@
 							Therefore, the differential equation must be <m>y' - ty'' =  12t^3\sin(t^2)</m>.
 						</p>
 					</solution>
+					<answer>
+						<p><m>12t^3\sin(t^2)</m></p>
+					</answer>
 				</exercise>
 			</exercisegroup>
 		</exercises>
@@ -1259,6 +1262,9 @@
 							So the two solutions are <m>k = -3, \frac{1}{3}.</m>
 						</p>
 					</solution>
+					<answer>
+						<p><m>k=\dfrac{1}{3}</m> or <m>k=-3</m>.</p>
+					</answer>
 				</exercise>
 
 				<exercise label="solns-problems-find-k-02">
@@ -1471,6 +1477,9 @@
 						</p>
 
 					</solution>
+					<answer>
+						<p>It must also satisfy the initial condition (here, <m>y(0)=0</m>).</p>
+					</answer>
 					<response />
 				</exercise>
 


### PR DESCRIPTION
# exercises-solns — 2026-01-14
Totals: VR:0 | M:0 | C:3

## VERIFY-REQUIRED (applied)
(none)

## Copy edits (applied)
C-001 | exercise solns-drills-05 | +<answer> (12t^3\sin(t^2)) | why:ensure each solution has a matching answer tag C-002 | exercise solns-problems-find-k-01 | +<answer> (k=\dfrac{1}{3} or k=-3.) | why:ensure each solution has a matching answer tag C-003 | exercise solns-ex-ivp-02 | +<answer> (It must also satisfy the initial condition (here, y(0)=0).) | why:ensure each solution has a matching answer tag

## References
(none)