### PR TITLE
Update sec-classifying-equilibrium-solutions.ptx

### DIFF
--- a/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
+++ b/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
@@ -15,7 +15,7 @@
 
 	<introduction>
 		<p>
-			Equilibrium solutions mark the places where a system comes to rest. But not all equilibrium solutions are alike, some attract nearby solutions, others repel them, and some do a bit of both. In this section, we'll learn how to classify these points by examining the slope field, the sign of <m>f(y)</m>, and a tool called a <term>phase line</term>.
+			Equilibrium solutions mark the places where a system comes to rest. But not all equilibrium solutions are alike; some attract nearby solutions, others repel them, and some do a bit of both. In this section, we'll learn how to classify these points by examining the slope field, the sign of <m>f(y)</m>, and a tool called a <term>phase line</term>.
 		</p>
 	</introduction>
 
@@ -643,12 +643,12 @@
 					</p>
 				</statement>
 				<choices randomize="yes">
-					<choice correct="yes"><statement><m>y = -1</m> is a sink, <m>y = 2</m> source</statement></choice>
-					<choice correct="no"><statement><m>y = -1</m> is a source, <m>y = 2</m> sink</statement></choice>
+					<choice correct="yes"><statement><m>y = -1</m> is a sink, <m>y = 3</m> source</statement></choice>
+					<choice correct="no"><statement><m>y = -1</m> is a source, <m>y = 3</m> sink</statement></choice>
 					<choice correct="no"><statement>Both are sinks</statement></choice>
 					<choice correct="no"><statement>Both are sources</statement></choice>
-					<choice correct="no"><statement><m>y = -1</m> is a node, <m>y = 2</m> sink</statement></choice>
-					<choice correct="no"><statement><m>y = -1</m> is a source, <m>y = 2</m> node</statement></choice>
+					<choice correct="no"><statement><m>y = -1</m> is a node, <m>y = 3</m> sink</statement></choice>
+					<choice correct="no"><statement><m>y = -1</m> is a source, <m>y = 3</m> node</statement></choice>
 				</choices>
 			</task>
 			
@@ -669,8 +669,7 @@
 						<statement><m>y=0</m></statement>
 						<feedback>Correct. Since <m>f'(y) = 2y-3</m> and <m>f'(0) = -3 \lt 0</m>, then <m>y=0</m> is a sink and pulls solutions toward it.</feedback>
 					</choice>
-					<choice>
-						<statement><m>y=3</m></statement>
+					<choice correct="no"><statement><m>y=3</m></statement>
 						<feedback>Incorrect. Since <m>f'(y) = 2y-3</m> and <m>f'(3) = +3 \gt 0</m>, then <m>y=3</m> is a source and repels solutions.</feedback>
 					</choice>
 				</choices>

--- a/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
+++ b/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
@@ -42,7 +42,7 @@
 		<title>Classification via the Phase Line</title>
 
 		<p>
-			Slope fields show a lot of information at once, but for autonomous equations we can simplify. Since the slope depends only on <m>y</m>, we can <q>compress</q> the slope field into a simple vertical diagram of just <m>y</m>-values. This is called a <term>phase line</term>.
+			Slope fields convey a great deal of information at once, but for autonomous equations, we can simplify them. Since the slope depends only on <m>y</m>, we can <q>compress</q> the slope field into a simple vertical diagram of just <m>y</m>-values. This is called a <term>phase line</term>.
 		</p>
 
     	<p>On a phase line:</p>
@@ -54,7 +54,7 @@
 		</ul>
 
 		<p>
-			The arrows summarize how <m>y(t)</m> changes: whether solutions are rising or falling. Follow the arrows up or down and you'll see where solutions eventually settle—or whether they're pushed away.
+			The arrows summarize how <m>y(t)</m> changes: whether solutions are rising or falling. Follow the arrows up or down, and you'll see where solutions eventually settle—or whether they're pushed away.
 		</p>
 		
 		<figure xml:id="phase-line-plot">
@@ -669,7 +669,8 @@
 						<statement><m>y=0</m></statement>
 						<feedback>Correct. Since <m>f'(y) = 2y-3</m> and <m>f'(0) = -3 \lt 0</m>, then <m>y=0</m> is a sink and pulls solutions toward it.</feedback>
 					</choice>
-					<choice correct="no"><statement><m>y=3</m></statement>
+					<choice correct="no">
+						<statement><m>y=3</m></statement>
 						<feedback>Incorrect. Since <m>f'(y) = 2y-3</m> and <m>f'(3) = +3 \gt 0</m>, then <m>y=3</m> is a source and repels solutions.</feedback>
 					</choice>
 				</choices>


### PR DESCRIPTION
# sec-classifying-equilibrium-solutions_MC-edit.md

- File: sec-classifying-equilibrium-solutions.ptx (source TXT: sec-classifying-equilibrium-solutions.txt)
- Mode: Looser Direct PTX
- Date: 2026-01-15
- Totals: VR=1 | M=1 | C=1

## VERIFY-REQUIRED (applied) — FIRST
VR-001 | classifying-equilibria-cyu-2 / <choices randomize="yes"> | Added correct="no" to the second <choice> (was missing correctness attribute) | conf(H) | verify:build/preview quiz grading | refs: R2

## Math/logic (applied)
M-001 | classifying-equilibria-cyu-1 choices | Fixed incorrect equilibrium label in answer choices: <m>y=2</m> → <m>y=3</m> (equilibria are -1 and 3) | conf(H) | refs: R1

## Copy edits (applied)
C-001 | Intro | Fixed comma splice: "alike, some ..." → "alike; some ..." | refs: R0

## References
R0 (in-file): <introduction> first paragraph.
R1 (in-file): <task label="classifying-equilibria-cyu-1"> answer choices. R2 (in-file): <task label="classifying-equilibria-cyu-2"> second <choice>.