### PR TITLE
Update sec-linear-terms.ptx

### DIFF
--- a/source/c1-classification/sec-linear-terms.ptx
+++ b/source/c1-classification/sec-linear-terms.ptx
@@ -1,21 +1,9 @@
-<!-- LICENSING
-  This file is part of the textbook "Exploring Differential Equations, An Interactive, Student-Centered Approach" by Geoffrey Cox.
-  License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
-  You are free to:
-    • Share — copy and redistribute the material in any medium or format.
-    • Adapt — remix, transform, and build upon the material for any purpose, even commercially.
-  Under the following terms:
-    • Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.
-    • ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license.
-  Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
-  Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
--->
 <section label="linear-terms">
-	<title>Linear &amp; Nonlinear Terms</title>
+	<title>Linear and Nonlinear Terms</title>
 
 	<introduction>
 		<p>
-			To decide whether a differential equation is linear, we first need to understand what it means for a <xref ref="summary-terms" text="custom">term</xref> to be linear. 
+			To decide whether a differential equation is linear, we first need to understand what it means for a <xref ref="summary-terms" text="custom">term</xref> to be linear.
 			In this context, linearity refers to the form in which the dependent variable and its derivatives appear in each term.
 		</p>
 	</introduction>
@@ -77,7 +65,8 @@
 				<evaluate>
 					<test correct="yes">
 						<strcmp>\s*(2t|2\s*t|2\s*\*\s*t|2\(t\))\s*</strcmp>
-						<feedback><p>Correct! <m>a(t) = 2t</m>.</p></feedback>
+						<feedback><p>Correct!
+						<m>a(t) = 2t</m>.</p></feedback>
 					</test>
 					<test>
 						<strcmp>\s*(2|two)\s*</strcmp>
@@ -93,7 +82,8 @@
 				<evaluate>
 					<test correct="yes">
 						<strcmp>\s*(sin\(\s*t\s*\)|sin\s*t|sine\s*t)\s*</strcmp>
-						<feedback><p>Correct! <m>a(t) = \sin(t)</m>.</p></feedback>
+						<feedback><p>Correct!
+						<m>a(t) = \sin(t)</m>.</p></feedback>
 					</test>
 					<test>
 						<strcmp>\s*(y|Y)\s*</strcmp>
@@ -109,7 +99,8 @@
 					</test>
 					<test>
 						<strcmp>\s*(y|Y)\s*</strcmp>
-						<feedback><p>Incorrect. <m>a(t)</m> should not contain <m>y</m>.</p></feedback>
+						<feedback><p>Incorrect.
+						<m>a(t)</m> should not contain <m>y</m>.</p></feedback>
 					</test>
 					<test><strcmp>\s*</strcmp><feedback><p>Type in something ...</p></feedback></test>
 					<test><strcmp>.*</strcmp><feedback><p>Incorrect</p></feedback></test>
@@ -124,7 +115,7 @@
 		<title>Nonlinear Terms</title>
 
 		<p>
-			A term is <term>nonlinear</term> if it is not in one of the forms in <xref ref="linear-term-forms"/>. 
+			A term is <term>nonlinear</term> if it is not in one of the forms in <xref ref="linear-term-forms"/>.
 			Assuming <m>y</m> is the dependent variable, some telltale signs that a term is nonlinear include:
 			<ul marker="square">
 				<li><p><m>y</m> or <m>y^{(n)}</m> are raised to a power other than 1 <m>\left(\text{e.g.,}\ y^2,\ (y')^{-4}\right)</m>.</p></li>
@@ -146,7 +137,8 @@
 				<li>
 				<title><m>\ds y\frac{d^5y}{dt^5}</m></title>
 				<p>
-					Nonlinear. This term involves a product of the dependent variable and its derivative, violating the rule that only one of them can appear in a term.
+					Nonlinear.
+					This term involves a product of the dependent variable and its derivative, violating the rule that only one of them can appear in a term.
 				</p>
 				</li>
 				<li>
@@ -164,13 +156,15 @@
 				<li>
 				<title><m>\ds y^2</m></title>
 				<p>
-					Nonlinear. The dependent variable appears raised to a power other than one.
+					Nonlinear.
+					The dependent variable appears raised to a power other than one.
 				</p>
 				</li>
 				<li>
 				<title><m>\ds t^3</m></title>
 				<p>
-					Linear. This term doesn't involve the dependent variable or any of its derivatives.
+					Linear.
+					This term doesn't involve the dependent variable or any of its derivatives.
 				</p>
 				</li>
 			</dl>
@@ -186,7 +180,7 @@
 					</row>
 					<row>
 						<cell><p>🔹</p></cell>
-						<cell>Match (by dragging) each term (on the left) to either Linear or Nonlinear.</cell>
+						<cell>Drag each term on the left to match it with either Linear or Nonlinear.</cell>
 					</row>
 					<row>
 						<cell><p>🔹</p></cell>
@@ -213,7 +207,7 @@
 		</exercise>
 
 		<p>
-			See if you can identify the linearity of the terms in the following examples, before looking at the solutions.
+			See if you can identify the linearity of the terms in the following examples before looking at the solutions.
 		</p>
 
 		<example>


### PR DESCRIPTION
# Notes for sec-linear-terms.ptx
R# | title | grammar | Changed "Linear & Nonlinear" to "Linear and Nonlinear" for style. R# | order-linearity-cyu-5 | grammar | Clarified matching instructions ("Drag each term..."). R# | text-before-example | grammar | Removed unnecessary comma.