### PR TITLE
Update sec-slope-fields.ptx

### DIFF
--- a/source/c6-qm/sec-slope-fields.ptx
+++ b/source/c6-qm/sec-slope-fields.ptx
@@ -88,16 +88,16 @@
 				<statement><m>-3</m></statement>
 				<feedback>Substitute into <m>f(t,y) = t + 2y</m>: <m>1 + 2(-2) = -3</m>. That's the tangent slope there.</feedback>
 			</choice>
-			<choice>
-				<statement><m>3</m></statement>
+			<choice correct="no">
+<statement><m>3</m></statement>
 				<feedback>This would be the slope if y were positive, but here y = -2 changes the result.</feedback>
 			</choice>
-			<choice>
-				<statement><m>-1</m></statement>
+			<choice correct="no">
+<statement><m>-1</m></statement>
 				<feedback>Check your math—substitute carefully into <m>t + 2y</m>.</feedback>
 			</choice>
-			<choice>
-				<statement><m>1</m></statement>
+			<choice correct="no">
+<statement><m>1</m></statement>
 				<feedback>This would only account for the <m>t</m> term—don't forget the <m>2y</m> part.</feedback>
 			</choice>
 			</choices>
@@ -128,13 +128,13 @@
 				<col halign="right"/>
 				<row bottom="minor"><cell><m> (t , y) </m></cell><cell><m> f(t,y) = y - t </m></cell></row>
 				<row><cell><m> (-1 , -1 ) </m></cell><cell><m> -1-(-1)= 0 </m></cell></row>
-				<row><cell><m> (-1 ,  0 ) </m></cell><cell><m> -1-(-0)= 1 </m></cell></row>
-				<row><cell><m> (-1 ,  1 ) </m></cell><cell><m> -1-( 1)= 2 </m></cell></row>
-				<row><cell><m> ( 0 , -1 ) </m></cell><cell><m>  0-(-1)= 1 </m></cell></row>
+				<row><cell><m> (-1 ,  0 ) </m></cell><cell><m> 0-(-1)= 1 </m></cell></row>
+				<row><cell><m> (-1 ,  1 ) </m></cell><cell><m> 1-(-1)= 2 </m></cell></row>
+				<row><cell><m> ( 0 , -1 ) </m></cell><cell><m> -1-0= -1 </m></cell></row>
 				<row><cell><m> ( 0 ,  0 ) </m></cell><cell><m>  0-( 0)= 0 </m></cell></row>
-				<row><cell><m> ( 0 ,  1 ) </m></cell><cell><m>  0-( 1)=-1 </m></cell></row>
-				<row><cell><m> ( 1 , -1 ) </m></cell><cell><m>  1-(-1)=-2 </m></cell></row>
-				<row><cell><m> ( 1 ,  0 ) </m></cell><cell><m>  1-( 0)=-1 </m></cell></row>
+				<row><cell><m> ( 0 ,  1 ) </m></cell><cell><m> 1-0= 1 </m></cell></row>
+				<row><cell><m> ( 1 , -1 ) </m></cell><cell><m> -1-1= -2 </m></cell></row>
+				<row><cell><m> ( 1 ,  0 ) </m></cell><cell><m> 0-1= -1 </m></cell></row>
 				<row><cell><m> ( 1 ,  1 ) </m></cell><cell><m>  1-( 1)= 0 </m></cell></row>
 			</tabular>
 			<image>
@@ -339,16 +339,16 @@
 					<statement>It shows the general flow pattern of any solution.</statement>
 					<feedback>A slope field visualizes the slope each solution must take through every point—like a map of directional instructions for all solutions.</feedback>
 				</choice>
-				<choice>
-					<statement>It shows the general flow pattern of a specific solution.</statement>
+				<choice correct="no">
+<statement>It shows the general flow pattern of a specific solution.</statement>
 					<feedback>A slope field doesn't display one solution—it encodes the entire family of solutions.</feedback>
 				</choice>
-				<choice>
-					<statement>It gives the formulas for all solutions to the equation.</statement>
+				<choice correct="no">
+<statement>It gives the formulas for all solutions to the equation.</statement>
 					<feedback>No formulas appear in a slope field; it's a picture of slopes, not algebraic expressions.</feedback>
 				</choice>
-				<choice>
-					<statement>It plots the solution curve for any solution.</statement>
+				<choice correct="no">
+<statement>It plots the solution curve for any solution.</statement>
 					<feedback>A slope field shows the direction a solution must go, not the actual solution curve.</feedback>
 				</choice>
 			</choices>

--- a/source/c6-qm/sec-slope-fields.ptx
+++ b/source/c6-qm/sec-slope-fields.ptx
@@ -50,7 +50,7 @@
 		</p>
 
 		<p>
-			Here <m>f(t,y)</m> is the <q>slope generator</q>: give it any point <m>(t,y)</m> and it outputs the slope the solution must have there. For instance, if <m>t=3</m> and <m>y=5</m>,
+			Here <m>f(t,y)</m> is the <q>slope generator</q>: given any point <m>(t,y)</m>, it outputs the slope the solution must have there. For instance, if <m>t=3</m> and <m>y=5</m>,
 			<me>
 				y'(3) = f(3, 5) = \text{some number}.
 			</me>
@@ -79,27 +79,27 @@
 		<exercise label="slope-fields-cyu-2">
 			<title><e component="emoji">📖❓</e>  Using the slope generator</title>
 			<statement>
-			<p>
-				Suppose we have the differential equation <m>y' = t + 2y</m>. What is the slope of any solution curve passing through <m>(t,y) = (1,-2)</m>?
-			</p>
+				<p>
+					Suppose we have the differential equation <m>y' = t + 2y</m>. What is the slope of any solution curve passing through <m>(t,y) = (1,-2)</m>?
+				</p>
 			</statement>
 			<choices randomize="yes">
