### PR TITLE
Update sec-linear-systems.ptx

### DIFF
--- a/source/c13-linsys/sec-linear-systems.ptx
+++ b/source/c13-linsys/sec-linear-systems.ptx
@@ -87,12 +87,12 @@
 		</p>
 
 		<p>
-			Matrix multiplication then packages both equations into the single vector equation
+			Matrix multiplication then packages both equations into a single vector equation
 			<me>\frac{dY}{dt} = AY.</me>
 		</p>
 
 		<p>
-			This compact format presents the system as a single equation, linking directly to linear algebra tools like eigenvalues, which we will explore later.
+			This compact format presents the system as a single equation, linking directly to linear-algebra tools such as eigenvalues, which we will explore later.
 		</p>
 	</subsection>
 

--- a/source/c13-linsys/sec-linear-systems.ptx
+++ b/source/c13-linsys/sec-linear-systems.ptx
@@ -32,7 +32,7 @@
 
 		<p>
 			A system is <em>linear</em> if every equation is linear with respect to its dependent variables (all to the power of one). For two variables
-			<m>x(t)</m> and <m>y(t)</m> general form is
+			<m>x(t)</m> and <m>y(t)</m> the general form is
 			<md>
 				<mrow>\frac{dx}{dt} \amp = a x + b y</mrow>
 				<mrow>\frac{dy}{dt} \amp = c x + d y</mrow>
@@ -43,7 +43,7 @@
 		<exercise>
 			<statement>
 				<p>
-					Select of linearity of each equation, then select the linearity of the system.
+					Select the linearity of each equation, then select the linearity of the system.
 				</p>
 			</statement>
 			<areas>
@@ -100,7 +100,7 @@
 		<title>From Two to <m>n</m> Dimensions</title>
 
 		<p>
-			For <m>n</m> variables <m>y_1,\dots,y_n</m> a constant-coefficient linear system reads
+			For <m>n</m> variables <m>y_1,\dots,y_n</m>, a constant-coefficient linear system reads
 			<me>
 				\frac{dY}{dt} = AY,
 				\qquad
@@ -116,7 +116,7 @@
 
 		<p>
 			The dimension of the system equals the length of <m>Y</m>.  
-			Our focus this chapter remains on the planar case (<m>n=2</m>) where geometry and
+			Our focus in this chapter remains on the planar case (<m>n=2</m>) where geometry and
 			algebra meet most clearly.
 		</p>
 
@@ -215,12 +215,14 @@
 					</choice>
 					<choice correct="no">
 						<statement><m>\ds\quad\left\{\ \begin{array}{l} x' = xy,\\ y' = x - y^2\end{array}\right.</m></statement>
+						<feedback><p>The product <m>xy</m> and the square <m>y^2</m> make this nonlinear.</p></feedback>
 					</choice>
 					<choice correct="yes">
 						<statement><m>\ds\quad\left\{\ \begin{array}{l} x' = -y,\\ y' = x\end{array}\right.</m></statement>
 					</choice>
 					<choice correct="no">
 						<statement><m>\ds\quad\left\{\ \begin{array}{l} x' = \sin x + y,\\ y' = x\end{array}\right.</m></statement>
+						<feedback><p>The <m>\sin x</m> term makes this nonlinear.</p></feedback>
 					</choice>
 				</choices>
 			</task>


### PR DESCRIPTION
# c13 — sec-linear-systems (Looser Set v1.9) — 2026-01-18

Totals: VR=0, M=2, C=4

## VERIFY-REQUIRED (applied) — FIRST
(none)

## Math/logic (applied)
M-001 | linear-systems-basics-cyu-2 | added feedback for nonlinear choice (xy, y^2) | why:missing feedback M-002 | linear-systems-basics-cyu-2 | added feedback for nonlinear choice (sin x) | why:missing feedback

## Copy edits (applied)
C-001 | “general form is” | inserted “the” ("the general form is") C-002 | “Select of linearity” | corrected to “Select the linearity” C-003 | “y_1,\dots,y_n” | inserted comma after y_n C-004 | “focus this chapter” | inserted “in” ("focus in this chapter")

## References
(none — V0 only)