### PR TITLE
Update exercises-qm.ptx

### DIFF
--- a/source/c6-qm/exercises-qm.ptx
+++ b/source/c6-qm/exercises-qm.ptx
@@ -44,20 +44,20 @@
 				</statement>
 
 				<choices randomize="no">
-				<choice>
-					<statement><m>0</m></statement>
+				<choice correct="no">
+<statement><m>0</m></statement>
 					<feedback>The slope doesn't magically flatten; it's determined by <m>y</m>.</feedback>
 				</choice>
-				<choice>
-					<statement><m>2</m></statement>
+				<choice correct="no">
+<statement><m>2</m></statement>
 					<feedback>The sign doesn't flip when <m>t</m> changes—time isn't part of the slope function.</feedback>
 				</choice>
 				<choice correct="yes">
 					<statement><m>-2</m></statement>
 					<feedback>Correct! Autonomous equations ignore <m>t</m> entirely. If <m>y=-1</m>, the slope is always <m>f(-1) = -2</m>, no matter the time.</feedback>
 				</choice>
-				<choice>
-					<statement>Impossible to know</statement>
+				<choice correct="no">
+<statement>Impossible to know</statement>
 					<feedback>It's absolutely possible—you just evaluate <m>f(y)</m> at <m>y=-1</m>.</feedback>
 				</choice>
 				</choices>
@@ -76,16 +76,16 @@
 				<statement><m>y(t + c)</m></statement>
 				<feedback>Correct—autonomous equations allow time-shifted versions of any solution.</feedback>
 				</choice>
-				<choice>
-				<statement><m>c \, y(t)</m></statement>
+				<choice correct="no">
+<statement><m>c \, y(t)</m></statement>
 				<feedback>No—scaling the solution doesn't necessarily work unless the equation is linear.</feedback>
 				</choice>
-				<choice>
-				<statement><m>y(t) + c</m></statement>
+				<choice correct="no">
+<statement><m>y(t) + c</m></statement>
 				<feedback>No—adding a constant changes <m>y</m> in a way that won't satisfy the DE.</feedback>
 				</choice>
-				<choice>
-				<statement><m>y(t)^c</m></statement>
+				<choice correct="no">
+<statement><m>y(t)^c</m></statement>
 				<feedback>Raising the solution to a power doesn't preserve the equation's behavior.</feedback>
 				</choice>
 			</choices>
@@ -106,16 +106,16 @@
 				<statement><m>y(t + 5)</m></statement>
 				<feedback>Yes! Sliding the solution along the t-axis still solves the equation.</feedback>
 				</choice>
-				<choice>
-				<statement><m>2y(t)</m></statement>
+				<choice correct="no">
+<statement><m>2y(t)</m></statement>
 				<feedback>Scaling <m>y</m> won't necessarily satisfy the same DE.</feedback>
 				</choice>
-				<choice>
-				<statement><m>y(t) + 5</m></statement>
+				<choice correct="no">
+<statement><m>y(t) + 5</m></statement>
 				<feedback>Adding to <m>y</m> changes the values in a way that usually breaks the equation.</feedback>
 				</choice>
-				<choice>
-				<statement><m>y(-t)</m></statement>
+				<choice correct="no">
+<statement><m>y(-t)</m></statement>
 				<feedback>Reversing time is not the same as sliding it—it usually won't satisfy the DE.</feedback>
 				</choice>
 			</choices>
@@ -196,50 +196,50 @@
 			<title>Practice Problems</title>
 			<p>
 				Try these problems to reinforce your understanding:
-				<ol marker="a.">
-					<li>Sketch the slope field for <me>\dfrac{dy}{dt} = y^2 - 4y</me>.</li>
+			</p>
+			<ol marker="a.">
+				<li>Sketch the slope field for <me>\dfrac{dy}{dt} = y^2 - 4y</me>.</li>
 					<li>Identify the equilibrium solutions and their stability.</li>
 					<li>Draw the phase line for the equation and describe the long-term behavior of solutions.</li>
-				</ol>
-			</p>
+			</ol>
 		</exercise>
 
 		<exercise label="qm-problems-02">
 			<title>Exploring Nonlinear Dynamics</title>
 			<p>
