### PR TITLE
Update exercises-linsys.ptx

### DIFF
--- a/source/c13-linsys/exercises-linsys.ptx
+++ b/source/c13-linsys/exercises-linsys.ptx
@@ -85,7 +85,7 @@
 				</statement>
 				<feedback>
 					<p>
-					Systems are classified by whether variables influence each other and how. Look for dependencies in the right-hand sides.
+					Systems are classified by whether variables influence each other and how they do so. Look for dependencies in the right-hand sides.
 					</p>
 				</feedback>
 				<cardsort>
@@ -184,7 +184,7 @@
 					</choice>
 					<choice correct="no">
 						<statement><p>Rewrite the system as a second-order equation for just one variable.</p></statement>
-						<feedback><p>You could do this in some cases, but for uncoupled systems it's simpler to solve each one directly.</p></feedback>
+						<feedback><p>You could do this in some cases, but for uncoupled systems, it's simpler to solve each one directly.</p></feedback>
 					</choice>
 					<choice correct="no">
 						<statement><p>Use Euler's Method only — they cannot be solved exactly.</p></statement>
@@ -704,36 +704,35 @@
 
 			<introduction>
 				<p>
-					Two large tanks, each holding 100 L of liquid, are interconnected by pipes, with the liquid flowing from tank 1 into tank 2 at a rate of 3 L/min and from tank 2 into tank 1 at a rate of 1 L/min. The liquid inside each tank is kept well-stirred.  A brine solution with salt concentration of 0.01 kg/L flows into tank 1 at a rate of 4 L/min.  The (diluted) solution flows out of the system from tank 1 at 2 L/min and from tank 2 at 2 L/min.Initially, tank 1 contains pure water and tank 2 contains 6 kg of salt.
+					Two large tanks, each holding 100 L of liquid, are interconnected by pipes, with the liquid flowing from tank 1 into tank 2 at 3 L/min and from tank 2 into tank 1 at 1 L/min. The liquid in each tank is kept well stirred. A brine solution with a salt concentration of 0.01 kg/L flows into tank 1 at a rate of 4 L/min.  The (diluted) solution flows out of the system from tank 1 at 2 L/min and from tank 2 at 2 L/min.Initially, tank 1 contains pure water and tank 2 contains 6 kg of salt.
 				</p>
 			</introduction>
 
 			<exercise>
 				<statement>
 					<p>
-						Write a system of differential equations for<m>x_1(t) </m> (the amount of salt, in kg, in tank 1 at tim <m>t </m> )and <m>x_2(t) </m> (the amount of salt, in kg, in tank 2 at tim <m>t </m> ).
+						Write a system of differential equations for<m>x_1(t) </m> (the amount of salt, in kg, in tank 1 at time <m>t </m> )and <m>x_2(t) </m> (the amount of salt, in kg, in tank 2 at time <m>t </m> ).
 					</p>
 				</statement>
 				<solution>
 					<p>
-					We consider the rate of change in the amount of salt in tank 1.
-					<md>
-						<mrow>  \frac{dx_1}{dt}  \amp =  \mbox{(rate of salt in to the tank)} - \mbox{(rate of salt in to the tank)} </mrow>
-						<mrow>   \amp =  \Bigg[\underbrace{0.1 \cdot 4}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}} + \underbrace{\frac{x_2}{100}\cdot 1}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}}\Bigg] - \Bigg[\underbrace{\frac{x_1}{100}\cdot 3}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}}\Bigg] </mrow>
-						<mrow>   \amp = 0.4 + \frac{1}{100}x_2 - \frac{1}{20}x_1  </mrow>
-					</md>
-					Similarly, we consider the rate of change in the amount of salt in tank 2.
-					<md>
-						<mrow>  \frac{dx_2}{dt}  \amp =  \mbox{(rate of salt in to the tank)} - \mbox{(rate of salt in to the tank)} </mrow>
-						<mrow>   \amp =  \Bigg[\underbrace{\frac{x_1}{100}\cdot 3}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}}\Bigg] - \Bigg[\underbrace{\frac{x_2}{100}\cdot 3}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}}\Bigg] </mrow>
-						<mrow>   \amp = \frac{3}{100}x_1 - \frac{3}{100}x_2  </mrow>
-					</md>
-					Hence, our system is:
-					<md>
-						<mrow>  x'_1	 \amp = - \frac{1}{20}x_1+ \frac{1}{100}x_2 + 0.4, </mrow>
-						<mrow>  x'_2	 \amp =  \frac{3}{100}x_1 - \frac{3}{100}x_2.  </mrow>
-					</md>
-					
+						We consider the rate of change in the amount of salt in tank 1.
+						<md>
+							<mrow>  \frac{dx_1}{dt}  \amp =  \mbox{(rate of salt in to the tank)} - \mbox{(rate of salt in to the tank)} </mrow>
+							<mrow>   \amp =  \Bigg[\underbrace{0.1 \cdot 4}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}} + \underbrace{\frac{x_2}{100}\cdot 1}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}}\Bigg] - \Bigg[\underbrace{\frac{x_1}{100}\cdot 3}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}}\Bigg] </mrow>
+							<mrow>   \amp = 0.4 + \frac{1}{100}x_2 - \frac{1}{20}x_1  </mrow>
+						</md>
+						Similarly, we consider the rate of change in the amount of salt in tank 2.
+						<md>
+							<mrow>  \frac{dx_2}{dt}  \amp =  \mbox{(rate of salt in to the tank)} - \mbox{(rate of salt in to the tank)} </mrow>
+							<mrow>   \amp =  \Bigg[\underbrace{\frac{x_1}{100}\cdot 3}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}}\Bigg] - \Bigg[\underbrace{\frac{x_2}{100}\cdot 3}_{ \frac{\mbox{kg}}{\mbox{L}}\cdot\frac{\mbox{L}}{\mbox{min}}}\Bigg] </mrow>
+							<mrow>   \amp = \frac{3}{100}x_1 - \frac{3}{100}x_2  </mrow>
+						</md>
+						Hence, our system is:
+						<md>
+							<mrow>  x'_1	 \amp = - \frac{1}{20}x_1+ \frac{1}{100}x_2 + 0.4, </mrow>
+							<mrow>  x'_2	 \amp =  \frac{3}{100}x_1 - \frac{3}{100}x_2.  </mrow>
+						</md>
 					</p>
 				</solution>
 				<answer>
