### PR TITLE
Update exercises-sov.ptx

### DIFF
--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -858,6 +858,9 @@
 							</ol>
 						</p>
 					</solution>
+					<answer>
+						<p>Only in the special cases <m>Q(x)=0</m> (homogeneous) or <m>P(x)=0</m> (no <m>y</m>-term), so that <m>y'=f(x)\,g(y)</m>.</p>
+					</answer>
 
 				</task>
 
@@ -906,6 +909,9 @@
 						</me>
 					</p>
 				</solution>
+				<answer>
+					<p><m>z = \tan(t + 79.66)</m></p>
+				</answer>
 			</exercise>
 
 			<exercise label="sov-drills-2">
@@ -922,6 +928,9 @@
 						and it should be clear that there is no way to separate <m>t</m> and <m>s</m> by <em>multiplication</em> in the numerator, so this equation <em>is not separable</em>.
 					</p>
 				</solution>
+				<answer>
+					<p><alert>not</alert> separable</p>
+				</answer>
 			</exercise>
 
 			<exercisegroup cols="2" label="sov-drills-3">
@@ -1154,6 +1163,9 @@
 							</li>
 						</ol>
 					</solution>
+					<answer>
+						<p><m>f(x)=\dfrac{e^x}{x}</m>, <m>g(y)=\dfrac{y^2-1}{y}</m>.</p>
+					</answer>
 
 				</exercise>
 


### PR DESCRIPTION
# exercises-sov — 2026-01-14
Totals: VR:0 | M:0 | C:4

## VERIFY-REQUIRED (applied)
(none)

## Copy edits (applied)
C-001 | task sov-cq-sa-05 | +<answer> (Only in the special cases Q(x)=0 (homogeneous) or P(x)=0 (no y-term...) | why:ensure each solution has a matching answer tag C-002 | exercise sov-drills-1 | +<answer> (z = \tan(t + 79.66)) | why:ensure each solution has a matching answer tag C-003 | exercise sov-drills-2 | +<answer> (not separable) | why:ensure each solution has a matching answer tag C-004 | exercise sov-warm-ups-ww-1 | +<answer> (f(x)=\dfrac{e^x}{x}, g(y)=\dfrac{y^2-1}{y}.) | why:ensure each solution has a matching answer tag

## References
(none)