### PR TITLE
Update sec-lhcc-eqn.ptx

### DIFF
--- a/source/c8-lhcc/sec-lhcc-eqn.ptx
+++ b/source/c8-lhcc/sec-lhcc-eqn.ptx
@@ -15,7 +15,7 @@
 
 	<introduction>
 		<p>
-			Before learning how to solve Linear Homogeneous Constant Coefficient (LHCC) differential equations, it's important to identify these equations and understand the nature of their structure. In this section, we'll define what it means for a differential equation to be homogeneous, review how constant coefficients affect the form of the equation, and formally define what qualifies as an LHCC equation.
+			Before learning how to solve Linear Homogeneous Constant Coefficient (LHCC) differential equations, it's important to identify these equations and understand their structure. In this section, we'll define what it means for a differential equation to be homogeneous, review how constant coefficients affect the form of the equation, and formally define what qualifies as an LHCC equation.
 		</p>
 	</introduction>
 
@@ -60,11 +60,7 @@
 		</p>
 
 		<p>
-			For example, in the equation
-			<me>
-				y'' + 2y + 5x = -5 + 3y'
-			</me>
-			the forcing function is not immediately clear. Rearranging it into standard form:
+			For example, in the equation <me>y'' + 2y + 5x = -5 + 3y'</me>, the forcing function is not immediately clear. Rearranging it into standard form:
 			<me>
 				y'' - 3y' + 2y = 5x - 5
 			</me>
@@ -224,7 +220,7 @@
 					<statement> <m>\ds\quad y'' + 4y^2 = 0 </m> </statement>
 					<feedback>
 						<p>
-							Incorrect. This equation looks homogeneous, but homogeneity only applies to linear equations.
+							Incorrect. This equation appears homogeneous, but homogeneity applies only to linear equations.
 						</p>
 					</feedback>
 				</choice>

--- a/source/c8-lhcc/sec-lhcc-eqn.ptx
+++ b/source/c8-lhcc/sec-lhcc-eqn.ptx
@@ -27,7 +27,7 @@
 		</p>
 
 		<p>
-			An equation is nonlinear <term>nonlinear</term> if it includes terms like <m>y^2</m>, <m>(y')^3</m>, <m>\sin(y)</m>, or <m>y \cdot y''</m>, where the dependent variable is raised to a power or multiplied by one of its derivatives.
+			An equation is <term>nonlinear</term> if it includes terms like <m>y^2</m>, <m>(y')^3</m>, <m>\sin(y)</m>, or <m>y \cdot y''</m>, where the dependent variable is raised to a power or multiplied by one of its derivatives.
 		</p>
 
 	  <p>
@@ -60,7 +60,7 @@
 		</p>
 
 		<p>
-			For example, the equation
+			For example, in the equation
 			<me>
 				y'' + 2y + 5x = -5 + 3y'
 			</me>
@@ -84,8 +84,8 @@
 			<choices randomize="yes">
 				<choice correct="yes">
 					<statement><m>5x + 10</m></statement>
-					<feedback>Correct! The forcing function is the entire right-hand side of the equation.</feedback>
-				</choice>`
+					<feedback>Correct! After rearranging into standard form, the forcing function is the entire right-hand side.</feedback>
+				</choice>
 				<choice>
 					<statement><p><m>x^2</m></p></statement>
 					<feedback><p>This is the coefficient of the <m>y''</m> term, not the forcing function.</p></feedback>


### PR DESCRIPTION
# Notes — c8_lhcc-eqn_U1_26JAN17

R1 | subsection=forcing-functions-on-linear-eqns | removed duplicated word: `nonlinear` | grammar/clarity R2 | exercise=chkpt-identifying-forcing-function-1 | clarified forcing-function feedback to reference standard form | clarity (matches preceding explanation) R3 | exercise=chkpt-identifying-forcing-function-1 | removed stray backtick after `</choice>` | PTX structural hygiene R4 | subsection=forcing-functions-on-linear-eqns | adjusted phrasing `For example, the equation` -> `For example, in the equation` | grammar