-				Consider the nonlinear equation <me>\dfrac{dy}{dt} = y^3 - 3y</me>. 
-				<ol marker="a.">
-					<li>Find the equilibrium solutions.</li>
+				Consider the nonlinear equation <me>\dfrac{dy}{dt} = y^3 - 3y</me>.
+			</p>
+			<ol marker="a.">
+				<li>Find the equilibrium solutions.</li>
 					<li>Sketch the phase line and indicate the stability of each equilibrium.</li>
 					<li>Discuss how this equation might model a system with multiple stable states.</li>
-				</ol>
-			</p>
+			</ol>
 			<response />
 		</exercise>
 
 		<exercise label="qm-problems-03">
 			<title>Exploring Chaos in Autonomous Systems</title>
 			<p>
-				Consider the equation <me>\dfrac{dy}{dt} = y^2 - 2y + 1</me>. 
-				<ol marker="a.">
-					<li>Identify the equilibrium solutions.</li>
+				Consider the equation <me>\dfrac{dy}{dt} = y^2 - 2y + 1</me>.
+			</p>
+			<ol marker="a.">
+				<li>Identify the equilibrium solutions.</li>
 					<li>Discuss whether this system exhibits chaotic behavior or not.</li>
 					<li>Sketch the phase line and describe the long-term behavior of solutions.</li>
-				</ol>
-			</p>
+			</ol>
 			<response />
 		</exercise>
 
 		<exercise label="qm-problems-04">
 			<title>Exploring Real-World Applications</title>
 			<p>
-				Consider a population of rabbits modeled by the equation <me>\frac{dP}{dt} = rP\left(1 - \frac{P}{K}\right)</me>, where <m>r</m> is the growth rate and <m>K</m> is the carrying capacity. 
-				<ol marker="a.">
-					<li>Identify the equilibrium solutions.</li>
+				Consider a population of rabbits modeled by the equation <me>\frac{dP}{dt} = rP\left(1 - \frac{P}{K}\right)</me>, where <m>r</m> is the growth rate and <m>K</m> is the carrying capacity.
+			</p>
+			<ol marker="a.">
+				<li>Identify the equilibrium solutions.</li>
 					<li>Sketch the phase line and describe the stability of each equilibrium.</li>
 					<li>Discuss how this model can help predict population dynamics over time.</li>
-				</ol>
-			</p>
+			</ol>
 			<response />
 		</exercise>
 
@@ -255,7 +255,7 @@
 					To find equilibrium solutions, we set <m>f(y) = y^2 = 0</m>. This gives us the solution <m>y = 0</m>. So, <m>y = 0</m> is the only equilibrium solution for this equation.
 				</p>
 				<p>
-					This means that if the solution starts at <m>y(0) = 0</m>, it will remain at zero for all time. If it starts anywhere else, it will either increase or decrease away from zero.
+					This means that if the solution starts at <m>y(0) = 0</m>, it will remain at zero for all time. If it starts with <m>y(0) &gt; 0</m>, it increases; if it starts with <m>y(0) &lt; 0</m>, it increases toward <m>0</m> (remaining negative).
 				</p>
 			</solution>
 		</exercise>
@@ -295,6 +295,11 @@
 					These are the equilibrium solutions where the slope is zero. At these points, the solution does not change over time.
 				</p>
 			</solution>
+			<answer>
+				<p>
+					The equilibrium solutions are <m>y=-1</m>, <m>y=0</m>, and <m>y=1</m>.
+				</p>
+			</answer>
 		</exercise>
 
 		<exercise label="qm-problems-07">

--- a/source/c6-qm/exercises-qm.ptx
+++ b/source/c6-qm/exercises-qm.ptx
@@ -33,23 +33,25 @@
 			</tabular>
 		</aside>
 
-		<exercise label="qm-cq"><title>Multiple-Choice</title>
+		<exercise label="qm-cq">
+			<title>Multiple-Choice</title>
+
 			<task label="qm-cq-mc-1">
 				<title>Does time matter here?</title>
-				<statement>
-				<p>
-					For the autonomous equation <me>y' = y^2 - 1</me>, the slope field shows a slope of <m>-2</m> at <m>(t,y) = (5,-1)</m>.  
-					What is the slope at <m>(t,y) = (-10,-1)</m>?
-				</p>
-				</statement>
 
+				<statement>
+					<p>
+						For the autonomous equation <me>y' = y^2 - 1</me>, the slope field shows a slope of <m>-2</m> at <m>(t,y) = (5,-1)</m>.  
+						What is the slope at <m>(t,y) = (-10,-1)</m>?
+					</p>
+				</statement>
 				<choices randomize="no">
 				<choice correct="no">
