### PR TITLE
Update sec-higher-order-lhcc-eqns.ptx

### DIFF
--- a/source/c8-lhcc/sec-higher-order-lhcc-eqns.ptx
+++ b/source/c8-lhcc/sec-higher-order-lhcc-eqns.ptx
@@ -15,7 +15,7 @@
 	
 	<introduction>
 		<p> 
-			Like second-order linear homogeneous constant coefficient (LHCC) equations, we solve higher-order equations by finding the roots of a characteristic equation. However, with higher-order comes higher-degree characteristic polynomials and an increased number of roots. While this results in additional terms, determining which ones go into the general solution is similar to the second-order case.
+			Like second-order linear homogeneous constant coefficient (LHCC) equations, we solve higher-order equations by finding the roots of a characteristic equation. However, with higher-order comes higher-degree characteristic polynomials and an increased number of roots. While this results in additional terms, determining which ones to include in the general solution is similar to the second-order case.
 		</p>
 	</introduction>
 
@@ -57,7 +57,7 @@
 				</choice>
 				<choice>
 					<statement>
-						The equation can have any order with general solution <m>\ ce^{-2x}</m>.
+						The equation can have any order with a general solution <m>\ ce^{-2x}</m>.
 					</statement>
 					<feedback>
 						Incorrect. The order of the equation is determined by the number of roots, which is <m>1</m> in this case.
@@ -154,7 +154,7 @@
 			<me>
 				e^{\alpha x} (c_1 \cos(\beta x) + c_2 \sin(\beta x))
 			</me>
-			to the general solution. There may be multiple pairs, each contributing their own term.
+			to the general solution. There may be multiple pairs, each contributing its own term.
 		</p>
 	</subsection>
 
@@ -211,39 +211,39 @@
 			<solution>
 				<p>
 					<ol>
-										<li>
-											<p>
-												Three different real roots:
-											</p>
-											<me>
-												y = c_1 e^{3x} + c_2 e^{-3x} + c_3 e^{5.3x}
-											</me>
-										</li>
-										<li>
-											<p>
-												A complex conjugate pair and a double real root at <m>r = 0</m>:
-											</p>
-											<me>
-												y = \ub{e^{6x} (c_1 \sin(\sqrt{7.7}x) + c_2 \cos(\sqrt{7.7}x))}_{\ds\text{from}\ 6 \pm i\sqrt{7.7}} + \ub{c_3\ +\ c_4 x}_{\ds\text{from}\ 0\ \text{(double)}}
-											</me>
-										</li>
-										<li>
-											<p>
-												A triple <m>-4</m> root and single <m>5.3</m> root:
-											</p>
-											<me>
-												y = \ub{c_1 e^{-4x} + c_2 x e^{-4x} + c_3 x^2 e^{-4x}\!}_{\ds\text{from}\ -4\ \text{(triple)}} + c_4 e^{5.3x}
-											</me>
-										</li>
-										<li>
-											<p>
-												Two complex conjugate pairs:
-											</p>
-											<me>
-												y = \ub{c_1 \sin\left(\frac{x}{2}\right) + c_2 \cos\left(\frac{x}{2}\right)}_{\ds\text{from}\ \pm \sfrac{i}{2}} + \ub{e^{2x} (c_3 \sin x + c_4 \cos x)}_{\ds\text{from}\ 2 \pm i}
-											</me>
-										</li>
-									</ol>
+						<li>
+							<p>
+								Three different real roots:
+							</p>
+							<me>
+								y = c_1 e^{3x} + c_2 e^{-3x} + c_3 e^{5.3x}
+							</me>
+						</li>
+						<li>
+							<p>
+								A complex conjugate pair and a double real root at <m>r = 0</m>:
+							</p>
+							<me>
+								y = \ub{e^{6x} (c_1 \sin(\sqrt{7.7}x) + c_2 \cos(\sqrt{7.7}x))}_{\ds\text{from}\ 6 \pm i\sqrt{7.7}} + \ub{c_3\ +\ c_4 x}_{\ds\text{from}\ 0\ \text{(double)}}
+							</me>
+						</li>
+						<li>
+							<p>
+								A triple <m>-4</m> root and single <m>5.3</m> root:
+							</p>
+							<me>
+								y = \ub{c_1 e^{-4x} + c_2 x e^{-4x} + c_3 x^2 e^{-4x}\!}_{\ds\text{from}\ -4\ \text{(triple)}} + c_4 e^{5.3x}
+							</me>
+						</li>
+						<li>
+							<p>
+								Two complex conjugate pairs:
+							</p>
+							<me>
+								y = \ub{c_1 \sin\left(\frac{x}{2}\right) + c_2 \cos\left(\frac{x}{2}\right)}_{\ds\text{from}\ \pm \sfrac{i}{2}} + \ub{e^{2x} (c_3 \sin x + c_4 \cos x)}_{\ds\text{from}\ 2 \pm i}
+							</me>
+						</li>
+					</ol>
 				</p>
 			</solution>
 		</example>

--- a/source/c8-lhcc/sec-higher-order-lhcc-eqns.ptx
+++ b/source/c8-lhcc/sec-higher-order-lhcc-eqns.ptx
@@ -15,7 +15,7 @@
 	
 	<introduction>
 		<p> 
