### PR TITLE
Update sec-second-order-to-system.ptx

### DIFF
--- a/source/c13-linsys/sec-second-order-to-system.ptx
+++ b/source/c13-linsys/sec-second-order-to-system.ptx
@@ -15,7 +15,7 @@
 
 	<introduction>
 		<p>
-      So far, we've looked at systems that involve multiple variables like <m>x(t)</m> and <m>y(t)</m>. But what if you start with just a single second-order differential equation? It turns out you can rewrite it as a system of first-order equations.
+      So far, we've looked at systems involving multiple variables, such as <m>x(t)</m> and <m>y(t)</m>. But what if you start with just a single second-order differential equation? It turns out you can rewrite it as a system of first-order equations.
     </p>
 	</introduction>
 
@@ -24,17 +24,17 @@
 
 		<p>
 			For example, consider the second-order equation:
-			<me>y'' + 3y' + 2y = 0</me>
+			<me>y'' + 3y' + 2y = 0</me>.
 		</p>
 
 		<p>
 			This equation involves only one dependent variable, <m>y(t)</m>, but it's second-order. To convert it into a system, we introduce a new variable:
-			<me>u = y, \quad v = y'</me>
+			<me>u = y, \quad v = y'</me>.
 		</p>
 
 		<p>
 			That means <m>u' = y' = v</m>. And since <m>y'' = v'</m>, we can rewrite the original equation as:
-			<me>v' = -3v - 2u</me>
+			<me>v' = -3v - 2u</me>.
 		</p>
 
 		<p>
@@ -42,7 +42,7 @@
 			<md>
 				<mrow> u' \amp = v </mrow>
 				<mrow> v' \amp = -3v - 2u </mrow>
-			</md>
+			</md>.
 		</p>
 
 		<exercise label="second-order-to-system-chkpt-1">

--- a/source/c13-linsys/sec-second-order-to-system.ptx
+++ b/source/c13-linsys/sec-second-order-to-system.ptx
@@ -54,7 +54,7 @@
 			</statement>
 			<feedback>
 				<p>
-					Correct. Introducing <m>x_1 = y</m> and <m>x_2 = y'</m> allows us to write <m>y''</m> as <m>x_2'</m> and form a system.
+					Correct. Introducing two variables for <m>y</m> and <m>y'</m> (for example, <m>u=y</m>, <m>v=y'</m>, or <m>x_1=y</m>, <m>x_2=y'</m>) lets us write <m>y''</m> as the derivative of the second variable and form a first-order system.
 				</p>
 			</feedback>
 		</exercise>
@@ -66,7 +66,7 @@
 					<title><e component="emoji">📖❓</e> Understanding Converted Systems</title>
 					<statement>
 						<p>
-						When you convert a second-order equation into a first-order system, which of the following are always true?
+						When you convert a second-order equation into a first-order system, which of the following are always true? (Select all that apply.)
 						</p>
 					</statement>
 					<choices randomize="yes">


### PR DESCRIPTION
# sec-second-order-to-system — MC edit notes

## Scope
Copy/paste mismatch and assessment-coherence pass under Looser Set v1.9, with minimal edits to avoid drift.

## Applied edits (high confidence)
- CYU-1 prompt: clarify multi-correct as select-all-that-apply (instances: 1)
- Chkpt feedback: align notation with u,v example and x1,x2 later tasks (instances: 1)

## VERIFY-REQUIRED (no automatic change made)
- None.