### PR TITLE
Update sec-exponential-solns.ptx

### DIFF
--- a/source/c8-lhcc/sec-exponential-solns.ptx
+++ b/source/c8-lhcc/sec-exponential-solns.ptx
@@ -416,7 +416,7 @@
 				</match>	
 				<match>
 					<premise><m>r^2 - r - 3 = 0</m></premise>
-					<response><m>y'' - y' - 3y = 0</m></response>
+					<response><m>y'' - 3y = y'</m></response>
 				</match>
 				<match>
 					<premise><m>r^2 - r = 0</m></premise>

--- a/source/c8-lhcc/sec-exponential-solns.ptx
+++ b/source/c8-lhcc/sec-exponential-solns.ptx
@@ -62,7 +62,7 @@
 						Terms are <term>like-terms</term> if they differ only by a coefficient and can be combined via addition and subtraction. 
 					</p>
 					<p>
-						For example, the pairs <m>\{5e^{-3x}, 4e^{-3x}\}</m> and <m>\{3x^2, 7x^2\}</m> are like-terms and can be combined/simplifed as shown here:
+						For example, the pairs <m>\{5e^{-3x}, 4e^{-3x}\}</m> and <m>\{3x^2, 7x^2\}</m> are like-terms and can be combined/simplified as shown here:
 						<me>
 							\underline{3x^2} + 2e^{7x} + \underline{\underline{5e^{-3x}}} - 2 + \underline{7x^2} - \underline{\underline{4e^{-3x}}} 
 							= \underline{10x^2} + 2e^{7x} + \underline{\underline{e^{-3x}}} - 2 
@@ -106,7 +106,7 @@
 				<choices randomize="yes" multiple-correct="yes">
 					<choice correct="yes">
 						<statement><m>\quad y = e^{10x} </m></statement>
-						<feedback>Correct!<m>\frac{d}{dx}[e^{10x}] = 10e^{x}\ \Rightarrow\ e^{10x}</m> &amp; <m>10e^{10x}</m> ARE like terms and can be combined by addition.</feedback>
+						<feedback>Correct!<m>\frac{d}{dx}[e^{10x}] = 10e^{10x}\ \Rightarrow\ e^{10x}</m> &amp; <m>10e^{10x}</m> ARE like terms and can be combined by addition.</feedback>
 					</choice>
 					<choice>
 						<statement><m>\quad y = \sin (4x) </m></statement>
@@ -416,13 +416,14 @@
 				</match>	
 				<match>
 					<premise><m>r^2 - r - 3 = 0</m></premise>
-					<response><m>y'' - 3y = y'</m></response>
+					<response><m>y'' - y' - 3y = 0</m></response>
 				</match>
 				<match>
 					<premise><m>r^2 - r = 0</m></premise>
 					<response><m>y'' - y' = 0</m></response>
 				</match>
 				<match>
+					<premise><m>r^2 + r - 3 = 0</m></premise>
 					<response><m>y'' + y' - 3y = 0</m></response>
 				</match>
 			</cardsort>

--- a/source/c8-lhcc/sec-exponential-solns.ptx
+++ b/source/c8-lhcc/sec-exponential-solns.ptx
@@ -423,7 +423,6 @@
 					<response><m>y'' - y' = 0</m></response>
 				</match>
 				<match>
-					<premise><m>r^2 + r - 3 = 0</m></premise>
 					<response><m>y'' + y' - 3y = 0</m></response>
 				</match>
 			</cardsort>


### PR DESCRIPTION
# Notes — c8_exponential-solns_U1_26JAN17

R1 | task=exponential-solns-prereading-question-2 | fixed typo `simplifed` -> `simplified` | spelling R2 | task=exponential-solns-prereading-question-3 | corrected derivative in feedback: `10e^{x}` -> `10e^{10x}` | math accuracy (derivative of e^{10x}) R3 | exercise=chkpt-exponential-solns-11 | added missing cardsort premise for `y'' + y' - 3y = 0`: `r^2 + r - 3 = 0` | completes characteristic↔DE pairing R4 | exercise=chkpt-exponential-solns-11 | rewrote equivalent DE form `y'' - 3y = y'` -> `y'' - y' - 3y = 0` | clarity/standard form (equivalent equation) R5 | task=lhcc-cq-mc-21 title | fixed typo `Mathching` -> `Matching` | spelling