@@ -783,7 +782,7 @@
 
 		<exercise>
 			<statement>
-				A simplified mathematical model for an arms race between two countries whose expenditures for %	defense are expressed by the variable <m>x(t)</m> and <m>y(t)</m> is given by the linear system
+				A simplified mathematical model for an arms race between two countries whose expenditures for	defense are expressed by the variables <m>x(t)</m> and <m>y(t)</m> is given by the linear system
 				<md>
 					<mrow>  \frac{dx}{dt}	 \amp =  2y - x + a		\amp x(0) = 1</mrow>
 					<mrow>  \frac{dy}{dt}	 \amp =  4x - 3y + b	\amp y(0) = 4</mrow>
@@ -794,46 +793,31 @@
 					<li>What might be appropriate units for <m>x(t) </m> and <m>y(t)</m>?</li>
 					<li>
 						How can we interpret the fact that the coefficient of <m>y </m> is positive in the equation for <m>\frac{dx}{dt}</m>?
-						Does it make sense? Would the DE make sense if the coefficient was negative instead?
+						Does it make sense? Would the DE make sense if the coefficient were negative instead?
 					</li>
 					<li>
 						How can we interpret the fact that the coefficient of <m>y </m> is negative in the equation for <m>\frac{dy}{dt}</m>?
-						Does it make sense? Would the DE make sense if the coefficient was positive instead?
+						Does it make sense? Would the DE make sense if the coefficient were positive instead?
 					</li>
 					<li>
 						Suppose country X trusts country Y, but country Y doesn't trust country X.
 						What can we say about <m>a</m> and <m>b</m>?
-						Should they be positive, negative or zero?</li>
+						Should they be positive, negative, or zero?</li>
 					<li>
 						Rewrite the system of differential equations in matrix form by using the vector
 						<m>\vec{X} = \begin{bmatrix} x\\y \end{bmatrix}.</m>
 						Notice that for this system, the right hand side should be of the for <m>A\vec{X} + \vec{B}.</m>
 					</li>
 					<li>
-						Write the initial conditions in a vector, also. That is, complete the following.
+						Write the initial conditions as a vector as well. That is, complete the following.
 						<m>\vec{X}(0) = \begin{bmatrix} ?\\? \end{bmatrix}</m>
 					</li>
 				</ol>
 				</p>
 			</statement>
-			<solution>
-				<p>
-					
-				</p>
-			</solution>
-			<answer>
-				<p>
-					
-				</p>
-			</answer>
 		</exercise>
 
 		<exercisegroup>
-
-			<introduction>
-				<p>
-				</p>
-			</introduction>
 
 			<exercise>
 				<statement>
@@ -867,22 +851,12 @@
 								<m>\vec{X} = \begin{bmatrix} x\\y \end{bmatrix}.</m>
 							</li>
 							<li>
-								Write the initial conditions in a vector, also. That is, complete the following. 
+								Write the initial conditions as a vector as well. That is, complete the following. 
 								<m>\vec{X}(0) = \begin{bmatrix} ?\\? \end{bmatrix}</m>
 							</li>
 						</ol>
 					</p>
 				</statement>
-				<solution>
-					<p>
-						
-					</p>
-				</solution>
-				<answer>
-					<p>
-						
-					</p>
-				</answer>
 			</exercise>
 
 			<exercise>
@@ -989,32 +963,12 @@
 				<statement>
 					<m>y'' - 4y' + 4y = 0 </m>
 				</statement>
-				<solution>
-					<p>
-						<m>y'' - 4y' + 4y = 0 </m>
-					</p>
-				</solution>
-				<answer>
-					<p>
-						
-					</p>
-				</answer>
 			</exercise>
 
 			<exercise>
 				<statement>
 					<m>x^2 y''' = 2y' </m>
 				</statement>
-				<solution>
-					<p>
-						<m>x^2 y''' = 2y' </m>
-					</p>
-				</solution>
-				<answer>
-					<p>
-						
-					</p>
-				</answer>
 			</exercise>
 
 			<exercise>
@@ -1023,28 +977,27 @@
 				</statement>
 				<solution>
 					<p>
