### PR TITLE
Update sec-qualitative-methods-systems.ptx

### DIFF
--- a/source/c13-linsys/sec-qualitative-methods-systems.ptx
+++ b/source/c13-linsys/sec-qualitative-methods-systems.ptx
@@ -20,47 +20,47 @@
 	</introduction>
 
 	<subsection xml:id="phase-plane">
-			<title>Phase Planes and Direction Fields</title>
+		<title>Phase Planes and Direction Fields</title>
 
-			<p>
-				One of the best ways to understand a system — especially a linear one — is to <em>see it</em>.
-			</p>
+		<p>
+			One of the best ways to understand a system — especially a linear one — is to <em>see it</em>.
+		</p>
 
-			<p>
-				The <em>phase plane</em> is a two-dimensional space where we plot one variable on the horizontal axis and the other on the vertical axis. A solution to the system becomes a <em>trajectory</em> — a path through the plane traced as time flows.
-			</p>
+		<p>
+			The <em>phase plane</em> is a two-dimensional space where we plot one variable on the horizontal axis and the other on the vertical axis. A solution to the system becomes a <em>trajectory</em> — a path through the plane traced as time flows.
+		</p>
 
-			<p>
-				To see the <q>push</q> of the system without fully solving it, we can draw a <em>direction field</em> (or slope field): at each point <m>(x, y)</m>, we sketch a small arrow showing the vector <m>(dx/dt, dy/dt)</m>.
-			</p>
+		<p>
+			To see the <q>push</q> of the system without fully solving it, we can draw a <em>direction field</em> (or slope field): at each point <m>(x, y)</m>, we sketch a small arrow showing the vector <m>(dx/dt, dy/dt)</m>.
+		</p>
 
-			<example xml:id="ex-phase-plane">
-					<title>Direction Field of an Uncoupled System</title>
-					<statement>
-							<p>
-									Consider the uncoupled system:
-							</p>
-							<md>
-									<mrow>\frac{dx}{dt} \amp = -x</mrow>
-									<mrow>\frac{dy}{dt} \amp = -2y</mrow>
-							</md>
-							<p>
-									In the phase plane, every trajectory moves toward the origin — 
-									trajectories are generally curved (except along the axes, which are straight-line solutions), since <m>x</m> and <m>y</m> decay independently at different rates.
-							</p>
-					</statement>
-			</example>
+		<example xml:id="ex-phase-plane">
+			<title>Direction Field of an Uncoupled System</title>
+			<statement>
+				<p>
+					Consider the uncoupled system:
+					<md>
+						<mrow>\frac{dx}{dt} \amp = -x</mrow>
+						<mrow>\frac{dy}{dt} \amp = -2y</mrow>
+					</md>
+				</p>
+				<p>
+					In the phase plane, every trajectory moves toward the origin — 
+					trajectories are generally curved (except along the axes, which are straight-line solutions), since <m>x</m> and <m>y</m> decay independently at different rates.
+				</p>
+			</statement>
+		</example>
 
-			<p>
-				For more interesting systems — like ones with partial or full coupling — the direction field can show curved paths, spirals, or saddle-shaped flows. This visual approach helps us predict system behavior even before we dive into equations.
-			</p>
+		<p>
+			For more interesting systems — like ones with partial or full coupling — the direction field can show curved paths, spirals, or saddle-shaped flows. This visual approach helps us predict system behavior even before we dive into equations.
+		</p>
 	</subsection>
 
 	<subsection label="visualizing-systems">
 		<title>Visualization Tools</title>
 
 		<p>
-			So far, we've seen examples of systems where variables evolve independently or influence each other. Now let's step back and look at how to visualize a system as a whole.
+			So far, we've seen examples of systems in which variables evolve independently or influence one another. Now let's step back and look at how to visualize a system as a whole.
 		</p>
 
 		<p>
@@ -84,42 +84,44 @@
 		</p>
 
 		<p>
