### PR TITLE
Update sec-product-rule.ptx

### DIFF
--- a/source/c5-if/sec-product-rule.ptx
+++ b/source/c5-if/sec-product-rule.ptx
@@ -136,96 +136,85 @@
 			</statement>
 
 			<solution>
-				<p>
-					<solution>
+	<p>
+		First, select an <m>f</m> and <m>g</m> in different terms, like so
+	</p>
 
-						<p>
-							First, select an <m>f</m> and <m>g</m> in different terms, like so
-						</p>
+	<p>
+		<me>
+			e^x \, 
+			\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}\cos x}}}
+			+
+			\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}e^x}}} \, 
+			\sin x
+		</me>.
+	</p>
 
-						<p>
-							<me>
-								e^x\
-								\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}\cos x}}}
-								+
-								\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}e^x}}}\
-								\sin x
-							</me>.
-						</p>
+	<p>
+		For this to work, <m>f'</m> should be <m>\sin x</m>, next to our chosen <m>g</m>. However,
+		<me>
+			f' = [\cos x]' = -\sin x \ne \sin x \quad ❌
+		</me>
+	</p>
 
-						<p>
-							For this to work, <m>f'</m> should be <m>\sin x</m>, next to our chosen <m>g</m>. However,
-							<me>
-								f' = [\cos x]' = -\sin x \ne \sin x \quad ❌
-							</me>
-						</p>
+	<p>
+		So this labeling doesn't work and we instead try the labels
+	</p>
 
-						<p>
-							So this labeling doesn't work and we instead try the labels
-						</p>
+	<p>
+		<me>
+			\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}e^x}}} \, 
+			\cos x
+			+
+			e^x \, 
+			\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}\sin x}}}
+		</me>.
+	</p>
 
-						<p>
-							<me>
-								\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}e^x}}}\
-								\cos x
-								+
-								e^x\
-								\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}\sin x}}}
-							</me>.
-						</p>
+	<p>
+		Noting that <m>f' = [e^x]' = e^x</m> is next to <m>g</m> and <m>g' = [\sin x]' = \cos x</m> is next to <m>f</m> confirms this is a valid product rule. Therefore, we can reverse the product rule as
+	</p>
 
-						<p>
-							Noting that <m>f' = [e^x]' = e^x</m> is next to <m>g</m> and <m>g' = [\sin x]' = \cos x</m> is next to <m>f</m> confirms this is a valid product rule. Therefore, we can reverse the product rule as
-						</p>
+	<me>
+		e^x \cos x + e^x \sin x = [e^x \sin x]'
+	</me>.
 
-						<me>
-							e^x \cos x + e^x \sin x = [e^x \sin x]'
-						</me>.
+	<p>
+		To make this easier, let's separate the terms as
+		<me>
+			\frac{1}{x} e^{x^2} + \ln x (2 x e^{x^2})
+		</me>.
+	</p>
 
+	<p>
+		So, as before, we first set <m>f</m> and <m>g</m>
+	</p>
 
-					</solution>
+	<me>
+		\frac{1}{x} \, 
+		\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}e^{x^2}}}}
+		+
+		\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}\ln x}}} \, 
+		2 x e^{x^2}
+	</me>,
 
-					<solution>
+	<p>
+		then verify the derivatives of <m>f</m> and <m>g</m> are in the other terms,
+	</p>
 
-						<p>
-							To make this easier, let's separate the terms as
-							<me>
-								\frac{1}{x} e^{x^2} + \ln x (2 x e^{x^2})
-							</me>.
-						</p>
-						
-						<p>
-							So, as before, we first set <m>f</m> and <m>g</m>
-						</p>
+	<me>
+		f' = \left[e^{x^2}\right]' = 2 x e^{x^2} \quad ✅ \qquad g' = \left[\ln x\right]' = \frac{1}{x} \quad ✅
+	</me>.
 
-						<me>
-							\frac{1}{x}\
-							\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}e^{x^2}}}}
-							+
-							\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}\ln x}}}\
-							2 x e^{x^2}
-						</me>,
+	<p>
+		Therefore,
+	</p>
 
-						<p>
-							then verify the derivatives of <m>f</m> and <m>g</m> are in the other terms,
-						</p>
-
-						<me>
-							f' = \left[e^{x^2}\right]' = 2 x e^{x^2} \quad ✅ \qquad g' = \left[\ln x\right]' = \frac{1}{x} \quad ✅
-						</me>.
-
-						<p>
-							Therefore,
-						</p>
-
-						<me>
-							\frac{e^{x^2}}{x} + 2 x \ln x e^{x^2} = \left[e^{x^2} \ln x\right]'
-						</me>.
-					</solution>
-				</p>
-			</solution>
-			
-		</example>
+	<me>
+		\frac{e^{x^2}}{x} + 2 x \ln x e^{x^2} = \left[e^{x^2} \ln x\right]'
+	</me>.
+</solution>
+</example>
 
 		<p>
 			Let's now try expressions involving a variable function, like <m>y(x)</m>. These are the ones we'll actually encounter when solving differential equations.
@@ -243,68 +232,58 @@
 			</statement>
 
 			<solution>