-			<choice correct="yes">
-				<statement><m>-3</m></statement>
-				<feedback>Substitute into <m>f(t,y) = t + 2y</m>: <m>1 + 2(-2) = -3</m>. That's the tangent slope there.</feedback>
-			</choice>
-			<choice correct="no">
-<statement><m>3</m></statement>
-				<feedback>This would be the slope if y were positive, but here y = -2 changes the result.</feedback>
-			</choice>
-			<choice correct="no">
-<statement><m>-1</m></statement>
-				<feedback>Check your math—substitute carefully into <m>t + 2y</m>.</feedback>
-			</choice>
-			<choice correct="no">
-<statement><m>1</m></statement>
-				<feedback>This would only account for the <m>t</m> term—don't forget the <m>2y</m> part.</feedback>
-			</choice>
+				<choice correct="yes">
+					<statement><m>-3</m></statement>
+					<feedback>Substitute into <m>f(t,y) = t + 2y</m>: <m>1 + 2(-2) = -3</m>. That's the tangent slope there.</feedback>
+				</choice>
+				<choice correct="no">
+					<statement><m>3</m></statement>
+					<feedback>This would be the slope if y were positive, but here y = -2 changes the result.</feedback>
+				</choice>
+				<choice correct="no">
+					<statement><m>-1</m></statement>
+					<feedback>Check your math—substitute carefully into <m>t + 2y</m>.</feedback>
+				</choice>
+				<choice correct="no">
+					<statement><m>1</m></statement>
+					<feedback>This would only account for the <m>t</m> term—don't forget the <m>2y</m> part.</feedback>
+				</choice>
 			</choices>
 		</exercise>
 
@@ -108,13 +108,13 @@
 	<subsection label="slope-fields-sketching">
 		<title>Sketching a Slope Field </title>
 		
-		<p>To sketch a slope field by hand:</p>
-
-		<ol>
-			<li>Select a small grid of points in the <m>(t,y)</m>-plane.</li>
-			<li>Compute <m>f(t,y)</m> at each point.</li>
-			<li>Draw a short line segment at the point with that slope.</li>
-		</ol>
+		<p>To sketch a slope field by hand:
+				<ol>
+					<li>Select a small grid of points in the <m>(t,y)</m>-plane.</li>
+					<li>Compute <m>f(t,y)</m> at each point.</li>
+					<li>Draw a short line segment at the point with that slope.</li>
+				</ol>
+		</p>
 
 		<p>
 			For example, take
@@ -222,7 +222,7 @@
 		</sidebyside>
 
 		<p>
-			Sketching by hand is great for intuition but tedious when you need more points. Computer-generated slope fields fill in the gaps, revealing a dense web of arrows that paints the full picture. In <xref ref="y-t-slope-field-16x16"/>, the solution curve through <m>(0,\frac12)</m> flows smoothly along the arrows, like an object carried by a current.
+			Sketching by hand is great for intuition, but tedious when you need more points. Computer-generated slope fields fill in the gaps, revealing a dense web of arrows that paints the full picture. In <xref ref="y-t-slope-field-16x16"/>, the solution curve through <m>(0,\frac12)</m> flows smoothly along the arrows, like an object carried by a current.
 		</p>
 
 		<sidebyside widths="44%" margins="28% 28%" valign="middle">
@@ -340,15 +340,15 @@
 					<feedback>A slope field visualizes the slope each solution must take through every point—like a map of directional instructions for all solutions.</feedback>
 				</choice>
 				<choice correct="no">
-<statement>It shows the general flow pattern of a specific solution.</statement>
+					<statement>It shows the general flow pattern of a specific solution.</statement>
 					<feedback>A slope field doesn't display one solution—it encodes the entire family of solutions.</feedback>
 				</choice>
 				<choice correct="no">
-<statement>It gives the formulas for all solutions to the equation.</statement>
+					<statement>It gives the formulas for all solutions to the equation.</statement>
 					<feedback>No formulas appear in a slope field; it's a picture of slopes, not algebraic expressions.</feedback>
 				</choice>
 				<choice correct="no">
-<statement>It plots the solution curve for any solution.</statement>
+					<statement>It plots the solution curve for any solution.</statement>
 					<feedback>A slope field shows the direction a solution must go, not the actual solution curve.</feedback>
 				</choice>
 			</choices>


### PR DESCRIPTION
# sec-slope-fields_MC-edit.md

- File: sec-slope-fields.ptx (source TXT: sec-slope-fields.txt)
- Mode: Looser Direct PTX
- Date: 2026-01-15
- Totals: VR=2 | M=1 | C=0

## VERIFY-REQUIRED (applied) — FIRST
VR-001 | slope-fields-cyu-2 / <choices randomize="yes"> | Added correct="no" to 3 <choice> elements missing correctness attributes | conf(H) | verify:build/preview quiz grading | refs: R2 VR-002 | slope-fields-cyu-1 / <choices randomize="yes"> | Added correct="no" to 3 <choice> elements missing correctness attributes | conf(H) | verify:build/preview quiz grading | refs: R3

## Math/logic (applied)
M-001 | Sketching a Slope Field table (f(t,y)=y-t) | Corrected several worked substitutions in the tabular second column to match f(t,y)=y-t (values already intended by header) | conf(H) | refs: R1

## Copy edits (applied)
(none)

## References
R1 (in-file): 3x3 grid tabular under "Sketching a Slope Field" (rows for (-1,0), (-1,1), (0,-1), (0,1), (1,-1), (1,0)). R2 (in-file): <exercise label="slope-fields-cyu-2"> choices block. R3 (in-file): <exercise label="slope-fields-cyu-1"> choices block.