-<statement><m>0</m></statement>
+					<statement><m>0</m></statement>
 					<feedback>The slope doesn't magically flatten; it's determined by <m>y</m>.</feedback>
 				</choice>
 				<choice correct="no">
-<statement><m>2</m></statement>
+					<statement><m>2</m></statement>
 					<feedback>The sign doesn't flip when <m>t</m> changes—time isn't part of the slope function.</feedback>
 				</choice>
 				<choice correct="yes">
@@ -57,79 +59,81 @@
 					<feedback>Correct! Autonomous equations ignore <m>t</m> entirely. If <m>y=-1</m>, the slope is always <m>f(-1) = -2</m>, no matter the time.</feedback>
 				</choice>
 				<choice correct="no">
-<statement>Impossible to know</statement>
+					<statement>Impossible to know</statement>
 					<feedback>It's absolutely possible—you just evaluate <m>f(y)</m> at <m>y=-1</m>.</feedback>
 				</choice>
 				</choices>
 			</task>
 
 			<task label="qm-cq-mc-2">
-			<title>Horizontal Shift Symmetry</title>
-			<statement>
-				<p>
-				Fill in the blank:  
-				If <m>y(t)</m> is a solution to an autonomous equation, then _______ is also guaranteed to be a solution.
-				</p>
-			</statement>
-			<choices randomize="yes">
-				<choice correct="yes">
-				<statement><m>y(t + c)</m></statement>
-				<feedback>Correct—autonomous equations allow time-shifted versions of any solution.</feedback>
-				</choice>
-				<choice correct="no">
-<statement><m>c \, y(t)</m></statement>
-				<feedback>No—scaling the solution doesn't necessarily work unless the equation is linear.</feedback>
-				</choice>
-				<choice correct="no">
-<statement><m>y(t) + c</m></statement>
-				<feedback>No—adding a constant changes <m>y</m> in a way that won't satisfy the DE.</feedback>
-				</choice>
-				<choice correct="no">
-<statement><m>y(t)^c</m></statement>
-				<feedback>Raising the solution to a power doesn't preserve the equation's behavior.</feedback>
-				</choice>
-			</choices>
+				<title>Horizontal Shift Symmetry</title>
+
+				<statement>
+					<p>
+						Fill in the blank:  
+						If <m>y(t)</m> is a solution to an autonomous equation, then _______ is also guaranteed to be a solution.
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement><m>y(t + c)</m></statement>
+						<feedback>Correct—autonomous equations allow time-shifted versions of any solution.</feedback>
+					</choice>
+					<choice correct="no">
+						<statement><m>c \, y(t)</m></statement>
+						<feedback>No—scaling the solution doesn't necessarily work unless the equation is linear.</feedback>
+					</choice>
+					<choice correct="no">
+						<statement><m>y(t) + c</m></statement>
+						<feedback>No—adding a constant changes <m>y</m> in a way that won't satisfy the DE.</feedback>
+					</choice>
+					<choice correct="no">
+						<statement><m>y(t)^c</m></statement>
+						<feedback>Raising the solution to a power doesn't preserve the equation's behavior.</feedback>
+					</choice>
+				</choices>
 			</task>
 
 			<task label="qm-cq-mc-3">
-			<title>Time Shifts in Practice</title>
-			<statement>
-				<p>
-				A biologist models population growth with the autonomous equation  
-				<me> \frac{dy}{dt} = y(1 - y). </me>  
-				They find a solution curve <m>y(t)</m> that fits data collected in spring.  
-				Which of the following will always produce another valid solution?
-				</p>
-			</statement>
-			<choices randomize="yes">
-				<choice correct="yes">
-				<statement><m>y(t + 5)</m></statement>
-				<feedback>Yes! Sliding the solution along the t-axis still solves the equation.</feedback>
-				</choice>
-				<choice correct="no">
-<statement><m>2y(t)</m></statement>
-				<feedback>Scaling <m>y</m> won't necessarily satisfy the same DE.</feedback>
-				</choice>
-				<choice correct="no">
-<statement><m>y(t) + 5</m></statement>
-				<feedback>Adding to <m>y</m> changes the values in a way that usually breaks the equation.</feedback>
-				</choice>
-				<choice correct="no">
-<statement><m>y(-t)</m></statement>
-				<feedback>Reversing time is not the same as sliding it—it usually won't satisfy the DE.</feedback>
-				</choice>
-			</choices>
+				<title>Time Shifts in Practice</title>
+
+				<statement>
+					<p>
+						A biologist models population growth with the autonomous equation  
+						<me> \frac{dy}{dt} = y(1 - y). </me>  
+						They find a solution curve <m>y(t)</m> that fits data collected in spring.  
+						Which of the following will always produce another valid solution?
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement><m>y(t + 5)</m></statement>
+						<feedback>Yes! Sliding the solution along the t-axis still solves the equation.</feedback>
+					</choice>
+					<choice correct="no">
+						<statement><m>2y(t)</m></statement>
+						<feedback>Scaling <m>y</m> won't necessarily satisfy the same DE.</feedback>
+					</choice>
+					<choice correct="no">
+						<statement><m>y(t) + 5</m></statement>
+						<feedback>Adding to <m>y</m> changes the values in a way that usually breaks the equation.</feedback>
+					</choice>
+					<choice correct="no">
+						<statement><m>y(-t)</m></statement>
+						<feedback>Reversing time is not the same as sliding it—it usually won't satisfy the DE.</feedback>
+					</choice>
+				</choices>
 			</task>
 
 			<task label="qm-cq-mc-4">
 				<title>Equilibrium Identification</title>