-			Each arrow represents the vector <m>(dx/dt, dy/dt)</m> at a point <m>(x, y)</m>. Together, they show how the system wants to evolve.
+			Each arrow represents the vector <m>(dx/dt, dy/dt)</m> at a point <m>(x, y)</m>. Together, they show how the system is evolving.
 		</p>
 
 		<example xml:id="ex-slopefield-uncoupled">
 			<title>Phase Portrait of an Uncoupled System</title>
+
 			<statement>
-			<p>
-				Consider the system:
-			</p>
-			<md>
-				<mrow> \frac{dx}{dt} \amp = -x </mrow>
-				<mrow> \frac{dy}{dt} \amp = -2y </mrow>
-			</md>
-			<p>
-				The phase portrait shows trajectories curving toward the origin (the axes themselves are straight-line trajectories), because each variable decays independently at its own rate.
-			</p>
+				<p>
+					Consider the system:
+					<md>
+						<mrow> \frac{dx}{dt} \amp = -x </mrow>
+						<mrow> \frac{dy}{dt} \amp = -2y </mrow>
+					</md>
+				</p>
+				<p>
+					The phase portrait shows trajectories curving toward the origin (the axes themselves are straight-line trajectories), because each variable decays independently at its own rate.
+				</p>
 			</statement>
 		</example>
 
 		<p>
-			In more interesting systems, like partially coupled ones, the slope field reveals how the variables influence each other.
+			In more interesting systems, such as partially coupled ones, the slope field reveals how the variables interact.
 		</p>
 
 		<example xml:id="ex-slopefield-partial">
 			<title>Phase Portrait of a Partially Coupled System</title>
+
 			<statement>
-			<p>
-				For the system:
-			</p>
-			<md>
-				<mrow> \frac{dx}{dt} \amp = -x </mrow>
-				<mrow> \frac{dy}{dt} \amp = -y + 2x </mrow>
-			</md>
-			<p>
-				The phase portrait shows <m>x(t)</m> decaying, and <m>y(t)</m> temporarily increasing in response before decaying, reflecting the one-way interaction.
-			</p>
+				<p>
+					For the system:
+					<md>
+						<mrow> \frac{dx}{dt} \amp = -x </mrow>
+						<mrow> \frac{dy}{dt} \amp = -y + 2x </mrow>
+					</md>
+				</p>
+				<p>
+					The phase portrait shows <m>x(t)</m> decaying and <m>y(t)</m> temporarily increasing before decaying, reflecting the one-way interaction.
+				</p>
 			</statement>
 		</example>
 
@@ -127,27 +129,27 @@
 			Phase portraits help us understand the big picture: where solutions are headed, whether they spiral, diverge, or settle down.
 		</p>
 
-		<corollary><title>Euler's Method Visualized</title>
+		<corollary>
+			<title>Euler's Method Visualized</title>
+
 			<statement>
 				<p>
 					This interactive slope field shows the direction of motion for the system <m>x' = x + y</m>, <m>y' = -x + y</m>.
 					Each arrow represents the vector <m>(dx/dt, dy/dt)</m> at that location.
 				</p>
-				<p>
-					<sidebyside width="80%" margins="15% 5%">
-						<interactive xml:id="phase-plane-slopefield"
-							platform="jsxgraph"
-							aspect="1:1"
-							dark-mode-enabled="yes"
-							source="code/jsxgraph/visualizing-systems/phase-plane-slopefield.js"
-						>
-							<slate xml:id="phase-plane-slopefield-plot1" surface="jsxboard" aspect="1:1" />
-							<static>
-								<image source="code/jsxgraph/img-labels/t.png" width="70%"> Need to Add </image>
-							</static>
-						</interactive>
-					</sidebyside>
-				</p>
+				<sidebyside width="80%" margins="15% 5%">
+					<interactive xml:id="phase-plane-slopefield"
+						platform="jsxgraph"
+						aspect="1:1"
+						dark-mode-enabled="yes"
+						source="code/jsxgraph/visualizing-systems/phase-plane-slopefield.js"
+					>
+						<slate xml:id="phase-plane-slopefield-plot1" surface="jsxboard" aspect="1:1" />
+						<static>
+							<image source="code/jsxgraph/img-labels/t.png" width="70%"> Need to Add </image>
+						</static>
+					</interactive>
+				</sidebyside>
 			</statement>
 		</corollary>
 
