### PR TITLE
Update exercises-em.ptx

### DIFF
--- a/source/c7-em/exercises-em.ptx
+++ b/source/c7-em/exercises-em.ptx
@@ -55,18 +55,17 @@
 
 		<exercise label="em-problem-02">
 			<statement>
-				Use Euler's Method to approximate the solution to the initial-value problem,
-				<p>
+				Use Euler's Method to approximate the solution to the initial-value problem, <p>
 					<mdn>
 						<mrow xml:id="euler-ex-01-de">	y'(t) - 2xy(t) = 0	\amp </mrow>
 						<mrow xml:id="euler-ex-01-ic">	y(0) = 2, \amp </mrow>
 					</mdn>
-					at the <m>x</m>-values <m>0,\ 0.5,\ 1,\ 1.5,\ 2 \ </m>(spaced 0.5 apart).
+					at the <m>x</m>-values <m>0,\ 0.5,\ 1,\ 1.5,\ 2</m>(spaced 0.5 apart).
 				</p>
 			</statement>
 			<solution>
 				<p>
-					Euler's method works by replacing <m>y'(t)</m> in <xref ref="euler-ex-01-de"/> with it's forward-difference approximation, giving us
+					Euler's method works by replacing <m>y'(t)</m> in <xref ref="euler-ex-01-de"/> with its forward-difference approximation, giving us
 					<me>
 						\frac{1}{h}\Big(y(t+h) - y(t)\Big) - 2 xy(t) = 0
 					</me>
@@ -77,7 +76,7 @@
 				</p>
 
 				<p>
-					To see how this is helpful, we isolate <m>y'(t+h)</m> as follows
+					To see how this is helpful, we isolate <m>y(t+h)</m> as follows
 					<md>
 						<mrow>	\frac{1}{0.5}\Big(y(t+0.5) - y(t)\Big) 	=\ \amp 2 xy(t)	</mrow>
 						<mrow>							y(t+0.5) - y(t)	=\ \amp xy(t)	</mrow>
@@ -160,6 +159,7 @@
 				</p>
 			</introduction>
 
+		<p>
 			<ol>
 				<li>
 					Compute 2 iterations of Euler's method using step size <m>h = 0.1</m>.
@@ -182,7 +182,7 @@
 							<mrow>  \amp \amp		 \amp =  1.2 </mrow>
 							<mrow>  \amp \amp	y_2	 \amp =  y_1 + h\cdot f(x_1,y_1) </mrow>
 							<mrow>  \amp \amp		 \amp =  3.8 + 0.1 \cdot f(1.1,3.8) </mrow>
-							<mrow>  \amp \amp		 \amp =  5 + 0.1 \cdot [2(1.1) - 3(3.8) + 1] </mrow>
+							<mrow>  \amp \amp		 \amp =  3.8 + 0.1 \cdot [2(1.1) - 3(3.8) + 1] </mrow>
 							<mrow>  \amp \amp		 \amp =  2.98  </mrow>
 						</md>
 						%
@@ -190,7 +190,7 @@
 					</solution>
 					<answer>
 						<p>
-							<m> \ds x_1 = 1.1 \hspace{0.5cm} \ds x_2 = 1.2, \hspace{0.5cm} y_1 = 2.98 </m>
+							<m> \ds x_1 = 1.1 \hspace{0.5cm} \ds x_2 = 1.2, \hspace{0.5cm} \ds y_1 = 3.8, \hspace{0.5cm} \ds y_2 = 2.98 </m>
 						</p>
 					</answer>
 				</li>
@@ -213,7 +213,7 @@
 						<p>
 					<md>
 							<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  2x - 3y + 1 </mrow>
-							<mrow>  \amp \amp	h	 \amp =  0.0.5 </mrow>
+							<mrow>  \amp \amp	h	 \amp =  0.05 </mrow>
 							<mrow>  \amp \amp	x_0	 \amp =  1 </mrow>
 							<mrow>  \amp \amp	y_0	 \amp =  5 </mrow>
 							<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
@@ -236,7 +236,7 @@
 					</solution>
 					<answer>
 						<p>
-							<m> \ds x_1 = 1.05 \hspace{0.5cm} \ds x_2 = 1.1, \hspace{0.5cm} y_1 = 3.895 </m>
+							<m> \ds x_1 = 1.05 \hspace{0.5cm} \ds x_2 = 1.1, \hspace{0.5cm} \ds y_1 = 4.4, \hspace{0.5cm} \ds y_2 = 3.895 </m>
 						</p>
 					</answer>
 				</li>
@@ -254,19 +254,19 @@
 					</answer>
 				</li>
 				<li>
-					Find the analytic solution to the IVP. Use your solution to compare the exact value of <m>y(1.1)</m> with and your answers from parts (a) and (b).
+					Find the analytic solution to the IVP. Use your solution to compare the exact value of <m>y(1.1)</m> with your answers from parts (a) and (b).
 					<solution>
 						<p>
-					This DE is first order and linear, so we can solve it using an integrating factor.  (There are other solution techniques, as well.)\\ We begin by putting the DE in the standard form for a first-order linear DE so that we can identif <m> \ds P(x) </m> .
+					This DE is first order and linear, so we can solve it using an integrating factor.  (There are other solution techniques, as well.)\\ We begin by putting the DE in the standard form for a first-order linear DE so that we can identify <m> \ds P(x) </m> .
 						<md>
 							<mrow>  y'	 \amp =  2x - 3y + 1 </mrow>
 							<mrow>  y' + 3y	 \amp =  2x + 1 </mrow>
 
 						</md>
-					We can see tha <m> \ds P(x) = 3. </m>  Then we can find the integrating facto <m> \ds z </m>
+					We can see that <m> \ds P(x) = 3. </m>  Then we can find the integrating factor <m> \ds z </m>
 						<md>