+
 				<statement>
 					<p>
-						For the equation
+						Which of the following is an equilibrium solution for the following equation?
 						<me>
-							\dfrac{dy}{dt} = y^2 - 4y + 3,
+							\dfrac{dy}{dt} = y^2 - 4y + 3.
 						</me>
-						which of the following is an equilibrium solution?
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -142,6 +146,7 @@
 
 			<task label="qm-cq-mc-5">
 				<title>Stability Classification</title>
+
 				<statement>
 					<p>
 						For the same equation
@@ -161,6 +166,7 @@
 
 			<task label="qm-cq-sa-1">
 				<title><e component="emoji">📖❓</e> Phase Line Practice </title>
+
 				<response />
 				<statement>
 					<p>
@@ -175,6 +181,7 @@
 
 			<task label="qm-cq-sa-2">
 				<title>Review Questions</title>
+
 				<statement>
 					<ol>
 						<li>What is an autonomous differential equation?</li>
@@ -206,45 +213,49 @@
 
 		<exercise label="qm-problems-02">
 			<title>Exploring Nonlinear Dynamics</title>
+
 			<p>
 				Consider the nonlinear equation <me>\dfrac{dy}{dt} = y^3 - 3y</me>.
-			</p>
-			<ol marker="a.">
-				<li>Find the equilibrium solutions.</li>
+				<ol marker="a.">
+					<li>Find the equilibrium solutions.</li>
 					<li>Sketch the phase line and indicate the stability of each equilibrium.</li>
 					<li>Discuss how this equation might model a system with multiple stable states.</li>
-			</ol>
+				</ol>
+			</p>
 			<response />
 		</exercise>
 
 		<exercise label="qm-problems-03">
 			<title>Exploring Chaos in Autonomous Systems</title>
+
 			<p>
 				Consider the equation <me>\dfrac{dy}{dt} = y^2 - 2y + 1</me>.
+					<ol marker="a.">
+						<li>Identify the equilibrium solutions.</li>
+						<li>Discuss whether this system exhibits chaotic behavior or not.</li>
+						<li>Sketch the phase line and describe the long-term behavior of solutions.</li>
+					</ol>
 			</p>
-			<ol marker="a.">
-				<li>Identify the equilibrium solutions.</li>
-					<li>Discuss whether this system exhibits chaotic behavior or not.</li>
-					<li>Sketch the phase line and describe the long-term behavior of solutions.</li>
-			</ol>
 			<response />
 		</exercise>
 
 		<exercise label="qm-problems-04">
 			<title>Exploring Real-World Applications</title>
+
 			<p>
 				Consider a population of rabbits modeled by the equation <me>\frac{dP}{dt} = rP\left(1 - \frac{P}{K}\right)</me>, where <m>r</m> is the growth rate and <m>K</m> is the carrying capacity.
-			</p>
-			<ol marker="a.">
-				<li>Identify the equilibrium solutions.</li>
+				<ol marker="a.">
+					<li>Identify the equilibrium solutions.</li>
 					<li>Sketch the phase line and describe the stability of each equilibrium.</li>
 					<li>Discuss how this model can help predict population dynamics over time.</li>
-			</ol>
+				</ol>
+			</p>
 			<response />
 		</exercise>
 
 		<exercise label="qm-problems-05">
 			<title>Find the Equilibrium Solution</title>