-			Like second-order linear homogeneous constant coefficient (LHCC) equations, we solve higher-order equations by finding the roots of a characteristic equation. However, with higher-order comes higher-degree characteristic polynomials and an increased number of roots. While this results in additional terms, determining which ones go into in the general solution is similar to the second-order case.
+			Like second-order linear homogeneous constant coefficient (LHCC) equations, we solve higher-order equations by finding the roots of a characteristic equation. However, with higher-order comes higher-degree characteristic polynomials and an increased number of roots. While this results in additional terms, determining which ones go into the general solution is similar to the second-order case.
 		</p>
 	</introduction>
 
@@ -60,7 +60,7 @@
 						The equation can have any order with general solution <m>\ ce^{-2x}</m>.
 					</statement>
 					<feedback>
-						Incorrect. The order of the equation is determined by the number of roots, which is <m>1</m> in this case, not <m>2</m>.
+						Incorrect. The order of the equation is determined by the number of roots, which is <m>1</m> in this case.
 					</feedback>
 				</choice>
 			</choices>
@@ -194,7 +194,7 @@
 		</p>
 
 		<example xml:id="lhcc-roots-to-general-solution">
-			<title>From Charateristic Roots to General Solution</title>
+			<title>From Characteristic Roots to General Solution</title>
 
 			<statement>
 				<p>
@@ -209,40 +209,42 @@
 			</statement>
 
 			<solution>
-				<ol>
-					<li>
-						<p>
-							Three different real roots:
-						</p>
-						<me>
-							y = c_1 e^{3x} + c_2 e^{-3x} + c_3 e^{5.3x}
-						</me>
-					</li>
-					<li>
-						<p>
-							A complex conjugate pair and a double real root at <m>r = 0</m>:
-						</p>
-						<me>
-							y = \ub{e^{6x} (c_1 \sin(\sqrt{7.7}x) + c_2 \cos(\sqrt{7.7}x))}_{\ds\text{from}\ 6 \pm i\sqrt{7.7}} + \ub{c_3\ +\ c_4 x}_{\ds\text{from}\ 0\ \text{(double)}}
-						</me>
-					</li>
-					<li>
-						<p>
-							A triple <m>-4</m> root and single <m>5.3</m> root:
-						</p>
-						<me>
-							y = \ub{c_1 e^{-4x} + c_2 x e^{-4x} + c_3 x^2 e^{-4x}\!}_{\ds\text{from}\ -4\ \text{(triple)}} + c_4 e^{5.3x}
-						</me>
-					</li>
-					<li>
-						<p>
-							Two complex conjugate pairs:
-						</p>
-						<me>
-							y = \ub{c_1 \sin\left(\frac{x}{2}\right) + c_2 \cos\left(\frac{x}{2}\right)}_{\ds\text{from}\ \pm \sfrac{i}{2}} + \ub{e^{2x} (c_3 \sin x + c_4 \cos x)}_{\ds\text{from}\ 2 \pm i}
-						</me>
-					</li>
-				</ol>
+				<p>
+					<ol>
+										<li>
+											<p>
+												Three different real roots:
+											</p>
+											<me>
+												y = c_1 e^{3x} + c_2 e^{-3x} + c_3 e^{5.3x}
+											</me>
+										</li>
+										<li>
+											<p>
+												A complex conjugate pair and a double real root at <m>r = 0</m>:
+											</p>
+											<me>
+												y = \ub{e^{6x} (c_1 \sin(\sqrt{7.7}x) + c_2 \cos(\sqrt{7.7}x))}_{\ds\text{from}\ 6 \pm i\sqrt{7.7}} + \ub{c_3\ +\ c_4 x}_{\ds\text{from}\ 0\ \text{(double)}}
+											</me>
+										</li>
+										<li>
+											<p>
+												A triple <m>-4</m> root and single <m>5.3</m> root:
+											</p>
+											<me>
+												y = \ub{c_1 e^{-4x} + c_2 x e^{-4x} + c_3 x^2 e^{-4x}\!}_{\ds\text{from}\ -4\ \text{(triple)}} + c_4 e^{5.3x}
+											</me>
+										</li>
+										<li>
+											<p>
+												Two complex conjugate pairs:
+											</p>
+											<me>
+												y = \ub{c_1 \sin\left(\frac{x}{2}\right) + c_2 \cos\left(\frac{x}{2}\right)}_{\ds\text{from}\ \pm \sfrac{i}{2}} + \ub{e^{2x} (c_3 \sin x + c_4 \cos x)}_{\ds\text{from}\ 2 \pm i}
+											</me>
+										</li>
+									</ol>
+				</p>
 			</solution>
 		</example>
 


### PR DESCRIPTION
# Notes — c8_higher-order-lhcc-eqns_U1_26JAN17

R1 | intro (higher-order-lhcc) | removed duplicate word: `go into in` -> `go into` | grammar R2 | example=lhcc-roots-to-general-solution title | fixed typo `Charateristic` -> `Characteristic` | spelling R3 | exercise=chkpt-higher-order-lhcc-1 (choice: any order) | trimmed incorrect feedback fragment (`not 2`) -> correct order statement | feedback accuracy R4 | example=lhcc-roots-to-general-solution solution | wrapped solution <ol> in a minimal <p>...</p> | PTX structural hazard: lists must be inside <p> per LAW