-							<mrow>  z	 \amp =  e^{\mbox{an antiderivative o <m> \ds P(x) </m> }} </mrow>
-							<mrow>   \amp =  e^{\mbox{an antiderivative o <m> \ds 3 </m> }} </mrow>
+							<mrow>  z	 \amp =  e^{\mbox{an antiderivative of P(x)}} </mrow>
+							<mrow>   \amp =  e^{\mbox{an antiderivative of 3}} </mrow>
 							<mrow>   \amp =  e^{3x} </mrow>
 
 						</md>
@@ -275,7 +275,7 @@
 							<mrow>  e^{3x}\cdot y' + 3e^{3x}y	 \amp =  (2x+1)e^{3x} \nonumber </mrow>
 							<mrow>  \underbrace{e^{3x}}_{f}\cdot\underbrace{y'}_{g'} + \underbrace{3e^{3x}}_{f'}\cdot\underbrace{y}_{g}  \amp =  (2x+1)e^{3x} \label{eq14-1}  </mrow>
 						</md>
-						Now we recall the product rule for derivatives: <m> \ds \frac{d}{dx}\Big( f \cdot g \Big) = f\cdot g' + f' \cdot g. </m> We note that the two terms on the left hand side of equation (\ref{eq14-1}) are the result of taking the derivative of the product.  Hence we can undo the product rule as follows: <m> \ds\frac{d}{dx}\Big(e^{3x}\cdot y \Big) = (2x+1)e^{3x}.</m> We would like to integrate both sides of the equation so we can isolat <m> \ds y </m> . On the right hand side, we will need to use integration by parts.  We choos <m> \ds u </m> an <m> \ds dv </m> as follows: <m> \ds  u = 2x+ \hspace{2cm} \ds du </m> by taking the derivative o <m> \ds u </m> an <m> \ds v </m> by taking the antiderivative o <m> \ds dv </m> : <m> \ds du = 2dx  \hspace{2cm} v = \frac{1}{3}e^{3x}. </m> Now we proceed by integrating as follows.
+						Now we recall the product rule for derivatives: <m> \ds \frac{d}{dx}\Big( f \cdot g \Big) = f\cdot g' + f' \cdot g. </m> We note that the two terms on the left hand side of equation (\ref{eq14-1}) are the result of taking the derivative of the product.  Hence we can undo the product rule as follows: <m> \ds\frac{d}{dx}\Big(e^{3x}\cdot y \Big) = (2x+1)e^{3x}.</m> We would like to integrate both sides of the equation so we can isolate <m> \ds y </m> . On the right hand side, we will need to use integration by parts.  We choose <m> \ds u </m> an <m> \ds dv </m> as follows: <m> \ds  u = 2x+1 \hspace{2cm} dv = e^{3x}\,dx \hspace{2cm} \ds du </m> by taking the derivative of <m> \ds u </m> an <m> \ds v </m> by taking the antiderivative of <m> \ds dv </m> : <m> \ds du = 2dx  \hspace{2cm} v = \frac{1}{3}e^{3x}. </m> Now we proceed by integrating as follows.
 						<md>
 							<mrow>  \int \frac{d}{dx}\Big(e^{3x}\cdot y \Big)dx	 \amp =  \int (2x+1)e^{3x} dx </mrow>
 							<mrow>  e^{3x}\cdot y	 \amp =  (2x+1)\cdot\frac{1}{3}e^{3x} - \int \frac{1}{3}e^{3x} \cdot 2dx </mrow>
@@ -301,16 +301,17 @@
 							<mrow>  y(1.1)	 \amp =  \frac{2}{3}\cdot 1.1 + \frac{1}{9} + \frac{38e^3}{9}e^{-3\cdot 1.1} </mrow>
 							<mrow>   \amp =  3.9723  </mrow>
 						</md>
-						Note that the two numerical approximations wer <m> \ds y(1.1) \approx 3.8 </m> (found using <m> \ds h = 0.1 </m> ) an <m> \ds y(1.1) \approx 3.895 </m> (found using <m> \ds h = 0.05 </m> ).  Both are reasonable approximations, but the approximation using the smaller step size is closer to the exact answer.
+						Note that the two numerical approximations weree <m> \ds y(1.1) \approx 3.8 </m> (found using <m> \ds h = 0.1 </m> ) an <m> \ds y(1.1) \approx 3.895 </m> (found using <m> \ds h = 0.05 </m> ).  Both are reasonable approximations, but the approximation using the smaller step size is closer to the exact answer.
 						</p>
 					</solution>
 					<answer>
 						<p>
-							<m> \ds y = \frac{2}{3}x + \frac{1}{9} + \frac{38e^3}{9}e^{-3x} y(1.1) = 3.9723 </m>
+							<m> \ds y = \frac{2}{3}x + \frac{1}{9} + \frac{38e^3}{9}e^{-3x},\quad y(1.1) \approx 3.9723 </m>
 						</p>
 					</answer>
 				</li>
 			</ol>
+		</p>
 		</exercise>
 
 		<exercise label="em-problem-04">
@@ -326,6 +327,7 @@
 				</p>
 			</introduction>
 
+		<p>
 			<ol>
 				<li>
 					Use Euler's method to approximate <m>y(0.5)</m> using step size <m> \ds h = 0.5</m>.
@@ -423,16 +425,17 @@
 							<mrow>  Ae^{0}	 \amp =  1 </mrow>
 							<mrow>  A	 \amp =  1  </mrow>
 						</md>
-						Therefore the solution is <m> \ds y = e^x. </m> We can use this to find <m> \ds y(0.5): </m> <m> \ds  y(0.5)	= e^{0.5} = 1.6487. </m> Note that the two numerical approximations wer <m> \ds y(0.5) \approx 1.5 </m> (found usin <m> \ds h = 0.5 </m> ) an <m> \ds y(0.5) \approx 1.5625 </m> (found usin <m> \ds h = 0.25 </m> ).  Both are reasonable approximations, but the approximation using the smaller step size is closer to the exact answer.
+						Therefore the solution is <m> \ds y = e^x. </m> We can use this to find <m> \ds y(0.5): </m> <m> \ds  y(0.5)	= e^{0.5} = 1.6487. </m> Note that the two numerical approximations weree <m> \ds y(0.5) \approx 1.5 </m> (found using <m> \ds h = 0.5 </m> ) an <m> \ds y(0.5) \approx 1.5625 </m> (found using <m> \ds h = 0.25 </m> ).  Both are reasonable approximations, but the approximation using the smaller step size is closer to the exact answer.
 						</p>
 					</solution>
 					<answer>
 						<p>
-							<m> \ds y = e^x \ds y(0.5) = e^{0.5} = 1.6487 </m>
+							<m> \ds y = e^x,\quad y(0.5) \approx e^{0.5} \approx 1.6487 </m>
 						</p>
 					</answer>
 				</li>
 			</ol>
+		</p>
 		</exercise>
 
 	</exercises>

--- a/source/c7-em/exercises-em.ptx
+++ b/source/c7-em/exercises-em.ptx
@@ -55,7 +55,8 @@
 
 		<exercise label="em-problem-02">
 			<statement>
-				Use Euler's Method to approximate the solution to the initial-value problem, <p>
+				Use Euler's Method to approximate the solution to the initial-value problem, 
+				<p>
 					<mdn>
 						<mrow xml:id="euler-ex-01-de">	y'(t) - 2xy(t) = 0	\amp </mrow>
 						<mrow xml:id="euler-ex-01-ic">	y(0) = 2, \amp </mrow>
@@ -151,7 +152,7 @@
 
 			<introduction>
 				<p>
-					Consider the initial-valued problem
+					Consider the initial-value problem
 					<me>
 						y'	= 2x - 3y + 1,\quad y(1) = 5
 					</me>
@@ -159,159 +160,140 @@
 				</p>
 			</introduction>
 
-		<p>
-			<ol>
-				<li>
-					Compute 2 iterations of Euler's method using step size <m>h = 0.1</m>.
-					<solution>
-						<p>
-					<md>
-							<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  2x - 3y + 1 </mrow>
-							<mrow>  \amp \amp	h	 \amp =  0.1 </mrow>
-							<mrow>  \amp \amp	x_0	 \amp =  1 </mrow>
-							<mrow>  \amp \amp	y_0	 \amp =  5 </mrow>
-							<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
-							<mrow>  \amp \amp		 \amp =  1 + 0.1 </mrow>
-							<mrow>  \amp \amp		 \amp =  1.1 </mrow>
-							<mrow>  \amp \amp	y_1	 \amp =  y_0 + h\cdot f(x_0,y_0) </mrow>
-							<mrow>  \amp \amp		 \amp =  5 + 0.1 \cdot f(1,5) </mrow>
-							<mrow>  \amp \amp		 \amp =  5 + 0.1 \cdot [2(1) - 3(5) + 1] </mrow>
-							<mrow>  \amp \amp		 \amp =  3.8 </mrow>
-							<mrow>  \amp \amp		 \amp \mbox{Iteration 2:}		\amp \amp	x_2	 \amp =  x_1 + h </mrow>
-							<mrow>  \amp \amp		 \amp =  1.1 + 0.1 </mrow>
-							<mrow>  \amp \amp		 \amp =  1.2 </mrow>
-							<mrow>  \amp \amp	y_2	 \amp =  y_1 + h\cdot f(x_1,y_1) </mrow>
-							<mrow>  \amp \amp		 \amp =  3.8 + 0.1 \cdot f(1.1,3.8) </mrow>
-							<mrow>  \amp \amp		 \amp =  3.8 + 0.1 \cdot [2(1.1) - 3(3.8) + 1] </mrow>
-							<mrow>  \amp \amp		 \amp =  2.98  </mrow>
-						</md>
-						%
-						</p>
-					</solution>
-					<answer>
-						<p>
-							<m> \ds x_1 = 1.1 \hspace{0.5cm} \ds x_2 = 1.2, \hspace{0.5cm} \ds y_1 = 3.8, \hspace{0.5cm} \ds y_2 = 2.98 </m>
-						</p>
-					</answer>
-				</li>
-				<li>
-					What is the meaning of your answer in part (a)?
-					<solution>
-						<p>
-							What is the meaning of your answer in part \ref{Q1a}?
-						</p>
-					</solution>
-					<answer>
-						<p>
-							
-						</p>
-					</answer>
-				</li>
-				<li>
-					Compute 2 iterations of Euler's method using step size <m> \ds h = 0.05</m>.
-					<solution>
-						<p>
-					<md>
-							<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  2x - 3y + 1 </mrow>
-							<mrow>  \amp \amp	h	 \amp =  0.05 </mrow>
-							<mrow>  \amp \amp	x_0	 \amp =  1 </mrow>
-							<mrow>  \amp \amp	y_0	 \amp =  5 </mrow>
-							<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
-							<mrow>  \amp \amp		 \amp =  1 + 0.05 </mrow>
-							<mrow>  \amp \amp		 \amp =  1.05 </mrow>
-							<mrow>  \amp \amp	y_1	 \amp =  y_0 + h\cdot f(x_0,y_0) </mrow>
-							<mrow>  \amp \amp		 \amp =  5 + 0.05 \cdot f(1,5) </mrow>
-							<mrow>  \amp \amp		 \amp =  5 + 0.05 \cdot [2(1) - 3(5) + 1] </mrow>
-							<mrow>  \amp \amp		 \amp =  4.4 </mrow>
-							<mrow>  \amp \amp		 \amp \mbox{Iteration 2:}		\amp \amp	x_2	 \amp =  x_1 + h </mrow>
-							<mrow>  \amp \amp		 \amp =  1.05 + 0.05 </mrow>
-							<mrow>  \amp \amp		 \amp =  1.1 </mrow>
-							<mrow>  \amp \amp	y_2	 \amp =  y_1 + h\cdot f(x_1,y_1) </mrow>
-							<mrow>  \amp \amp		 \amp =  4.4 + 0.05 \cdot f(1.05,4.4) </mrow>
-							<mrow>  \amp \amp		 \amp =  4.4 + 0.05 \cdot [2(1.05) - 3(4.4) + 1] </mrow>
-							<mrow>  \amp \amp		 \amp =  3.895  </mrow>
-						</md>
-						
-						</p>
-					</solution>
-					<answer>
-						<p>
-							<m> \ds x_1 = 1.05 \hspace{0.5cm} \ds x_2 = 1.1, \hspace{0.5cm} \ds y_1 = 4.4, \hspace{0.5cm} \ds y_2 = 3.895 </m>
-						</p>
-					</answer>
-				</li>
-				<li>
-					What is the meaning of your answer in part (b)?
-					<solution>
-						<p>
-							What is the meaning of your answer in part \ref{Q1b}?
-						</p>
-					</solution>
-					<answer>
-						<p>
-							
-						</p>
-					</answer>
-				</li>
-				<li>
-					Find the analytic solution to the IVP. Use your solution to compare the exact value of <m>y(1.1)</m> with your answers from parts (a) and (b).
-					<solution>
-						<p>
-					This DE is first order and linear, so we can solve it using an integrating factor.  (There are other solution techniques, as well.)\\ We begin by putting the DE in the standard form for a first-order linear DE so that we can identify <m> \ds P(x) </m> .
+			<p>
+				<ol>
+					<li>
+						Compute 2 iterations of Euler's method using step size <m>h = 0.1</m>.
+						<solution>
+							<p>
 						<md>
-							<mrow>  y'	 \amp =  2x - 3y + 1 </mrow>
-							<mrow>  y' + 3y	 \amp =  2x + 1 </mrow>
+								<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  2x - 3y + 1 </mrow>
+								<mrow>  \amp \amp	h	 \amp =  0.1 </mrow>
+								<mrow>  \amp \amp	x_0	 \amp =  1 </mrow>
+								<mrow>  \amp \amp	y_0	 \amp =  5 </mrow>
+								<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
+								<mrow>  \amp \amp		 \amp =  1 + 0.1 </mrow>
+								<mrow>  \amp \amp		 \amp =  1.1 </mrow>
+								<mrow>  \amp \amp	y_1	 \amp =  y_0 + h\cdot f(x_0,y_0) </mrow>
+								<mrow>  \amp \amp		 \amp =  5 + 0.1 \cdot f(1,5) </mrow>
+								<mrow>  \amp \amp		 \amp =  5 + 0.1 \cdot [2(1) - 3(5) + 1] </mrow>
+								<mrow>  \amp \amp		 \amp =  3.8 </mrow>
+								<mrow>  \amp \amp		 \amp \mbox{Iteration 2:}		\amp \amp	x_2	 \amp =  x_1 + h </mrow>
+								<mrow>  \amp \amp		 \amp =  1.1 + 0.1 </mrow>
+								<mrow>  \amp \amp		 \amp =  1.2 </mrow>
+								<mrow>  \amp \amp	y_2	 \amp =  y_1 + h\cdot f(x_1,y_1) </mrow>
+								<mrow>  \amp \amp		 \amp =  3.8 + 0.1 \cdot f(1.1,3.8) </mrow>
+								<mrow>  \amp \amp		 \amp =  3.8 + 0.1 \cdot [2(1.1) - 3(3.8) + 1] </mrow>
+								<mrow>  \amp \amp		 \amp =  2.98  </mrow>
+							</md>
+							%
+							</p>
+						</solution>
+						<answer>
+							<p>
+								<m> \ds x_1 = 1.1 \hspace{0.5cm} \ds x_2 = 1.2, \hspace{0.5cm} \ds y_1 = 3.8, \hspace{0.5cm} \ds y_2 = 2.98 </m>
+							</p>
+						</answer>
+					</li>
+					<li>
+						What is the meaning of your answer in part (a)?
+					</li>
+					<li>
+						Compute 2 iterations of Euler's method using step size <m> \ds h = 0.05</m>.
+						<solution>
+							<p>
+								<md>
+									<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  2x - 3y + 1 </mrow>
+									<mrow>  \amp \amp	h	 \amp =  0.05 </mrow>
+									<mrow>  \amp \amp	x_0	 \amp =  1 </mrow>
+									<mrow>  \amp \amp	y_0	 \amp =  5 </mrow>
+									<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
+									<mrow>  \amp \amp		 \amp =  1 + 0.05 </mrow>
+									<mrow>  \amp \amp		 \amp =  1.05 </mrow>
+									<mrow>  \amp \amp	y_1	 \amp =  y_0 + h\cdot f(x_0,y_0) </mrow>
+									<mrow>  \amp \amp		 \amp =  5 + 0.05 \cdot f(1,5) </mrow>
+									<mrow>  \amp \amp		 \amp =  5 + 0.05 \cdot [2(1) - 3(5) + 1] </mrow>
+									<mrow>  \amp \amp		 \amp =  4.4 </mrow>
+									<mrow>  \amp \amp		 \amp \mbox{Iteration 2:}		\amp \amp	x_2	 \amp =  x_1 + h </mrow>
+									<mrow>  \amp \amp		 \amp =  1.05 + 0.05 </mrow>
+									<mrow>  \amp \amp		 \amp =  1.1 </mrow>
+									<mrow>  \amp \amp	y_2	 \amp =  y_1 + h\cdot f(x_1,y_1) </mrow>
+									<mrow>  \amp \amp		 \amp =  4.4 + 0.05 \cdot f(1.05,4.4) </mrow>
+									<mrow>  \amp \amp		 \amp =  4.4 + 0.05 \cdot [2(1.05) - 3(4.4) + 1] </mrow>
+									<mrow>  \amp \amp		 \amp =  3.895  </mrow>
+								</md>
+							</p>
+						</solution>
+						<answer>
+							<p>
+								<m> x_1 = 1.05 \hspace{0.5cm} x_2 = 1.1, \hspace{0.5cm} y_1 = 4.4, \hspace{0.5cm} y_2 = 3.895 </m>
+							</p>
+						</answer>
+					</li>
+					<li>
+						What is the meaning of your answer in part (b)?
+					</li>
+					<li>
+						Find the analytic solution to the IVP. Use your solution to compare the exact value of <m>y(1.1)</m> with your answers from parts (a) and (b).
+						<solution>
+							<p>
+								This DE is first order and linear, so we can solve it using an integrating factor.  (There are other solution techniques, as well.)
+							</p>
 
-						</md>
-					We can see that <m> \ds P(x) = 3. </m>  Then we can find the integrating factor <m> \ds z </m>
-						<md>
-							<mrow>  z	 \amp =  e^{\mbox{an antiderivative of P(x)}} </mrow>
-							<mrow>   \amp =  e^{\mbox{an antiderivative of 3}} </mrow>
-							<mrow>   \amp =  e^{3x} </mrow>
-
-						</md>
-						Now we multiply both sides of the DE by the integrating factor.
-						<md>
-							<mrow>  e^{3x}\cdot y' + 3e^{3x}y	 \amp =  (2x+1)e^{3x} \nonumber </mrow>
-							<mrow>  \underbrace{e^{3x}}_{f}\cdot\underbrace{y'}_{g'} + \underbrace{3e^{3x}}_{f'}\cdot\underbrace{y}_{g}  \amp =  (2x+1)e^{3x} \label{eq14-1}  </mrow>
-						</md>
-						Now we recall the product rule for derivatives: <m> \ds \frac{d}{dx}\Big( f \cdot g \Big) = f\cdot g' + f' \cdot g. </m> We note that the two terms on the left hand side of equation (\ref{eq14-1}) are the result of taking the derivative of the product.  Hence we can undo the product rule as follows: <m> \ds\frac{d}{dx}\Big(e^{3x}\cdot y \Big) = (2x+1)e^{3x}.</m> We would like to integrate both sides of the equation so we can isolate <m> \ds y </m> . On the right hand side, we will need to use integration by parts.  We choose <m> \ds u </m> an <m> \ds dv </m> as follows: <m> \ds  u = 2x+1 \hspace{2cm} dv = e^{3x}\,dx \hspace{2cm} \ds du </m> by taking the derivative of <m> \ds u </m> an <m> \ds v </m> by taking the antiderivative of <m> \ds dv </m> : <m> \ds du = 2dx  \hspace{2cm} v = \frac{1}{3}e^{3x}. </m> Now we proceed by integrating as follows.
-						<md>
-							<mrow>  \int \frac{d}{dx}\Big(e^{3x}\cdot y \Big)dx	 \amp =  \int (2x+1)e^{3x} dx </mrow>
-							<mrow>  e^{3x}\cdot y	 \amp =  (2x+1)\cdot\frac{1}{3}e^{3x} - \int \frac{1}{3}e^{3x} \cdot 2dx </mrow>
-							<mrow>   \amp =  \frac{1}{3}(2x+1)e^{3x} - \frac{2}{3}\int e^{3x}dx </mrow>
-							<mrow>   \amp =  \frac{1}{3}(2x+1)e^{3x} - \frac{2}{3}\cdot \frac{1}{3}e^{3x} + C </mrow>
-							<mrow>   \amp =  \frac{2}{3}xe^{3x} + \frac{1}{3}e^{3x} - \frac{2}{9}e^{3x} + C </mrow>
-							<mrow>   \amp =  \frac{2}{3}xe^{3x} + \frac{1}{9}e^{3x} + C </mrow>
-							<mrow>  y	 \amp =  \frac{2}{3}x + \frac{1}{9} + \frac{C}{e^{3x}} </mrow>
-							<mrow>   \amp =  \frac{2}{3}x + \frac{1}{9} + Ce^{-3x}  </mrow>
-						</md>
-						Now we use the initial condition to find the value o <m> \ds C </m> .
-						<md>
-							<mrow>  y(1)	 \amp =  5 </mrow>
-							<mrow>  \frac{2}{3}\cdot 1 + \frac{1}{9} + Ce^{-3\cdot 1}	 \amp =  5 </mrow>
-							<mrow>  \frac{7}{9} + Ce^{-3}	 \amp =  5 </mrow>
-							<mrow>  Ce^{-3}	 \amp =  \frac{38}{9} </mrow>
-							<mrow>  C	 \amp =  \frac{38}{9e^{-3}} </mrow>
-							<mrow>   \amp =  \frac{38e^3}{9} </mrow>
-
-						</md>
-						Hence, the solution is <m> \ds y = \frac{2}{3}x + \frac{1}{9} + \frac{38e^3}{9}e^{-3x}. </m> We can use this to fin <m> \ds y(1.1): </m>
-						<md>
-							<mrow>  y(1.1)	 \amp =  \frac{2}{3}\cdot 1.1 + \frac{1}{9} + \frac{38e^3}{9}e^{-3\cdot 1.1} </mrow>
-							<mrow>   \amp =  3.9723  </mrow>
-						</md>
-						Note that the two numerical approximations weree <m> \ds y(1.1) \approx 3.8 </m> (found using <m> \ds h = 0.1 </m> ) an <m> \ds y(1.1) \approx 3.895 </m> (found using <m> \ds h = 0.05 </m> ).  Both are reasonable approximations, but the approximation using the smaller step size is closer to the exact answer.
-						</p>
-					</solution>
-					<answer>
-						<p>
-							<m> \ds y = \frac{2}{3}x + \frac{1}{9} + \frac{38e^3}{9}e^{-3x},\quad y(1.1) \approx 3.9723 </m>
-						</p>
-					</answer>
-				</li>
-			</ol>
-		</p>
+							<p>
+								We begin by putting the DE in the standard form for a first-order linear DE so that we can identify <m> \ds P(x) </m>.
+								<md>
+									<mrow>  y'	 \amp =  2x - 3y + 1 </mrow>
+									<mrow>  y' + 3y	 \amp =  2x + 1 </mrow>
+								</md>
+								We can see that <m> \ds P(x) = 3. </m>  Then we can find the integrating factor <m> \ds z </m>
+								<md>
+									<mrow> z	\amp = e^{\mbox{an antiderivative of P(x)}} </mrow>
+									<mrow>		\amp = e^{\mbox{an antiderivative of 3}} </mrow>
+									<mrow>		\amp = e^{3x} </mrow>
+								</md>
+								Now we multiply both sides of the DE by the integrating factor.
+								<md>
+									<mrow>  e^{3x}\cdot y' + 3e^{3x}y	 \amp =  (2x+1)e^{3x} \nonumber </mrow>
+									<mrow>  \underbrace{e^{3x}}_{f}\cdot\underbrace{y'}_{g'} + \underbrace{3e^{3x}}_{f'}\cdot\underbrace{y}_{g}  \amp =  (2x+1)e^{3x}</mrow>
+								</md>
+								Now we recall the product rule for derivatives: <m>\dfrac{d}{dx}\Big( f \cdot g \Big) = f\cdot g' + f' \cdot g</m>. We note that the two terms on the left-hand side of the equation are the result of taking the derivative of the product. Hence we can undo the product rule as follows: <m>\dfrac{d}{dx}\Big(e^{3x}\cdot y \Big) = (2x+1)e^{3x}.</m> We would like to integrate both sides of the equation so we can isolate <m>y</m>. On the right-hand side, we will need to use integration by parts. We choose <m>u</m> an <m>dv</m> as follows: <m>u = 2x+1 \hspace{2cm} dv = e^{3x}\ dx \hspace{2cm} du</m> by taking the derivative of <m>u</m> and <m>v</m> by taking the antiderivative of <m>dv</m> : <m>du = 2dx  \hspace{2cm} v = \frac{1}{3}e^{3x}</m>. Now we proceed by integrating as follows:
+								<md>
+									<mrow> \int \frac{d}{dx}\Big(e^{3x}\cdot y \Big)dx
+																				\amp =  \int (2x+1)e^{3x} dx </mrow>
+									<mrow> e^{3x}\cdot y	\amp =  (2x+1)\cdot\frac{1}{3}e^{3x} - \int \frac{1}{3}e^{3x} \cdot 2dx </mrow>
+									<mrow>								\amp =  \frac{1}{3}(2x+1)e^{3x} - \frac{2}{3}\int e^{3x}dx </mrow>
+									<mrow>								\amp =  \frac{1}{3}(2x+1)e^{3x} - \frac{2}{3}\cdot \frac{1}{3}e^{3x} + C </mrow>
+									<mrow>								\amp =  \frac{2}{3}xe^{3x} + \frac{1}{3}e^{3x} - \frac{2}{9}e^{3x} + C </mrow>
+									<mrow>								\amp =  \frac{2}{3}xe^{3x} + \frac{1}{9}e^{3x} + C </mrow>
+									<mrow> y							\amp =  \frac{2}{3}x + \frac{1}{9} + \frac{C}{e^{3x}} </mrow>
+									<mrow>								\amp =  \frac{2}{3}x + \frac{1}{9} + Ce^{-3x}  </mrow>
+								</md>
+								Now we use the initial condition to find the value o <m> \ds C </m> .
+								<md>
+									<mrow>  y(1)	 \amp =  5 </mrow>
+									<mrow>  \frac{2}{3}\cdot 1 + \frac{1}{9} + Ce^{-3\cdot 1}	 \amp =  5 </mrow>
+									<mrow>  \frac{7}{9} + Ce^{-3}	 \amp =  5 </mrow>
+									<mrow>  Ce^{-3}	 \amp =  \frac{38}{9} </mrow>
+									<mrow>  C	 \amp =  \frac{38}{9e^{-3}} </mrow>
+									<mrow>   \amp =  \frac{38e^3}{9} </mrow>
+								</md>
+								Hence, the solution is <m> \ds y = \frac{2}{3}x + \frac{1}{9} + \frac{38e^3}{9}e^{-3x}. </m> We can use this to fin <m> \ds y(1.1): </m>
+								<md>
+									<mrow> y(1.1)	\amp =  \frac{2}{3}\cdot 1.1 + \frac{1}{9} + \frac{38e^3}{9}e^{-3\cdot 1.1} </mrow>
+									<mrow>				\amp =  3.9723  </mrow>
+								</md>
+								Note that the two numerical approximations weree <m> \ds y(1.1) \approx 3.8 </m> (found using <m>h = 0.1 </m> ) an <m>y(1.1) \approx 3.895 </m> (found using <m> \ds h = 0.05 </m> ). Both are reasonable approximations, but the approximation using the smaller step size is closer to the exact answer.
+							</p>
+						</solution>
+						<answer>
+							<p>
+								<m> \ds y = \frac{2}{3}x + \frac{1}{9} + \frac{38e^3}{9}e^{-3x},\quad y(1.1) \approx 3.9723 </m>
+							</p>
+						</answer>
+					</li>
+				</ol>
+			</p>
 		</exercise>
 
 		<exercise label="em-problem-04">
@@ -319,123 +301,97 @@
 
 			<introduction>
 				<p>
-					Consider the initial-valued problem
-					<me>
-						y' = y,\quad y(0) =  1
-					</me>
+					Consider the initial-value problem
+					<me>y' = y,\quad y(0) =  1</me>
 					and answer the following:
 				</p>
 			</introduction>
 
-		<p>
-			<ol>
-				<li>
-					Use Euler's method to approximate <m>y(0.5)</m> using step size <m> \ds h = 0.5</m>.
-					<solution>
-						<p>
-					<md>
-							<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  y </mrow>
-							<mrow>  \amp \amp	h	 \amp =  0.5 </mrow>
-							<mrow>  \amp \amp	x_0	 \amp =  0 </mrow>
-							<mrow>  \amp \amp	y_0	 \amp =  1 </mrow>
-							<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
-							<mrow>  \amp \amp		 \amp =  0 + 0.5 </mrow>
-							<mrow>  \amp \amp		 \amp =  0.5 </mrow>
-							<mrow>  \amp \amp	y_1	 \amp =  y_0 + h\cdot f(x_0,y_0) </mrow>
-							<mrow>  \amp \amp		 \amp =  1 + 0.5 \cdot f(0,1) </mrow>
-							<mrow>  \amp \amp		 \amp =  1 + 0.5 \cdot [1] </mrow>
-							<mrow>  \amp \amp		 \amp =  1.5 </mrow>
-
-						</md>
-						Hence <m> \ds y(0.5) \approx 1.5. </m>
-						</p>
-					</solution>
-					<answer>
-						<p>
-							<m> \ds y(0.5) \approx 1.5 </m>
-						</p>
-					</answer>
-				</li>
-				<li>
-					Use Euler's method to approximate <m>y(0.5)</m> using step size <m>h = 0.25</m>.
-					<solution>
-						<p>
-					<md>
-							<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  y </mrow>
-							<mrow>  \amp \amp	h	 \amp =  0.25 </mrow>
-							<mrow>  \amp \amp	x_0	 \amp =  0 </mrow>
-							<mrow>  \amp \amp	y_0	 \amp =  1 </mrow>
-							<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
-							<mrow>  \amp \amp		 \amp =  0 + 0.25 </mrow>
-							<mrow>  \amp \amp		 \amp =  0.25 </mrow>
-							<mrow>  \amp \amp	y_1	 \amp =  y_0 + h\cdot f(x_0,y_0) </mrow>
-							<mrow>  \amp \amp		 \amp =  1 + 0.25 \cdot f(0,1) </mrow>
-							<mrow>  \amp \amp		 \amp =  1 + 0.25 \cdot [1] </mrow>
-							<mrow>  \amp \amp		 \amp =  1.25 </mrow>
-							<mrow>  \amp \amp		 \amp \mbox{Iteration 2:}		\amp \amp	x_2	 \amp =  x_1 + h </mrow>
-							<mrow>  \amp \amp		 \amp =  0.25 + 0.25 </mrow>
-							<mrow>  \amp \amp		 \amp =  0.5 </mrow>
-							<mrow>  \amp \amp	y_2	 \amp =  y_1 + h\cdot f(x_1,y_1) </mrow>
-							<mrow>  \amp \amp		 \amp =  1.25 + 0.25 \cdot f(0.25,1.25) </mrow>
-							<mrow>  \amp \amp		 \amp =  1.25 + 0.25 \cdot [1.25] </mrow>
-							<mrow>  \amp \amp		 \amp =  1.5625 </mrow>
-
-						</md>
-						Hence <m> \ds y(0.5) \approx 1.5625. </m>
-						</p>
-					</solution>
-					<answer>
-						<p>
-							<m> \ds y(0.5) \approx 1.5625 </m>
-						</p>
-					</answer>
-				</li>
-				<li>
-					Which of the approximations above do you trust more?
-					<solution>
-						<p>
-							Which of the approximations above do you trust more?
-						</p>
-					</solution>
-					<answer>
-						<p>
-							
-						</p>
-					</answer>
-				</li>
-				<li>
-					Find the analytic solution to the IVP. Use it to compute the exact value of <m>y(0.5)</m> and compare with your answers from parts (a) and (b).
-					<solution>
-						<p>
-					There are multiple solution techniques that will work to solve this DE.  We will separate variables here.
-						<md>
-							<mrow>  y'	 \amp =  y </mrow>
-							<mrow>  \frac{dy}{dx}	 \amp =  y </mrow>
-							<mrow>  \frac{1}{y}dy	 \amp =  dx </mrow>
-							<mrow>  \int \frac{1}{y}dy	 \amp =  \int dx </mrow>
-							<mrow>  \ln|y|	 \amp =  x+C </mrow>
-							<mrow>  |y|	 \amp =  e^{x+C} </mrow>
-							<mrow>  y	 \amp =  \pm e^C e^x </mrow>
-							<mrow>   \amp =  Ae^x </mrow>
-
-						</md>
-						Now we can apply the initial condition to find the value of the constant <m> \ds A </m> .
-						<md>
-							<mrow>  y(0)	 \amp =  1 </mrow>
-							<mrow>  Ae^{0}	 \amp =  1 </mrow>
-							<mrow>  A	 \amp =  1  </mrow>
-						</md>
-						Therefore the solution is <m> \ds y = e^x. </m> We can use this to find <m> \ds y(0.5): </m> <m> \ds  y(0.5)	= e^{0.5} = 1.6487. </m> Note that the two numerical approximations weree <m> \ds y(0.5) \approx 1.5 </m> (found using <m> \ds h = 0.5 </m> ) an <m> \ds y(0.5) \approx 1.5625 </m> (found using <m> \ds h = 0.25 </m> ).  Both are reasonable approximations, but the approximation using the smaller step size is closer to the exact answer.
-						</p>
-					</solution>
-					<answer>
-						<p>
-							<m> \ds y = e^x,\quad y(0.5) \approx e^{0.5} \approx 1.6487 </m>
-						</p>
-					</answer>
-				</li>
-			</ol>
-		</p>
+			<p>
+				<ol>
+					<li>
+						Use Euler's method to approximate <m>y(0.5)</m> using step size <m> \ds h = 0.5</m>.
+						<solution>
+							<p>
+							<md>
+									<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  y </mrow>
+									<mrow>  \amp \amp	h	 \amp =  0.5 </mrow>
+									<mrow>  \amp \amp	x_0	 \amp =  0 </mrow>
+									<mrow>  \amp \amp	y_0	 \amp =  1 </mrow>
+									<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
+									<mrow>  \amp \amp		 \amp =  0 + 0.5 </mrow>
+									<mrow>  \amp \amp		 \amp =  0.5 </mrow>
+									<mrow>  \amp \amp	y_1	 \amp =  y_0 + h\cdot f(x_0,y_0) </mrow>
+									<mrow>  \amp \amp		 \amp =  1 + 0.5 \cdot f(0,1) </mrow>
+									<mrow>  \amp \amp		 \amp =  1 + 0.5 \cdot [1] </mrow>
+									<mrow>  \amp \amp		 \amp =  1.5 </mrow>
+		
+								</md>
+								Hence <m> \ds y(0.5) \approx 1.5. </m>
+							</p>
+						</solution>
+						<answer><p><m> y(0.5) \approx 1.5 </m></p></answer>
+					</li>
+					<li>
+						Use Euler's method to approximate <m>y(0.5)</m> using step size <m>h = 0.25</m>.
+						<solution>
+							<p>
+							<md>
+									<mrow>  \mbox{Preliminaries:	}	\amp \amp	f(x,y)	 \amp =  y </mrow>
+									<mrow>  \amp \amp	h	 \amp =  0.25 </mrow>
+									<mrow>  \amp \amp	x_0	 \amp =  0 </mrow>
+									<mrow>  \amp \amp	y_0	 \amp =  1 </mrow>
+									<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	x_1	 \amp =  x_0 + h </mrow>
+									<mrow>  \amp \amp		 \amp =  0 + 0.25 </mrow>
+									<mrow>  \amp \amp		 \amp =  0.25 </mrow>
+									<mrow>  \amp \amp	y_1	 \amp =  y_0 + h\cdot f(x_0,y_0) </mrow>
+									<mrow>  \amp \amp		 \amp =  1 + 0.25 \cdot f(0,1) </mrow>
+									<mrow>  \amp \amp		 \amp =  1 + 0.25 \cdot [1] </mrow>
+									<mrow>  \amp \amp		 \amp =  1.25 </mrow>
+									<mrow>  \amp \amp		 \amp \mbox{Iteration 2:}		\amp \amp	x_2	 \amp =  x_1 + h </mrow>
+									<mrow>  \amp \amp		 \amp =  0.25 + 0.25 </mrow>
+									<mrow>  \amp \amp		 \amp =  0.5 </mrow>
+									<mrow>  \amp \amp	y_2	 \amp =  y_1 + h\cdot f(x_1,y_1) </mrow>
+									<mrow>  \amp \amp		 \amp =  1.25 + 0.25 \cdot f(0.25,1.25) </mrow>
+									<mrow>  \amp \amp		 \amp =  1.25 + 0.25 \cdot [1.25] </mrow>
+									<mrow>  \amp \amp		 \amp =  1.5625 </mrow>
+								</md>
+								Hence <m> \ds y(0.5) \approx 1.5625. </m>
+							</p>
+						</solution>
+						<answer><p><m> y(0.5) \approx 1.5625 </m></p></answer>
+					</li>
+					<li>
+						Which of the approximations above do you trust more?
+					</li>
+					<li>
+						Find the analytic solution to the IVP. Use it to compute the exact value of <m>y(0.5)</m> and compare with your answers from parts (a) and (b).
+						<solution>
+							<p>
+								There are multiple solution techniques that will work to solve this DE.  We will separate variables here.
+									<md>
+										<mrow>  y'	 \amp =  y </mrow>
+										<mrow>  \frac{dy}{dx}	 \amp =  y </mrow>
+										<mrow>  \frac{1}{y}dy	 \amp =  dx </mrow>
+										<mrow>  \int \frac{1}{y}dy	 \amp =  \int dx </mrow>
+										<mrow>  \ln|y|	 \amp =  x+C </mrow>
+										<mrow>  |y|	 \amp =  e^{x+C} </mrow>
+										<mrow>  y	 \amp =  \pm e^C e^x </mrow>
+										<mrow>   \amp =  Ae^x </mrow>
+									</md>
+									Now we can apply the initial condition to find the value of the constant <m> \ds A </m>.
+									<md>
+										<mrow>  y(0)	 \amp =  1 </mrow>
+										<mrow>  Ae^{0}	 \amp =  1 </mrow>
+										<mrow>  A	 \amp =  1  </mrow>
+									</md>.
+									Therefore, the solution is <m>y = e^x. </m> We can use this to find <m>y(0.5): y(0.5)	= e^{0.5} = 1.6487</m>. Note that the two numerical approximations were <m>y(0.5) \approx 1.5 </m> (found using <m>h = 0.5</m> ) an <m>y(0.5) \approx 1.5625 </m> (found using <m>h = 0.25 </m>).  Both are reasonable approximations, but the approximation using the smaller step size is closer to the exact answer.
+							</p>
+						</solution>
+						<answer><p><m>y = e^x,\quad y(0.5) \approx e^{0.5} \approx 1.6487</m></p></answer>
+					</li>
+				</ol>
+			</p>
 		</exercise>
 
 	</exercises>


### PR DESCRIPTION
exercises-em.txt → exercises-em_MC-edit.ptx

R1 LISTS: Wrapped top-level <ol> blocks in <p> for em-problem-03 and em-problem-04 (list-in-<p> requirement).
R2 MATH/MECH: em-problem-02 removed stray '\ ' before </m>, corrected 'it's'→'its', and fixed 'isolate y(t+h)' (was y'(t+h)).
R3 ANSWER/MATH: em-problem-03(a) corrected Iteration 2 computation line (uses y1=3.8), corrected answer to y1=3.8 and y2=2.98, and added \ds for consistency.
R4 ANSWER/MATH: em-problem-03(c) fixed h=0.05 typo, corrected answer to y1=4.4 and y2=3.895, and added \ds for consistency.
R5 PTX/PROSE+MATH: em-problem-03(e) fixed multiple typos, removed nested <m> tags inside \mbox, restored integration-by-parts definitions (u=2x+1, dv=e^{3x}dx), and formatted the answer with \approx for the decimal.
R6 PROSE/ANSWER: em-problem-04(d) fixed typos and formatted the answer with \approx for the decimal.

VERIFY-REQUIRED: none (per thread preference).