### PR TITLE
Update sec-autonomous-equations.ptx

### DIFF
--- a/source/c6-qm/sec-autonomous-equations.ptx
+++ b/source/c6-qm/sec-autonomous-equations.ptx
@@ -288,8 +288,8 @@
 				<title><e component="emoji">📖❓</e>  Shifting Solutions</title>
 				<statement>
 					<p>
-					Suppose <m>y(t)</m> is a solution to the autonomous equation <m>y' = f(y)</m>.  
-					Which of the following must also be a solution?
+						Suppose <m>y(t)</m> is a solution to the autonomous equation <m>y' = f(y)</m>.  
+						Which of the following must also be a solution?
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -297,16 +297,16 @@
 						<statement><m>\ y(t + 3)</m></statement>
 						<feedback>Exactly—autonomous equations ignore the clock. Shifting in time just slides the solution along the <m>t</m>-axis.</feedback>
 					</choice>
-					<choice correct="no">
-					<statement><m>\ y(t) + 3</m></statement>
+					<choice>
+						<statement><m>\ y(t) + 3</m></statement>
 						<feedback>Adding to <m>y</m> changes the function itself—this doesn't preserve the solution.</feedback>
 					</choice>
-					<choice correct="no">
-					<statement><m>\ 3\ y(t)</m></statement>
+					<choice>
+						<statement><m>\ 3\ y(t)</m></statement>
 						<feedback>Scaling <m>y</m> is not guaranteed to produce another solution unless the DE is linear, which this one may not be.</feedback>
 					</choice>
-					<choice correct="no">
-					<statement><m>\ y(-t)</m></statement>
+					<choice>
+						<statement><m>\ y(-t)</m></statement>
 						<feedback>Flipping time is not generally a symmetry—it changes how <m>y</m> evolves.</feedback>
 					</choice>
 				</choices>

--- a/source/c6-qm/sec-autonomous-equations.ptx
+++ b/source/c6-qm/sec-autonomous-equations.ptx
@@ -23,7 +23,7 @@
 		</p>
 
 		<p>
-			<q>Autonomous</q> means <q>self-governing.</q> In these equations, the rate of change of <m>y</m> depends only on <m>y</m> itself, not on time <m>t</m>. The system's behavior is determined entirely by its current state. Think of a spring: it pushes back the same way no matter the time of day. Only how far it's compressed matters, not what time it is.
+			<q>Autonomous</q> means <q>self-governing</q>. In these equations, the rate of change of <m>y</m> depends only on <m>y</m> itself, not on time <m>t</m>. The system's behavior is determined entirely by its current state. Think of a spring: it pushes back the same way no matter the time of day. Only how far it's compressed matters, not what time it is.
 		</p>
 	</introduction>
 
@@ -247,7 +247,7 @@
 		</figure>
 
 		<p>
-			This symmetry isn't just in the slope field, it shows up in the <em>solutions</em> themselves. As seen in <xref ref="horizontal-solution-symmetry"/>, if you know one solution curve for an autonomous equation, you can create others simply by shifting that solution horizontally. That's because the equation doesn't <q>know</q> what time it is; it only cares about <m>y</m>.
+			This symmetry isn't just in the slope field; it shows up in the <em>solutions</em> themselves. As seen in <xref ref="horizontal-solution-symmetry"/>, if you know one solution curve for an autonomous equation, you can create others simply by shifting that solution horizontally. That's because the equation doesn't <q>know</q> what time it is; it only cares about <m>y</m>.
 		</p>
 
 		<exercise label="autonomous-eqns-cyu-bundle">
@@ -256,7 +256,7 @@
 				<title><e component="emoji">📖❓</e>  What does a slope field represent? </title>
 				<statement>
 					<p>
-						Suppose you compute the slope of an autonomous differential equation be <m>3</m> at the point <m>(2, 1)</m>. What is the slope at <m>(-3, 1)</m>?
+						Suppose you compute the slope of an autonomous differential equation to be <m>3</m> at the point <m>(2, 1)</m>. What is the slope at <m>(-3, 1)</m>?
 					</p>
 				</statement>
 
@@ -297,16 +297,16 @@
 						<statement><m>\ y(t + 3)</m></statement>
 						<feedback>Exactly—autonomous equations ignore the clock. Shifting in time just slides the solution along the <m>t</m>-axis.</feedback>
 					</choice>
-					<choice>
-						<statement><m>\ y(t) + 3</m></statement>
+					<choice correct="no">
+					<statement><m>\ y(t) + 3</m></statement>
 						<feedback>Adding to <m>y</m> changes the function itself—this doesn't preserve the solution.</feedback>
 					</choice>
-					<choice>
-						<statement><m>\ 3\ y(t)</m></statement>
+					<choice correct="no">
+					<statement><m>\ 3\ y(t)</m></statement>
 						<feedback>Scaling <m>y</m> is not guaranteed to produce another solution unless the DE is linear, which this one may not be.</feedback>
 					</choice>
-					<choice>
-						<statement><m>\ y(-t)</m></statement>
+					<choice correct="no">
+					<statement><m>\ y(-t)</m></statement>
 						<feedback>Flipping time is not generally a symmetry—it changes how <m>y</m> evolves.</feedback>
 					</choice>
 				</choices>


### PR DESCRIPTION
# sec-autonomous-equations_MC-edit.md

- File: sec-autonomous-equations.ptx (source TXT: sec-autonomous-equations.txt)
- Mode: Looser Direct PTX
- Date: 2026-01-15
- Totals: VR=1 | M=0 | C=3

## VERIFY-REQUIRED (applied) — FIRST
VR-001 | Shifting Solutions / <choices randomize="yes"> | Added correct="no" to the three <choice> elements missing a correctness attribute | conf(M) | verify:build/preview quiz grading | refs:

## Math/logic (applied)
(none)

## Copy edits (applied)
C-001 | "Autonomous" means "self-governing." | Moved period outside quoted term: <q>self-governing</q>. C-002 | "isn't just in the slope field, it shows up" | Fixed comma splice: comma → semicolon. C-003 | "equation be 3" | Grammar fix: be → to be.

## References
None (V0 in-file checks only).