+
 			<statement>
 				<p>
 					Find the equilibrium solutions for the autonomous differential equation <me>\dfrac{dy}{dx} = y^2</me>.
@@ -262,6 +273,7 @@
 
 		<exercise label="qm-problems-06">
 			<title>Finding Equilibrium Points</title>
+
 			<statement>
 				<p>
 					Find all equilibrium solutions of the autonomous differential equation
@@ -273,26 +285,26 @@
 			<solution>
 				<p>
 					To find the equilibrium solutions, we set the right-hand side equal to zero:
+					<me>
+						y^2 - y^4 = 0.
+					</me>
 				</p>
-				<me>
-					y^2 - y^4 = 0.
-				</me>
 				<p>
 					Factoring gives us:
+					<me>
+						y^2(1 - y^2) = 0.
+					</me>
 				</p>
-				<me>
-					y^2(1 - y^2) = 0.
-				</me>
 				<p>
 					This has solutions:
+					<ol marker="a.">
+						<li><m>y = 0</m></li>
+						<li><m>y = 1</m></li>
+						<li><m>y = -1</m></li>
+					</ol>
 				</p>
-				<ol marker="a.">
-					<li><m>y = 0</m></li>
-					<li><m>y = 1</m></li>
-					<li><m>y = -1</m></li>
-				</ol>
 				<p>
-					These are the equilibrium solutions where the slope is zero. At these points, the solution does not change over time.
+					These are the equilibrium solutions where the slope is zero. At these points, the solution remains constant over time.
 				</p>
 			</solution>
 			<answer>
@@ -304,6 +316,7 @@
 
 		<exercise label="qm-problems-07">
 			<title>Phase Line Sketching</title>
+
 			<statement>
 				<p>
 					Sketch a phase line for the equation


### PR DESCRIPTION
# exercises-qm_MC-edit.md
Kathy's Note: missing answer not corrected: qm-problems-05 is mostly qualitative (no single clean terminal answer to copy).

- File: exercises-qm.ptx (source TXT: exercises-qm.txt)
- Mode: Looser Direct PTX
- Date: 2026-01-15
- Totals: VR=3 | M=1 | C=4

## VERIFY-REQUIRED (applied) — FIRST
VR-001 | qm-cq-mc-1 / <choices randomize="no"> | Added correct="no" to 3 <choice> elements missing correctness attributes | conf(H) | verify:build/preview quiz grading | refs: R1 VR-002 | qm-cq-mc-2 / <choices randomize="yes"> | Added correct="no" to 3 <choice> elements missing correctness attributes | conf(H) | verify:build/preview quiz grading | refs: R2 VR-003 | qm-cq-mc-3 / <choices randomize="yes"> | Added correct="no" to 3 <choice> elements missing correctness attributes | conf(H) | verify:build/preview quiz grading | refs: R3

## Math/logic (applied)
M-001 | qm-problems-05 / <solution> | Corrected qualitative behavior statement for <m>dy/dx=y^2</m>: for <m>y(0)&lt;0</m>, solutions increase toward 0 (do not "decrease away") | conf(H) | refs: R5

## Copy edits (applied)
C-001 | qm-problem-01 <p>/<ol> | Fixed PTX structure: moved <ol marker="a."> out of enclosing <p> (list is now sibling) | refs: R4a C-002 | qm-problems-02 <p>/<ol> | Fixed PTX structure: moved <ol marker="a."> out of enclosing <p> (list is now sibling) | refs: R4b C-003 | qm-problems-03 <p>/<ol> | Fixed PTX structure: moved <ol marker="a."> out of enclosing <p> (list is now sibling) | refs: R4c C-004 | qm-problems-04 <p>/<ol> | Fixed PTX structure: moved <ol marker="a."> out of enclosing <p> (list is now sibling) | refs: R4d

## References
R1 (in-file): <task label="qm-cq-mc-1"> choices block. R2 (in-file): <task label="qm-cq-mc-2"> choices block. R3 (in-file): <task label="qm-cq-mc-3"> choices block. R4a (in-file): <exercise label="qm-problem-01"> paragraph + list. R4b (in-file): <exercise label="qm-problems-02"> paragraph + list. R4c (in-file): <exercise label="qm-problems-03"> paragraph + list. R4d (in-file): <exercise label="qm-problems-04"> paragraph + list. R5 (in-file): <exercise label="qm-problems-05"> second paragraph inside <solution>.