### PR TITLE
Update sec-parameter-analysis.ptx

### DIFF
--- a/source/c6-qm/sec-parameter-analysis.ptx
+++ b/source/c6-qm/sec-parameter-analysis.ptx
@@ -41,23 +41,22 @@
 				\frac{dx}{dt} = f(x, \mu),
 			</me>
 			where <m>\mu</m> is a parameter. As <m>\mu</m> changes:
+			<ul marker="square">
+				<li><em>Existing equilibria</em> may change from stable to unstable (or vice versa).</li>
+				<li><em>New equilibria</em> may appear or disappear altogether.</li>
+				<li>In some cases, the <em>long-term behavior</em> of the entire system changes.</li>
+			</ul>
 		</p>
-
-		<ul marker="square">
-			<li><em>Existing equilibria</em> may change from stable to unstable (or vice versa).</li>
-			<li><em>New equilibria</em> may appear or disappear altogether.</li>
-			<li>In some cases, the <em>long-term behavior</em> of the entire system changes.</li>
-		</ul>
 
 		<p>
 			The basic workflow for bifurcation analysis is:
+			<ol>
+				<li><term>Find equilibria:</term> Solve <m>f(x, \mu) = 0</m> for <m>x</m> in terms of the parameter <m>\mu</m>.</li>
+				<li><term>Classify stability:</term> Compute <m>\frac{\partial f}{\partial x}</m> at each equilibrium. The sign determines whether the equilibrium is a <em>sink</em> (stable) or a <em>source</em> (unstable).</li>
+				<li><term>Track changes:</term> See how the equilibria and their stability change as <m>\mu</m> varies. Identify critical values where the behavior <q>flips</q>.</li>
+			</ol>
 		</p>
 
-		<ol>
-			<li><term>Find equilibria:</term> Solve <m>f(x, \mu) = 0</m> for <m>x</m> in terms of the parameter <m>\mu</m>.</li>
-			<li><term>Classify stability:</term> Compute <m>\frac{\partial f}{\partial x}</m> at each equilibrium. The sign determines whether the equilibrium is a <em>sink</em> (stable) or a <em>source</em> (unstable).</li>
-			<li><term>Track changes:</term> See how the equilibria and their stability change as <m>\mu</m> varies. Identify critical values where the behavior <q>flips</q>.</li>
-		</ol>
 		<p>
 			Consider the parameterized system:
 			<me>
@@ -74,13 +73,12 @@
 
 		<p>
 			To see how the equilibria depend on <m>\mu</m>, solve for equilibrium:
-		</p>
-
 			<ul>
-<li>For <m>\mu > 0</m>: two equilibria exist (<m>x = \pm \sqrt{\mu}</m>). </li>
+				<li>For <m>\mu > 0</m>: two equilibria exist (<m>x = \pm \sqrt{\mu}</m>). </li>
 				<li>For <m>\mu = 0</m>: a single equilibrium (<m>x = 0</m>). </li>
 				<li>For <m>\mu &lt; 0</m>: no real equilibria. </li>
 			</ul>
+		</p>
 
 		<p>
 			Stability analysis shows that one branch is stable and the other is unstable when <m>\mu &gt; 0</m>. The bifurcation diagram reveals a <q>collision</q> of equilibria at <m>\mu=0</m>, called a <term>saddle-node bifurcation</term>.
@@ -88,13 +86,12 @@
 
 		<p>
 			The results are often summarized in a <term>bifurcation diagram</term>—a picture showing:
-		</p>
-
 			<ul marker="square">
-<li>The equilibria plotted against <m>\mu</m>.</li>
+				<li>The equilibria plotted against <m>\mu</m>.</li>
 				<li>Solid lines for stable equilibria, dashed lines for unstable ones.</li>
 				<li>Critical parameter values where the diagram changes shape.</li>
 			</ul>
+		</p>
 
 		<p>
 			<xref ref="saddle-node-bifurcation-diagram"/> shows the bifurcation diagram for the previous example.
@@ -147,7 +144,7 @@
 
 		<ul marker="square">
 			<li><term>Stable equilibria</term> correspond to long-term states the system will settle into.</li>
-			<li><term>Bifurcation points</term> are thresholds where those long-term states shift—suddenly and sometimes irreversibly.</li>
+			<li><term>Bifurcation points</term> are thresholds where those long-term states shift suddenly and sometimes irreversibly.</li>
 		</ul>
 
 		<p>
@@ -165,21 +162,21 @@
 				<title>Spot the Bifurcation</title>
 				<statement>
 					<p>
-					The model <m>\frac{dx}{dt} = \mu - x^2</m> changes behavior as <m>\mu</m> varies. What happens when <m>\mu</m> crosses zero?
+						The model <m>\frac{dx}{dt} = \mu - x^2</m> changes behavior as <m>\mu</m> varies. What happens when <m>\mu</m> crosses zero?
 					</p>
 				</statement>
 				<choices randomize="yes">
 					<choice correct="yes">
-					<statement>Two equilibria collide and disappear.</statement>
-					<feedback>Correct—this is the hallmark of a saddle-node bifurcation.</feedback>
+						<statement>Two equilibria collide and disappear.</statement>
+						<feedback>Correct—this is the hallmark of a saddle-node bifurcation.</feedback>
 					</choice>
 					<choice correct="no">