-				We have one second-order and one first-order DE, which means we will need three variables to generate a systemof three first-order DEs.\\ Let <m>u = y </m> <m>v = y', </m> and <m>w = x </m> .  Then we have the following.
-					<md>
-						<mrow> u'	 \amp =  y' = v \label{eq14-9}  </mrow>
-					</md>
-					Substituting into the first DE yields the following.
-					<md>
-						<mrow>  y'' + x	 \amp =  12 \nonumber </mrow>
-						<mrow>  v' + w	 \amp =  12 \nonumber </mrow>
-						<mrow>  v'	 \amp =  12 - w \label{eq14-10}  </mrow>
-					</md>
-					Substituting into the second DE yields the following.
-					<md>
-						<mrow>  w' + 2ut	 \amp =  \cos t \nonumber </mrow>
-						<mrow>  w'	 \amp =  \cos t - 2ut \label{eq14-11}  </mrow>
-					</md>
-					Then equations (\ref{eq14-9}), (\ref{eq14-10}) and (\ref{eq14-11}) constitute a system of first-order DEs in the variable <m>u </m> <m>v </m> , and <m>w </m> , as below:
-					<md>
-						<mrow>  u'	 \amp =  v </mrow>
-						<mrow>  v'	 \amp =  12 - w </mrow>
-						<mrow>  w'	 \amp =  \cos t - 2ut  </mrow>
-					</md>
-					
+						We have one second-order and one first-order DE, which means we will need three variables to generate a systemof three first-order DEs.\\ Let <m>u = y </m> <m>v = y', </m> and <m>w = x </m> .  Then we have the following.
+						<md>
+							<mrow> u'	 \amp =  y' = v \label{eq14-9}  </mrow>
+						</md>
+						Substituting into the first DE yields the following.
+						<md>
+							<mrow>  y'' + x	 \amp =  12 \nonumber </mrow>
+							<mrow>  v' + w	 \amp =  12 \nonumber </mrow>
+							<mrow>  v'	 \amp =  12 - w \label{eq14-10}  </mrow>
+						</md>
+						Substituting into the second DE yields the following.
+						<md>
+							<mrow>  w' + 2ut	 \amp =  \cos t \nonumber </mrow>
+							<mrow>  w'	 \amp =  \cos t - 2ut \label{eq14-11}  </mrow>
+						</md>
+						Then equations (\ref{eq14-9}), (\ref{eq14-10}) and (\ref{eq14-11}) constitute a system of first-order DEs in the variable <m>u </m> <m>v </m> , and <m>w </m> , as below:
+						<md>
+							<mrow>  u'	 \amp =  v </mrow>
+							<mrow>  v'	 \amp =  12 - w </mrow>
+							<mrow>  w'	 \amp =  \cos t - 2ut  </mrow>
+						</md>
 					</p>
 				</solution>
 				<answer>
@@ -1058,7 +1011,6 @@
 		<exercise>
 			<title>Euler's Method for Higher Order Systems</title>
 			
-			
 			<statement>
 				<p>
 					Use Euler's method to approximate <m>y(0.2)</m> for the solution to the IVP
@@ -1070,62 +1022,65 @@
 			</statement>
 			<solution>
 				<p>
