### PR TITLE
Update exercises-if.ptx

### DIFF
--- a/source/c5-if/exercises-if.ptx
+++ b/source/c5-if/exercises-if.ptx
@@ -321,6 +321,9 @@
 							</me>
 						</p>
 					</solution>
+<answer>
+						<p><alert>Nonlinear and non-separable</alert> first-order equations. Example: <m>y' = y^2 + x</m>.</p>
+					</answer>
 					<response/>
 				</task>
 
@@ -421,7 +424,7 @@
 					</statement>
 					<solution>
 					<p>
-						This DE is first order and linear, so it can be solved using an integrating factor.
+						This DE is first-order and linear, so it can be solved using an integrating factor.
 					</p>
 					<p>
 						It is <em>not</em> separable. After isolating the derivative:
@@ -443,7 +446,7 @@
 					</statement>
 					<solution>
 					<p>
-						This DE is first order but <em>not</em> linear because the dependent variable <m>x</m> appears inside the nonlinear term <m>e^x</m>.
+						This DE is first-order but <em>not</em> linear because the dependent variable <m>x</m> appears inside the nonlinear term <m>e^x</m>.
 					</p>
 					<p>
 						It is also not separable. After isolating the derivative:
@@ -465,7 +468,7 @@
 					</statement>
 					<solution>
 					<p>
-						This DE is first order and linear, so it can be solved using an integrating factor.
+						This DE is first-order and linear, so it can be solved using an integrating factor.
 					</p>
 					<p>
 						It is also separable. Solving for the derivative:
@@ -492,7 +495,7 @@
 					</statement>
 					<solution>
 					<p>
-						This DE is first order but <em>not</em> linear because the dependent variable <m>y</m> is raised to a power (<m>y^2</m>).
+						This DE is first-order but <em>not</em> linear because the dependent variable <m>y</m> is raised to a power (<m>y^2</m>).
 					</p>
 					<p>
 						It <em>is</em> separable. Solving for the derivative:
@@ -518,7 +521,7 @@
 					</statement>
 					<solution>
 					<p>
-						This DE is first order and linear, so it can be solved using an integrating factor.
+						This DE is first-order and linear, so it can be solved using an integrating factor.
 					</p>
 					<p>
 						It is <em>not</em> separable. Solving for the derivative:
@@ -537,7 +540,7 @@
 		</exercises>
 
 		<exercises label="if-problems">
-			<title><e component="emoji">✍🏻</e> Problems </title>
+			<title><e component="emoji">✍🏻</e> Problems</title>
 
 			<exercisegroup cols="2" label="if-problem-gen-sol">
 				<title>General Solution</title>


### PR DESCRIPTION
# exercises-if — 2026-01-14 (MERGED)
Totals: VR:0 | M:0 | C:7

## VERIFY-REQUIRED (applied)
(none)

## Math/logic (applied)
(none)

## Copy edits (applied)
C-001 | if-drill-which-method-1 | first order→first-order C-002 | if-drill-which-method-2 | first order→first-order C-003 | if-drill-which-method-3 | first order→first-order C-004 | if-drill-which-method-4 | first order→first-order C-005 | if-drill-which-method-5 | first order→first-order C-006 | ✍🏻 Problems | trim trailing space in <title> C-007 | task if-cq-sa-02 | +<answer> (Nonlinear and non-separable first-order equations. Example: y' = y^2 + x.) | why:ensure each solution has a matching answer tag

## References
(none)