-					<statement>The system gains an oscillation.</statement>
-					<feedback>This model is one-dimensional; it cannot generate oscillations.</feedback>
+						<statement>The system gains an oscillation.</statement>
+						<feedback>This model is one-dimensional; it cannot generate oscillations.</feedback>
 					</choice>
 					<choice correct="no">
-					<statement>The system's slope changes sign but equilibria stay the same.</statement>
-					<feedback>No—the set of equilibria itself changes.</feedback>
+						<statement>The system's slope changes sign, but equilibria stay the same.</statement>
+						<feedback>No—the set of equilibria itself changes.</feedback>
 					</choice>
 				</choices>
 			</task>

--- a/source/c6-qm/sec-parameter-analysis.ptx
+++ b/source/c6-qm/sec-parameter-analysis.ptx
@@ -56,7 +56,7 @@
 		<ol>
 			<li><term>Find equilibria:</term> Solve <m>f(x, \mu) = 0</m> for <m>x</m> in terms of the parameter <m>\mu</m>.</li>
 			<li><term>Classify stability:</term> Compute <m>\frac{\partial f}{\partial x}</m> at each equilibrium. The sign determines whether the equilibrium is a <em>sink</em> (stable) or a <em>source</em> (unstable).</li>
-			<li><term>Track changes:</term> See how the equilibria and their stability change as <m>\mu</m> varies. Identify critical values where the behavior <q>flips.</q></li>
+			<li><term>Track changes:</term> See how the equilibria and their stability change as <m>\mu</m> varies. Identify critical values where the behavior <q>flips</q>.</li>
 		</ol>
 		<p>
 			Consider the parameterized system:
@@ -74,12 +74,13 @@
 
 		<p>
 			To see how the equilibria depend on <m>\mu</m>, solve for equilibrium:
+		</p>
+
 			<ul>
-				<li>For <m>\mu > 0</m>: two equilibria exist (<m>x = \pm \sqrt{\mu}</m>). </li>
+<li>For <m>\mu > 0</m>: two equilibria exist (<m>x = \pm \sqrt{\mu}</m>). </li>
 				<li>For <m>\mu = 0</m>: a single equilibrium (<m>x = 0</m>). </li>
 				<li>For <m>\mu &lt; 0</m>: no real equilibria. </li>
 			</ul>
-		</p>
 
 		<p>
 			Stability analysis shows that one branch is stable and the other is unstable when <m>\mu &gt; 0</m>. The bifurcation diagram reveals a <q>collision</q> of equilibria at <m>\mu=0</m>, called a <term>saddle-node bifurcation</term>.
@@ -87,12 +88,13 @@
 
 		<p>
 			The results are often summarized in a <term>bifurcation diagram</term>—a picture showing:
+		</p>
+
 			<ul marker="square">
-				<li>The equilibria plotted against <m>\mu</m>.</li>
+<li>The equilibria plotted against <m>\mu</m>.</li>
 				<li>Solid lines for stable equilibria, dashed lines for unstable ones.</li>
 				<li>Critical parameter values where the diagram changes shape.</li>
 			</ul>
-		</p>
 
 		<p>
 			<xref ref="saddle-node-bifurcation-diagram"/> shows the bifurcation diagram for the previous example.
@@ -171,11 +173,11 @@
 					<statement>Two equilibria collide and disappear.</statement>
 					<feedback>Correct—this is the hallmark of a saddle-node bifurcation.</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 					<statement>The system gains an oscillation.</statement>
 					<feedback>This model is one-dimensional; it cannot generate oscillations.</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 					<statement>The system's slope changes sign but equilibria stay the same.</statement>
 					<feedback>No—the set of equilibria itself changes.</feedback>
 					</choice>


### PR DESCRIPTION
# sec-parameter-analysis_MC-edit.md

- File: sec-parameter-analysis.ptx (source TXT: sec-parameter-analysis.txt)
- Mode: Looser Direct PTX
- Date: 2026-01-15
- Totals: VR=1 | M=0 | C=3

## VERIFY-REQUIRED (applied) — FIRST
VR-001 | parameter-analysis-cyu-1 / <choices randomize="yes"> | Added correct="no" to the two <choice> elements missing a correctness attribute | conf(H) | verify:build/preview quiz grading | refs: R3

## Math/logic (applied)
(none)

## Copy edits (applied)
C-001 | Bifurcation Analysis workflow step 3 | Moved period outside quoted term: <q>flips</q>. | refs: R0 C-002 | Equilibria vs parameter list | Fixed PTX structure: moved <ul> out of enclosing <p> (list is now sibling of paragraph) | refs: R1 C-003 | Bifurcation diagram summary list | Fixed PTX structure: moved <ul marker="square"> out of enclosing <p> (list is now sibling of paragraph) | refs: R2

## References
R0 (in-file): workflow step 3 item ending with <q>flips</q>. R1 (in-file): paragraph starting "To see how the equilibria depend on \mu..." and its bullet list. R2 (in-file): paragraph starting "The results are often summarized..." and its bullet list. R3 (in-file): <task label="parameter-analysis-cyu-1"> second/third <choice> elements.