-					First we convert the second-order DE to a system of two first-order DEs. Let <m>u = y </m> and <m>v = y' </m> .  Then \begin{equation} u' = y' = v\label{eq14-12} \end{equation} and \begin{equation} v' = (y')' = y''.\label{eq14-13} \end{equation} Substituting equations (\ref{eq14-12}) and (\ref{eq14-13}) into the DE yields the following.
-				<md>
-					<mrow>  y'' + 2y' + y^2	 \amp =  0 \nonumber  </mrow>
-					<mrow>  v' + 2v + u^2	 \amp =  0 \nonumber  </mrow>
-					<mrow>  v'	 \amp =  -2v - u^2 \label{eq14-14}  </mrow>
-				</md>
-				Then equations (\ref{eq14-12}) and (\ref{eq14-14}) constitute a system of first-order DEs in the variable <m>u </m> and <m>v </m> .
-				<md>
-					<mrow>  u'	 \amp =  v </mrow>
-					<mrow>  v'	 \amp =  -2v - u^2 </mrow>
-
-				</md>
-				Note that we can also convert the initial conditions to the new variables:
-				<md>
-					<mrow> u(0)	 \amp =  1 </mrow>
-					<mrow>  v(0)	 \amp =  2  </mrow>
-				</md>
-				Now we can use Euler's method as follows.
-				<md>
-					<mrow>  \mbox{Preliminaries:	}	\amp \amp	f_1(t,u,v)	 \amp =  v </mrow>
-					<mrow>  \amp \amp	f_2(t,u,v)	 \amp =  -2v-u^2 </mrow>
-					<mrow>  \amp \amp	h	 \amp =  0.1 </mrow>
-					<mrow>  \amp \amp	t_0	 \amp =  0 </mrow>
-					<mrow>  \amp \amp	u_0	 \amp =  1 </mrow>
-					<mrow>  \amp \amp	v_0	 \amp =  2 </mrow>
-					<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	t_1	 \amp =  t_0 + h </mrow>
-					<mrow>  \amp \amp		 \amp =  0 + 0.1 </mrow>
-					<mrow>  \amp \amp		 \amp =  0.1 </mrow>
-					<mrow>  \amp \amp	u_1	 \amp =  u_0 + h \cdot f_1(t_0,u_0,v_0) </mrow>
-					<mrow>  \amp \amp		 \amp =  1 + 0.1 \cdot f_1(0,1,2) </mrow>
-					<mrow>  \amp \amp		 \amp =  1 + 0.1 \cdot [2] </mrow>
-					<mrow>  \amp \amp		 \amp =  1.2 </mrow>
-					<mrow>  \amp \amp	v_1	 \amp =  v_0 + h\cdot f_2(t_0,u_0,v_0) </mrow>
-					<mrow>  \amp \amp		 \amp =  2 + 0.1 \cdot f_2(0,1,2) </mrow>
-					<mrow>  \amp \amp		 \amp =  2 + 0.1 \cdot [-2(2) - (1)^2] </mrow>
-					<mrow>  \amp \amp		 \amp =  1.5 </mrow>
-					<mrow>  \amp \amp		 \amp \mbox{Iteration 2:}		\amp \amp	t_2	 \amp =  t_1 + h </mrow>
-					<mrow>  \amp \amp		 \amp =  0.1 + 0.1 </mrow>
-					<mrow>  \amp \amp		 \amp =  0.2 </mrow>
-					<mrow>  \amp \amp	u_2	 \amp =  u_1 + h \cdot f_1(t_1,u_1,v_1) </mrow>
-					<mrow>  \amp \amp		 \amp =  1.2 + 0.1 \cdot f_1(0.1, 1.2, 1.5) </mrow>
-					<mrow>  \amp \amp		 \amp =  1.2 + 0.1 \cdot [1.5] </mrow>
-					<mrow>  \amp \amp		 \amp =  1.35 </mrow>
-					<mrow>  \amp \amp	v_2	 \amp =  v_1 + h\cdot f_2(t_1,u_1,v_1) </mrow>
-					<mrow>  \amp \amp		 \amp =  1.5 + 0.1 \cdot f_2(0.1, 1.2, 1.5) </mrow>
-					<mrow>  \amp \amp		 \amp =  1.5 + 0.1 \cdot [-2(1.5) - (1.2)^2] </mrow>
-					<mrow>  \amp \amp		 \amp =  1.0560  </mrow>
-				</md>
-				Therefore <m>u(0.2) \approx 1.35 </m> and <m>v(0.2) \approx 1.0560. </m>	This mean <m>y(0.2) \approx 1.35 </m> (and, even though we were not asked for it specifically <m>y'(0.2) \approx 1.0560 </m> ).
+					First, we convert the second-order DE to a system of two first-order DEs. Let <m>u = y </m> and <m>v = y' </m>. Then
+					<men xml:id="uprime-is-yprime">
+						u' = y' = v
+					</men>
+					and 
+					<men xml:id="vprime-is-yprimeprime">
+						v' = (y')' = y''.
+					</men>
+					Substituting equations <xref ref="uprime-is-yprime"/> and <xref ref="vprime-is-yprimeprime"/> into the DE yields the following:
+					<mdn>
+						<mrow>  y'' + 2y' + y^2	 \amp =  0  </mrow>
+						<mrow>  v' + 2v + u^2	 \amp =  0  </mrow>
+						<mrow xml:id="yprimeprime-de">  v'	 \amp =  -2v - u^2  </mrow>
+					</mdn>
+					Then equations <xref ref="uprime-is-yprime"/> and <xref ref="yprimeprime-de"/> constitute a system of first-order DEs in the variable <m>u</m> and <m>v</m>.
+					<md>
+						<mrow>  u'	 \amp =  v </mrow>
+						<mrow>  v'	 \amp =  -2v - u^2 </mrow>
+					</md>
+					Note that we can also convert the initial conditions to the new variables:
+					<md>
+						<mrow> u(0)	 \amp =  1 </mrow>
+						<mrow> v(0)	 \amp =  2  </mrow>
+					</md>
+					Now we can use Euler's method as follows.
+					<md>
+						<mrow>  \mbox{Preliminaries:	}	\amp \amp	f_1(t,u,v)	 \amp =  v </mrow>
+						<mrow>  \amp \amp	f_2(t,u,v)	 \amp =  -2v-u^2 </mrow>
+						<mrow>  \amp \amp	h	 \amp =  0.1 </mrow>
+						<mrow>  \amp \amp	t_0	 \amp =  0 </mrow>
+						<mrow>  \amp \amp	u_0	 \amp =  1 </mrow>
+						<mrow>  \amp \amp	v_0	 \amp =  2 </mrow>
+						<mrow>  \amp \amp		 \amp \mbox{Iteration 1:}		\amp \amp	t_1	 \amp =  t_0 + h </mrow>
+						<mrow>  \amp \amp		 \amp =  0 + 0.1 </mrow>
+						<mrow>  \amp \amp		 \amp =  0.1 </mrow>
+						<mrow>  \amp \amp	u_1	 \amp =  u_0 + h \cdot f_1(t_0,u_0,v_0) </mrow>
+						<mrow>  \amp \amp		 \amp =  1 + 0.1 \cdot f_1(0,1,2) </mrow>
+						<mrow>  \amp \amp		 \amp =  1 + 0.1 \cdot [2] </mrow>
+						<mrow>  \amp \amp		 \amp =  1.2 </mrow>
+						<mrow>  \amp \amp	v_1	 \amp =  v_0 + h\cdot f_2(t_0,u_0,v_0) </mrow>
+						<mrow>  \amp \amp		 \amp =  2 + 0.1 \cdot f_2(0,1,2) </mrow>
+						<mrow>  \amp \amp		 \amp =  2 + 0.1 \cdot [-2(2) - (1)^2] </mrow>
+						<mrow>  \amp \amp		 \amp =  1.5 </mrow>
+						<mrow>  \amp \amp		 \amp \mbox{Iteration 2:}		\amp \amp	t_2	 \amp =  t_1 + h </mrow>
+						<mrow>  \amp \amp		 \amp =  0.1 + 0.1 </mrow>
+						<mrow>  \amp \amp		 \amp =  0.2 </mrow>
+						<mrow>  \amp \amp	u_2	 \amp =  u_1 + h \cdot f_1(t_1,u_1,v_1) </mrow>
+						<mrow>  \amp \amp		 \amp =  1.2 + 0.1 \cdot f_1(0.1, 1.2, 1.5) </mrow>
+						<mrow>  \amp \amp		 \amp =  1.2 + 0.1 \cdot [1.5] </mrow>
+						<mrow>  \amp \amp		 \amp =  1.35 </mrow>
+						<mrow>  \amp \amp	v_2	 \amp =  v_1 + h\cdot f_2(t_1,u_1,v_1) </mrow>
+						<mrow>  \amp \amp		 \amp =  1.5 + 0.1 \cdot f_2(0.1, 1.2, 1.5) </mrow>
+						<mrow>  \amp \amp		 \amp =  1.5 + 0.1 \cdot [-2(1.5) - (1.2)^2] </mrow>
+						<mrow>  \amp \amp		 \amp =  1.0560  </mrow>
+					</md>
+					Therefore <m>u(0.2) \approx 1.35 </m> and <m>v(0.2) \approx 1.0560. </m>	This means <m>y(0.2) \approx 1.35 </m> (and, even though we were not asked for it specifically, <m>y'(0.2) \approx 1.0560 </m>).
 				</p>
 			</solution>
-			<answer>
-				<p>
-					<m>y(0.2) \approx 1.35 </m>
-				</p>
-			</answer>
+			<answer><p><m>y(0.2) \approx 1.35 </m></p></answer>
 		</exercise>
 
 		<exercise>
@@ -1143,13 +1098,21 @@
 
 			<solution>
 				<p>
-					First we convert the second-order DE to a system of two first-order DEs. Let <m>u = y </m> and <m>v = y' </m> .  Then \begin{equation} u' = y' = v\label{eq14-15} \end{equation} and \begin{equation} v' = (y')' = y''.\label{eq14-16} \end{equation} Substituting equations (\ref{eq14-14}) and (\ref{eq14-15}) into the DE yields the following.
+					First, we convert the second-order DE to a system of two first-order DEs. Let <m>u = y </m> and <m>v = y' </m>. Then
+					<men xml:id="uprime-is-yprime2">
+						u' = y' = v
+					</men>
+					and 
+					<men xml:id="vprime-is-yprimeprime2">
+						v' = (y')' = y''.
+					</men>
+					Substituting equations <xref ref="uprime-is-yprime2"/> and <xref ref="vprime-is-yprimeprime2"/> into the DE yields the following:
 					<md>
 						<mrow>  y'' - 2y	 \amp =  e^{t-3} \cos t \nonumber  </mrow>
 						<mrow>  v' - 2u	 \amp =  e^{t-3}\cos t \nonumber  </mrow>
-						<mrow>  v'	 \amp =  e^{t-3}\cos t +2u \label{eq14-17}  </mrow>
+						<mrow xml:id="yprimeprime-de2">  v'	 \amp =  e^{t-3}\cos t +2u  </mrow>
 					</md>
-					Then equations (\ref{eq14-15}) and (\ref{eq14-17}) constitute a system of first-order DEs in the variable <m>u </m> and <m>v </m> .
+					Then equations <xref ref="uprime-is-yprime2"/> and <xref ref="yprimeprime-de2"/> constitute a system of first-order DEs in the variable <m>u</m> and <m>v</m>:
 					<md>
 						<mrow>  u'	 \amp =  v </mrow>
 						<mrow>  v'	 \amp =  e^{t-3}\cos t +2u  </mrow>
@@ -1157,7 +1120,7 @@
 					Note that we can also convert the initial conditions to the new variables:
 					<md>
 						<mrow> u(3)	 \amp =  -1 </mrow>
-						<mrow>  v(3)	 \amp =  0  </mrow>
+						<mrow> v(3)	 \amp =  0  </mrow>
 					</md>
 					Now we can use Euler's method as follows.
 					<md>
@@ -1179,14 +1142,10 @@
 						<mrow>  \amp \amp		 \amp =  0 + 0.2 \cdot [e^{3-3}\cos(3) + 2(-1)] </mrow>
 						<mrow>  \amp \amp		 \amp =  -0.5980  </mrow>
 					</md>
-					Therefore <m>u(3.2) \approx -1 </m> , which mean <m>y(3.2) \approx -1 </m> (and, even though we were not asked for it specifically, we also know <m>y'(3.2) \approx -0.5980 </m> ).
+					Therefore <m>u(3.2) \approx -1 </m>, which means <m>y(3.2) \approx -1 </m> (and, even though we were not asked for it specifically, we also know <m>y'(3.2) \approx -0.5980 </m>).
 				</p>
 			</solution>
-
-			<answer>
-				<p><m>y(3.2) \approx -1</m></p>
-			</answer>
-		
+			<answer><p><m>y(3.2) \approx -1</m></p></answer>
 		</exercise>
 
 		<exercise>
@@ -1203,7 +1162,7 @@
 
 			<solution>
 				<p>
-					We will use the system of DEs developed in part \ref{partA_euler} Now we can use Euler's method as follows.
+					We will use the system of DEs developed earlier and use Euler's method as follows:
 					<md>
 						<mrow>  \mbox{Preliminaries:	}	\amp \amp	f_1(t,u,v)	 \amp =  v </mrow>
 						<mrow>  \amp \amp	f_2(t,u,v)	 \amp =  e^{t-3}\cos t +2u </mrow>
@@ -1234,14 +1193,10 @@
 						<mrow>  \amp \amp		 \amp =  -0.2990 + 0.1 \cdot [e^{3.1 - 3}\cos(3.1) + 2(-1)] </mrow>
 						<mrow>  \amp \amp		 \amp =  -0.6094  </mrow>
 					</md>
-					Therefore <m>u(3.2) \approx -1.0299 </m> , which mean <m>y(3.2) \approx -1.0299 </m> (and, even though we were not asked for it specifically, we also know <m>y'(3.2) \approx -0.6094 </m> ).\\ %
+					Therefore <m>u(3.2) \approx -1.0299 </m>, which means <m>y(3.2) \approx -1.0299 </m> (and, even though we were not asked for it specifically, we also know <m>y'(3.2) \approx -0.6094 </m>).
 				</p>
 			</solution>
-
-			<answer>
-				<p><m>y(3.2) \approx -1.0299 </m></p>
-			</answer>
-		
+			<answer><p><m>y(3.2) \approx -1.0299 </m></p></answer>
 		</exercise>
 	</exercises>
 	

--- a/source/c13-linsys/exercises-linsys.ptx
+++ b/source/c13-linsys/exercises-linsys.ptx
@@ -59,11 +59,11 @@
 					</choice>
 					<choice correct="no">
 						<statement><p>This is an uncoupled system.</p></statement>
-						<feedback><p>Not quite — notice that <m>x</m> shows up in the <m>dy/dt</m> equation.</p></feedback>
+						<feedback><p>Not quite — notice that <m>y</m> shows up in the <m>dx/dt</m> equation.</p></feedback>
 					</choice>
 					<choice correct="yes">
 						<statement><p>You must solve for <m>y</m> before you can solve for <m>x</m>.</p></statement>
-						<feedback><p>Actually, you can solve <m>x</m> first since it's independent.</p></feedback>
+						<feedback><p>Yes — solve <m>y</m> first (it is independent), then use it to solve for <m>x</m>.</p></feedback>
 					</choice>
 				</choices>
 			</task>
@@ -220,7 +220,7 @@
 				</statement>
 				<solution>
 					<p>
-						We can take the LT of each DE.  The result is two algebraic equations in two unknowns <m>X(s) </m> an <m>Y(s). </m>  We will solve the equations simultaneously as shown below.
+						We can take the LT of each DE.  The result is two algebraic equations in two unknowns <m>X(s) </m> and <m>Y(s). </m>  We will solve the equations simultaneously as shown below.
 						<md>
 							<mrow>  \frac{dx}{dt}	 \amp =  -x+y				\amp			\frac{dy}{dt}	\amp = 2x </mrow>
 							<mrow>  \lap{\frac{dx}{dt}}	 \amp =  \lap{-x+y}		\amp	\lap{\frac{dy}{dt}}	\amp = \lap{2x} </mrow>
@@ -238,7 +238,7 @@
 							<mrow>   \amp =  \frac{1}{(s+2)(s-1)}\cdot (s+1)	\amp						\amp </mrow>
 							<mrow>   \amp =  \frac{s+1}{(s+2)(s-1)}			\amp						\amp  </mrow>
 						</md>
-						We need only take the inverse LT of each function in order to solve for the desired function <m>x(t) </m> an <m>y(t). </m> This means we will need to find a partial fraction decomposition for each.
+						We need only take the inverse LT of each function in order to solve for the desired function <m>x(t) </m> and <m>y(t). </m> This means we will need to find a partial fraction decomposition for each.
 						<md>
 							<mrow>  \frac{1}{(s+2)(s-1)}	 \amp =  \frac{A}{s+2} + \frac{B}{s-1} </mrow>
 							<mrow>  1	 \amp =  A(s-1) + B(s+2) </mrow>
@@ -388,7 +388,7 @@
 							<mrow>   \amp =  \frac{-s-5}{s^2 + 9} </mrow>
 
 						</md>
-						We need only take the inverse LT of each function in order to solve for the desired functions <m>x(t) </m> an <m>y(t). </m>
+						We need only take the inverse LT of each function in order to solve for the desired functions <m>x(t) </m> and <m>y(t). </m>
 						<md>
 							<mrow>  x(t)	 \amp =   \lap^{-1}\left\{ X(s) \right\} </mrow>
 							<mrow>   \amp =  \lap^{-1}\left\{ \frac{-s-5}{s^2 + 9} \right\}  </mrow>
@@ -502,7 +502,7 @@
 							<mrow>   \amp =  \frac{s(s+1)}{s^2(s-3)(s+2)} </mrow>
 							<mrow>   \amp =  \frac{s+1}{s(s-3)(s+2)}  </mrow>
 						</md>
-						We need only take the inverse LT of each function in order to solve for the desired function <m>x(t) </m> an <m>y(t). </m> This means we will need to find a partial fraction decomposition for each.
+						We need only take the inverse LT of each function in order to solve for the desired function <m>x(t) </m> and <m>y(t). </m> This means we will need to find a partial fraction decomposition for each.
 						<md>
 							<mrow>  \frac{s+3}{s(s-3)(s+2)}	 \amp =  \frac{A}{s} + \frac{B}{s-3} + \frac{C}{s+2} </mrow>
 							<mrow>  s+3	 \amp =  A(s-3)(s+2) + B(s)(s+2) + C(s)(s-3) </mrow>
@@ -638,11 +638,13 @@
 
 		<exercise>
 			<statement>
-				A brine solution of salt flows at a constant rate of 4 L/min into a large tank that initially he of pure water.  The solution inside the tank is kept well-stirred and flows out of the tank at a rate of 3 L/min. Suppose the concentration of salt in the brine entering the tank is <m>0.2</m> kg/L. Then
+				A brine solution of salt flows at a constant rate of 4 L/min into a large tank that initially is pure water.  The solution inside the tank is kept well-stirred and flows out of the tank at a rate of 3 L/min. Suppose the concentration of salt in the brine entering the tank is <m>0.2</m> kg/L. Then
+				<p>
 				<ol marker="(a)">
-					<li>Determine the mass of the salt in the tank afte <m>t </m> minutes.</li>
+					<li>Determine the mass of the salt in the tank after <m>t </m> minutes.</li>
 					<li>What is the concentration of salt after one hour?</li>
 				</ol>
+				</p>
 			</statement>
 			<solution>
 				<p>
@@ -691,6 +693,11 @@
 					<mrow> v' \amp = u </mrow>
 				</md>
 			</solution>
+			<answer>
+				<p>
+					<m>u' = v, \quad v' = u</m>
+				</p>
+			</answer>
 		</exercise>
 
 		<exercisegroup>
@@ -704,7 +711,7 @@
 			<exercise>
 				<statement>
 					<p>
-						Write a system of differential equations for<m>x_1(t) </m> (the amount of salt, in kg, in tank 1 at tim <m>t </m> )an <m>x_2(t) </m> (the amount of salt, in kg, in tank 2 at tim <m>t </m> ).
+						Write a system of differential equations for<m>x_1(t) </m> (the amount of salt, in kg, in tank 1 at tim <m>t </m> )and <m>x_2(t) </m> (the amount of salt, in kg, in tank 2 at tim <m>t </m> ).
 					</p>
 				</statement>
 				<solution>
@@ -739,7 +746,7 @@
 			<exercise>
 				<statement>
 					<p>
-						How many initial conditions will you need to find a particularsolution? Write the initial conditions.
+						How many initial conditions will you need to find a particular solution? Write the initial conditions.
 					</p>
 				</statement>
 				<solution>
@@ -749,7 +756,7 @@
 				</solution>
 				<answer>
 					<p>
-						two <m>x_1(0) = 0 </m> an <m>x_2(0) = 6 </m>
+						two <m>x_1(0) = 0 </m> and <m>x_2(0) = 6 </m>
 					</p>
 				</answer>
 			</exercise>
@@ -757,17 +764,17 @@
 			<exercise>
 				<statement>
 					<p>
-						Why can't we solve each of the DEs you found individually usingtechniques we already know?
+						Why can't we solve each of the DEs you found individually using techniques we already know?
 					</p>
 				</statement>
 				<solution>
 					<p>
-						We can't solve this system using techniques we already know becaus <m>x_1(t) </m> an <m>x_2(t) </m> are both unknown functions, and each DE contains BOTH of the unknowns.  All of the techniques we have so far help us solve for a single unknown function.
+						We can't solve this system using techniques we already know because <m>x_1(t) </m> and <m>x_2(t) </m> are both unknown functions, and each DE contains BOTH of the unknowns.  All of the techniques we have so far help us solve for a single unknown function.
 					</p>
 				</solution>
 				<answer>
 					<p>
-						<m>x_1(t) </m> an <m>x_2(t) </m> are both unknown functions, and each DE contains BOTH of the unknowns
+						<m>x_1(t) </m> and <m>x_2(t) </m> are both unknown functions, and each DE contains BOTH of the unknowns
 					</p>
 				</answer>
 			</exercise>
@@ -776,12 +783,13 @@
 
 		<exercise>
 			<statement>
-				A simplified mathematical model for an arms race between two countries whose expenditures for %	defense are expressed by the variable <m>x(t)</m> an <m>y(t)</m> is given by the linear system
+				A simplified mathematical model for an arms race between two countries whose expenditures for %	defense are expressed by the variable <m>x(t)</m> and <m>y(t)</m> is given by the linear system
 				<md>
 					<mrow>  \frac{dx}{dt}	 \amp =  2y - x + a		\amp x(0) = 1</mrow>
 					<mrow>  \frac{dy}{dt}	 \amp =  4x - 3y + b	\amp y(0) = 4</mrow>
 				</md>
 				where <m>a </m> and <m>b </m> are constants that measure the trust (or distrust!) each country has for the other.
+				<p>
 				<ol marker="(a)">
 					<li>What might be appropriate units for <m>x(t) </m> and <m>y(t)</m>?</li>
 					<li>
@@ -794,7 +802,7 @@
 					</li>
 					<li>
 						Suppose country X trusts country Y, but country Y doesn't trust country X.
-						What can we say abou <m>a</m> and <m>b</m>?
+						What can we say about <m>a</m> and <m>b</m>?
 						Should they be positive, negative or zero?</li>
 					<li>
 						Rewrite the system of differential equations in matrix form by using the vector
@@ -806,6 +814,7 @@
 						<m>\vec{X}(0) = \begin{bmatrix} ?\\? \end{bmatrix}</m>
 					</li>
 				</ol>
+				</p>
 			</statement>
 			<solution>
 				<p>
@@ -844,7 +853,7 @@
 						<ol>
 							<li>
 								In the first equation, explain why it makes sense for <m>y</m> to have a positive coefficient
-								an <m>x </m> to have a negative coefficient.
+								and <m>x </m> to have a negative coefficient.
 							</li>
 							<li>
 								Notice that if we add these two equations, we get
@@ -888,6 +897,11 @@
 						</me>
 					</p>
 				</solution>
+			<answer>
+				<me>
+					\frac{dy}{dt} \amp = 5 - 2 \frac{y(t)}{100 - 2t}
+				</me>
+			</answer>
 			</exercise>
 
 		</exercisegroup>
@@ -952,7 +966,7 @@
 							<mrow>  \amp \amp		 \amp =  2.6 + 0.1 \cdot [7] </mrow>
 							<mrow>  \amp \amp		 \amp =  3.3  </mrow>
 						</md>
-						Therefore <m>x(0.2) \approx 8.15 </m> an <m>y(0.2) \approx 3.3. </m>
+						Therefore <m>x(0.2) \approx 8.15 </m> and <m>y(0.2) \approx 3.3. </m>
 					</p>
 				</solution>
 				<answer>
@@ -1009,7 +1023,7 @@
 				</statement>
 				<solution>
 					<p>
-				We have one second-order and one first-order DE, which means we will need three variables to generate a systemof three first-order DEs.\\ Let <m>u = y </m> <m>v = y', </m> an <m>w = x </m> .  Then we have the following.
+				We have one second-order and one first-order DE, which means we will need three variables to generate a systemof three first-order DEs.\\ Let <m>u = y </m> <m>v = y', </m> and <m>w = x </m> .  Then we have the following.
 					<md>
 						<mrow> u'	 \amp =  y' = v \label{eq14-9}  </mrow>
 					</md>
@@ -1035,7 +1049,7 @@
 				</solution>
 				<answer>
 					<p>
-						<m>u' = v,v' = 12 - w,w' = \cos t - 2ut </m> where <m>u = y,v = y', </m> an <m>w = x </m>
+						<m>u' = v,v' = 12 - w,w' = \cos t - 2ut </m> where <m>u = y,v = y', </m> and <m>w = x </m>
 					</p>
 				</answer>
 			</exercise>
@@ -1104,7 +1118,7 @@
 					<mrow>  \amp \amp		 \amp =  1.5 + 0.1 \cdot [-2(1.5) - (1.2)^2] </mrow>
 					<mrow>  \amp \amp		 \amp =  1.0560  </mrow>
 				</md>
-				Therefore <m>u(0.2) \approx 1.35 </m> an <m>v(0.2) \approx 1.0560. </m>	This mean <m>y(0.2) \approx 1.35 </m> (and, even though we were not asked for it specifically <m>y'(0.2) \approx 1.0560 </m> ).
+				Therefore <m>u(0.2) \approx 1.35 </m> and <m>v(0.2) \approx 1.0560. </m>	This mean <m>y(0.2) \approx 1.35 </m> (and, even though we were not asked for it specifically <m>y'(0.2) \approx 1.0560 </m> ).
 				</p>
 			</solution>
 			<answer>


### PR DESCRIPTION
# Notes — exercises-linsys_MC-edit
- Chapter: c13-linsys (from FYI tree)
- Date: 2026-01-18

## Summary
This pass focused on **copy/paste mismatches**, **missing answer tags**, and **PTX list-in-<p> compliance**, with a few high-confidence typo fixes.

## Applied changes

### FeedbackRepair (allowed exception)
- M-001 | linsys-cq-1 | corrected feedback to match dependencies in the displayed system (x depends on y; y independent).

### AnswerTagRepair (allowed exception)
- C-001 | ex-second-order-to-system | inserted missing <answer> (verbatim terminal system).
- C-002 | salt tank DE exercise | inserted missing <answer> (copied terminal DE from solution).

### PTX list rule repair (allowed structural repair)
- C-003 | brine mixing exercise | wrapped the (a)-(b) <ol> in a minimal <p> wrapper.
- C-004 | arms race exercise | wrapped the (a)-(f) <ol> in a minimal <p> wrapper.

### Copy-edit (high-confidence, local)
- C-010 | brine mixing exercise | “initially he of” → “initially is”.
- C-011 | brine mixing exercise | “afte” → “after”.
- C-012 | arms race exercise | “abou” → “about”.
- C-013 | initial conditions prompt | “particularsolution” → “particular solution”.
- C-014 | coupled-system prompt | “usingtechniques” → “using techniques”.
- C-015 | coupled-system solution | “becaus” → “because”.
- C-016 | file-wide (14 hits) | “ an <m>” → “ and <m>” where clearly intended as conjunction before math.

## VERIFY-REQUIRED
- None flagged in this pass.