@@ -192,7 +194,7 @@
 		</p>
 
 		<p>
-			Later, we'll connect these patterns to the algebra of the system's coefficients. But even now, these <q>big picture</q> behaviors help us think about what the math is saying.
+			Later, we'll connect these patterns to the algebra of the system's coefficients. But even now, these <q>big-picture</q> behaviors help us think about what the math is saying.
 		</p>
 
 		<exercise label="qualitative-methods-for-linear-systems-cyu-bundle">

--- a/source/c13-linsys/sec-qualitative-methods-systems.ptx
+++ b/source/c13-linsys/sec-qualitative-methods-systems.ptx
@@ -35,7 +35,7 @@
 			</p>
 
 			<example xml:id="ex-phase-plane">
-					<title>Phase Portrait of an Uncoupled System</title>
+					<title>Direction Field of an Uncoupled System</title>
 					<statement>
 							<p>
 									Consider the uncoupled system:
@@ -45,8 +45,8 @@
 									<mrow>\frac{dy}{dt} \amp = -2y</mrow>
 							</md>
 							<p>
-									In the phase plane, every trajectory moves straight toward the origin — 
-									<m>x</m> and <m>y</m> are simply decaying independently, so the arrows point inward along both axes.
+									In the phase plane, every trajectory moves toward the origin — 
+									trajectories are generally curved (except along the axes, which are straight-line solutions), since <m>x</m> and <m>y</m> decay independently at different rates.
 							</p>
 					</statement>
 			</example>
@@ -72,7 +72,7 @@
 		</p>
 
 		<p>
-			becomes a curve in the <m>(x, y)</m> plane: a path that the system traces over time. We often call this a <em>trajectory</em>.
+			Such a solution becomes a curve in the <m>(x, y)</m> plane: a path that the system traces over time. We often call this a <em>trajectory</em>.
 		</p>
 
 		<p>
@@ -98,7 +98,7 @@
 				<mrow> \frac{dy}{dt} \amp = -2y </mrow>
 			</md>
 			<p>
-				The phase portrait shows straight-line motion toward the origin along both axes, because each variable decays independently.
+				The phase portrait shows trajectories curving toward the origin (the axes themselves are straight-line trajectories), because each variable decays independently at its own rate.
 			</p>
 			</statement>
 		</example>


### PR DESCRIPTION
# sec-qualitative-methods-systems — MC edit notes

## Scope
Focused pass for copy/paste mismatches, dangling/fragmented prose, and high-confidence mathematical meaning issues. Minimal edits to avoid drift.

## Applied edits (high confidence)
- **Grammar/continuity: dangling sentence fixed**
  - Before: becomes a curve in the (x, y) plane:
  - After:  Such a solution becomes a curve in the (x, y) plane:
- **Math accuracy: uncoupled system phase portrait description**
  - Before: trajectories move straight toward the origin
  - After:  trajectories move toward the origin; generally curved except along axes
- **Clarity: duplicate example title reduced**
  - Before: Phase Portrait of an Uncoupled System (first occurrence)
  - After:  Direction Field of an Uncoupled System

## VERIFY-REQUIRED items (no automatic change made)
- PLACEHOLDER: Two <image> elements contain the literal text “Need to Add” inside <static> blocks. Confirm whether this should remain as a TODO or be removed/replaced before student-facing release.
- POTENTIAL-REDUNDANCY: The subsections “Phase Planes and Direction Fields” and “Visualization Tools” repeat core definitions and include very similar uncoupled examples. This may be intentional scaffolding, but it also looks like copy/paste duplication.

## Notes on the main math correction
For the uncoupled system x' = -x, y' = -2y, trajectories in the phase plane satisfy dy/dx = 2y/x, so typical solution curves are of the form y = C x^2 (parabolic), not straight lines (except along the coordinate axes).