-				<p>
-					<solution>
-						<p>
-							Since <m>dy/dx</m> and <m>y</m> are in separate terms, setting <m>g</m> to <m>y</m> gives you <m>g'</m> and <m>f</m> for free since
-						</p>
+	<p>
+		Since <m>dy/dx</m> and <m>y</m> are in separate terms, setting <m>g</m> to <m>y</m> gives you <m>g'</m> and <m>f</m> for free since
+	</p>
 
-						<me>
-							\underset{\Large f}{ \underset{\uparrow}{\ul{e^{9x}}}}\
-							\underset{\Large g'}{ \underset{\uparrow}{\ul{\vphantom{|}\frac{dy}{dx}}}}
-							+
-							\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}y}}}\
-							(9 e^{9x})
-						</me>.
+	<me>
+		\underset{\Large f}{ \underset{\uparrow}{\ul{e^{9x}}}} \, 
+		\underset{\Large g'}{ \underset{\uparrow}{\ul{\vphantom{|}\frac{dy}{dx}}}}
+		+
+		\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}y}}} \, 
+		(9 e^{9x})
+	</me>.
 
-						<p>
-							The only thing you need to check is
-							<me>
-								f' = [e^{9x}]' = 9e^{9x} \quad ✅
-							</me>
-							which is sitting right next to <m>g</m>. Therefore, we have
-						</p>
+	<p>
+		The only thing you need to check is
+		<me>
+			f' = [e^{9x}]' = 9e^{9x} \quad ✅
+		</me>
+		which is sitting right next to <m>g</m>. Therefore, we have
+	</p>
 
-						<me>
-							e^{9x}\frac{dy}{dx} + 9 e^{9x} y = \left[e^{9x} y\right]'
-						</me>.
+	<me>
+		e^{9x}\frac{dy}{dx} + 9 e^{9x} y = \left[e^{9x} y\right]'
+	</me>.
 
-					</solution>
+	<p>
+		Again, set <m>g</m> to <m>y</m> and the rest fall into place as
+	</p>
 
-					<solution>
+	<me>
+		\underset{\Large f}{ \underset{\uparrow}{\ul{e^{1/x}}}} \, 
+		\underset{\Large g'}{ \underset{\uparrow}{\ul{\vphantom{|}y'}}}
+		+
+		\left(-\frac{e^{1/x}}{x^2}\right) \, 
+		\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}y}}}
+	</me>.
 
-						<p>
-							Again, set <m>g</m> to <m>y</m> and the rest fall into place as
-						</p>
+	<p>
+		The only thing left to do is verify the derivative of <m>f</m>:
+		<me>
+			f' = \left[e^{1/x}\right]' = e^{1/x}\left[\frac{1}{x}\right]^\prime = e^{1/x}\left(-\frac{1}{x^2}\right) = -\frac{e^{1/x}}{x^2} \quad ✅
+		</me>.
+	</p>
 
-						<me>
-							\underset{\Large f}{ \underset{\uparrow}{\ul{e^{1/x}}}}\
-							\underset{\Large g'}{ \underset{\uparrow}{\ul{\vphantom{|}y'}}}
-							+
-							\left(-\frac{e^{1/x}}{x^2}\right)\
-							\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}y}}}
-						</me>.
+	<p>
+		So, we can reverse the product rule as
+	</p>
 
-						<p>
-							The only thing left to do is verify the derivative of <m>f</m>:
-							<me>
-								f' = \left[e^{1/x}\right]' = e^{1/x}\left[\frac{1}{x}\right]^\prime = e^{1/x}\left(-\frac{1}{x^2}\right) = -\frac{e^{1/x}}{x^2} \quad ✅
-							</me>.
-						</p>
-
-						<p>
-							So, we can reverse the product rule as
-						</p>
-
-						<me>
-							e^{1/x}y' - \frac{e^{1/x}}{x^2}y = \left[e^{1/x} y\right]'
-						</me>.
-
-					</solution>
-				</p>
-			</solution>
-			
-		</example>
+	<me>
+		e^{1/x}y' - \frac{e^{1/x}}{x^2}y = \left[e^{1/x} y\right]'
+	</me>.
+</solution>
+</example>
 
 		<exercise label="chkpt-reversed-product-rule-2">
 			<title><e component="emoji">📖❓</e>  What's Missing in the Product Rule</title>
@@ -422,7 +401,7 @@
 					<condition string="p">
 						<feedback>
 							<p>
-								<line>The variable should be a capitol <m>P</m>.</line>
+								<line>The variable should be a capital <m>P</m>.</line>
 							</p>
 						</feedback>
 					</condition>


### PR DESCRIPTION
# Notes — c5_product-rule_U1_26JAN17

R1 | example (product-rule-in-reverse) | Removed invalid nested <solution> blocks and unwrapped block content from a <p> wrapper | PTX structural correctness: nested <solution> and <p> containing block elements can break rendering.

R2 | same example | Replaced stray TeX line-ending backslashes (\) with explicit thin spaces (\,) inside <me> blocks | Conversion artifacts: lone backslashes at end-of-line can cause LaTeX errors.

R3 | reversed-product-rule-example | Removed invalid nested <solution> blocks and unwrapped block content from a <p> wrapper; replaced stray TeX line-ending backslashes (\) with \ , | PTX structural correctness + LaTeX safety.

R4 | chkpt-reversed-product-rule-2 feedback | "capitol" → "capital" | Spelling/meaning fix (capital letter vs. capitol building).