### PR TITLE
Update sec-solving-linear-systems.ptx

### DIFF
--- a/source/c13-linsys/sec-solving-linear-systems.ptx
+++ b/source/c13-linsys/sec-solving-linear-systems.ptx
@@ -23,8 +23,8 @@
 
 		<p>
 			We'll start with a method that mirrors how we solved single constant-coefficient equations: 
-			we guess exponential solutions. This guess transforms the differential system into an algebra problem — 
-			one that will lead naturally to eigenvalues and eigenvectors.
+			We guess exponential solutions. This guess transforms the differential system into an algebraic problem — 
+			one that naturally leads to eigenvalues and eigenvectors.
 		</p>
 	</introduction>
 
@@ -112,7 +112,7 @@
 		<p>
 			This tells us something powerful:  
 			<ul marker="disc">
-				<li>Linear systems often have solutions made of exponentials.</li>
+				<li>Linear systems often have solutions that are exponential functions.</li>
 				<li>The allowed exponential rates <m>r</m> are the <em>eigenvalues</em> of <m>A</m>.</li>
 				<li>The corresponding coefficients <m>C</m> and <m>D</m> form the <em>eigenvectors</em>.</li>
 			</ul>
@@ -142,19 +142,17 @@
 
 				<p>
 					Find eigenvalues of <m>A</m> by solving <m>\det(A - rI) = 0</m>.
+					<me>
+						\det \begin{bmatrix} 1-r \amp 1 \\ 4 \amp 1-r \end{bmatrix} = (1-r)^2 - 4 = r^2 - 2r - 3.
+					</me>
 				</p>
-
-				<me>
-					\det \begin{bmatrix} 1-r \amp 1 \\ 4 \amp 1-r \end{bmatrix} = (1-r)^2 - 4 = r^2 - 2r - 3.
-				</me>
 
 				<p>
 					Set equal to zero: <m>r^2 - 2r - 3 = 0</m>. Factor:
+					<me>
+						(r - 3)(r + 1) = 0 \quad \Rightarrow \quad r_1 = 3, \ r_2 = -1.
+					</me>
 				</p>
-
-				<me>
-					(r - 3)(r + 1) = 0 \quad \Rightarrow \quad r_1 = 3, \ r_2 = -1.
-				</me>
 
 				<p>
 					Find eigenvectors for each eigenvalue.
@@ -162,50 +160,47 @@
 
 				<p>
 					<ul>
-					<li><term>For r = 3:</term> Solve <m>(A - 3I)\vec{v} = 0</m>.
-						<me>
-							\begin{bmatrix} -2 \amp 1 \\ 4 \amp -2 \end{bmatrix} \begin{bmatrix} v_1 \\ v_2 \end{bmatrix} = \begin{bmatrix} 0 \\ 0 \end{bmatrix}.
-						</me>
-						From the first row: <m>-2v_1 + v_2 = 0 \Rightarrow v_2 = 2v_1</m>.  
-						Choose <m>v_1 = 1</m>, giving eigenvector <m>\vec{v}_1 = \begin{bmatrix}1 \\ 2\end{bmatrix}</m>.
-					</li>
-
-					<li><term>For r = -1:</term> Solve <m>(A + I)\vec{v} = 0</m>.
-						<me>
-							\begin{bmatrix} 2 \amp 1 \\ 4 \amp 2 \end{bmatrix} \begin{bmatrix} v_1 \\ v_2 \end{bmatrix} = \begin{bmatrix} 0 \\ 0 \end{bmatrix}.
-						</me>
-						From the first row: <m>2v_1 + v_2 = 0 \Rightarrow v_2 = -2v_1</m>.  
-						Choose <m>v_1 = 1</m>, giving eigenvector <m>\vec{v}_2 = \begin{bmatrix}1 \\ -2\end{bmatrix}</m>.
-					</li>
-				</ul>
+						<li><term>For r = 3:</term> Solve <m>(A - 3I)\vec{v} = 0</m>.
+							<me>
+								\begin{bmatrix} -2 \amp 1 \\ 4 \amp -2 \end{bmatrix} \begin{bmatrix} v_1 \\ v_2 \end{bmatrix} = \begin{bmatrix} 0 \\ 0 \end{bmatrix}.
+							</me>
+							From the first row: <m>-2v_1 + v_2 = 0 \Rightarrow v_2 = 2v_1</m>.  
+							Choose <m>v_1 = 1</m>, giving eigenvector <m>\vec{v}_1 = \begin{bmatrix}1 \\ 2\end{bmatrix}</m>.
+						</li>
+	
+						<li><term>For r = -1:</term> Solve <m>(A + I)\vec{v} = 0</m>.
+							<me>
+								\begin{bmatrix} 2 \amp 1 \\ 4 \amp 2 \end{bmatrix} \begin{bmatrix} v_1 \\ v_2 \end{bmatrix} = \begin{bmatrix} 0 \\ 0 \end{bmatrix}.
+							</me>
+							From the first row: <m>2v_1 + v_2 = 0 \Rightarrow v_2 = -2v_1</m>.  
+							Choose <m>v_1 = 1</m>, giving eigenvector <m>\vec{v}_2 = \begin{bmatrix}1 \\ -2\end{bmatrix}</m>.
+						</li>
+					</ul>
 				</p>
 
 				<p>
-					Write the general solution.
+					Write the general solution:
+					<me>
+						Y(t) = C_1 \vec{v}_1 e^{3t} + C_2 \vec{v}_2 e^{-t}.
+					</me>
 				</p>
-
-				<me>
-					Y(t) = C_1 \vec{v}_1 e^{3t} + C_2 \vec{v}_2 e^{-t}.
-				</me>
 
 				<p>
 					Substitute the eigenvectors:
+					<me>
+						\begin{bmatrix} x(t) \\ y(t) \end{bmatrix} =
+						C_1 \begin{bmatrix} 1 \\ 2 \end{bmatrix} e^{3t} +
+						C_2 \begin{bmatrix} 1 \\ -2 \end{bmatrix} e^{-t}.
+					</me>
 				</p>
-
-				<me>
-					\begin{bmatrix} x(t) \\ y(t) \end{bmatrix} =
-					C_1 \begin{bmatrix} 1 \\ 2 \end{bmatrix} e^{3t} +
-					C_2 \begin{bmatrix} 1 \\ -2 \end{bmatrix} e^{-t}.
-				</me>
 
 				<p>
 					Or written componentwise:
+					<me>
+						x(t) = C_1 e^{3t} + C_2 e^{-t}, \qquad
+						y(t) = 2C_1 e^{3t} - 2C_2 e^{-t}.
+					</me>
 				</p>
-
-				<me>
-					x(t) = C_1 e^{3t} + C_2 e^{-t}, \qquad
-					y(t) = 2C_1 e^{3t} - 2C_2 e^{-t}.
-				</me>
 
 				<p>
 					The constants <m>C_1</m> and <m>C_2</m> will be found from initial conditions.
@@ -215,14 +210,15 @@
 
 		<example xml:id="ex-complex-eigenvalues">
 			<title>Complex Eigenvalues and Spirals</title>
+
 			<statement>
 				<p>
 					Consider the system:
+					<md>
+						<mrow>\frac{dx}{dt} \amp = 2x - 5y</mrow>
+						<mrow>\frac{dy}{dt} \amp = 5x + 2y</mrow>
+					</md>
 				</p>
-				<md>
-					<mrow>\frac{dx}{dt} \amp = 2x - 5y</mrow>
-					<mrow>\frac{dy}{dt} \amp = 5x + 2y</mrow>
-				</md>
 				<p>
 					Solve the system and describe the behavior of solutions.
 				</p>
@@ -234,25 +230,24 @@
 
 				<p>
 					Find eigenvalues by solving <m>\det(A - rI) = 0</m>.
+					<me>
+						\det \begin{bmatrix} 2-r \amp -5 \\ 5 \amp 2-r \end{bmatrix} = (2-r)^2 + 25 = r^2 - 4r + 29.
+					</me>
 				</p>
-
-				<me>
-					\det \begin{bmatrix} 2-r \amp -5 \\ 5 \amp 2-r \end{bmatrix} = (2-r)^2 + 25 = r^2 - 4r + 29.
-				</me>
 
 				<p>
 					Set equal to zero: <m>r^2 - 4r + 29 = 0</m>.  
 					Using the quadratic formula:
+					<me>
+						r = \frac{4 \pm \sqrt{(-4)^2 - 4(29)}}{2} = \frac{4 \pm \sqrt{-100}}{2} = 2 \pm 5i.
+					</me>
 				</p>
-
-				<me>
-					r = \frac{4 \pm \sqrt{(-4)^2 - 4(29)}}{2} = \frac{4 \pm \sqrt{-100}}{2} = 2 \pm 5i.
-				</me>
 
 				<p>
 					The eigenvalues are <m>2 \pm 5i</m> — complex conjugates.  
-					The real part (<m>2</m>) means solutions grow exponentially;  
-					the imaginary part (<m>5i</m>) means they also rotate: the system's trajectories spiral outward.
+					The real part (<m>2</m>) indicates that solutions grow exponentially, 
+					and the imaginary part (<m>5i</m>) indicates that they also rotate: 
+					the system's trajectories spiral outward.
 				</p>
 
 				<p>
@@ -266,14 +261,13 @@
 
 				<p>
 					We form the real solution by taking the real and imaginary parts:
+					<me>
+						\begin{aligned}
+						x(t) \amp = e^{2t}\left( C_1 \cos(5t) + C_2 \sin(5t) \right) \\
+						y(t) \amp = e^{2t}\left( -C_1 \sin(5t) + C_2 \cos(5t) \right)
+						\end{aligned}
+					</me>
 				</p>
-
-				<me>
-					\begin{aligned}
-					x(t) \amp = e^{2t}\left( C_1 \cos(5t) + C_2 \sin(5t) \right) \\
-					y(t) \amp = e^{2t}\left( -C_1 \sin(5t) + C_2 \cos(5t) \right)
-					\end{aligned}
-				</me>
 
 				<p>
 					The exponential factor <m>e^{2t}</m> causes growth; the sine and cosine produce rotation.
@@ -287,6 +281,7 @@
 
 			<task label="solving-linear-systems-cyu-1">
 				<title><e component="emoji">📖❓</e> Eigenvalues and Behavior</title>
+
 				<statement>
 					<p>
 						Suppose the eigenvalues of a system are <m>r = -2 \pm 3i</m>. What does this tell you about the solutions?

--- a/source/c13-linsys/sec-solving-linear-systems.ptx
+++ b/source/c13-linsys/sec-solving-linear-systems.ptx
@@ -81,8 +81,8 @@
 			This leaves an algebraic system involving the unknowns: <m>C</m>, <m>D</m>, and <m>r</m>. It turns out that these unknowns have a very special relationship. To see this, flip the system around:
 			<md alignment="alignat">
 				<mrow>3{\DLBb C} \amp {}+{} \amp 4{\DLGb D} \amp {}={} \amp r{\DLBb C}   </mrow>
-				<mrow>-4{\DLBb C} \amp {}+{} \amp 3{\DLGb D} \amp {}={} \amp r{\DLGb D} </mrow>.
-			</md>
+				<mrow>-4{\DLBb C} \amp {}+{} \amp 3{\DLGb D} \amp {}={} \amp r{\DLGb D} </mrow>
+			</md>.
 		</p>
 
 		<p>
@@ -160,7 +160,8 @@
 					Find eigenvectors for each eigenvalue.
 				</p>
 
-				<ul>
+				<p>
+					<ul>
 					<li><term>For r = 3:</term> Solve <m>(A - 3I)\vec{v} = 0</m>.
 						<me>
 							\begin{bmatrix} -2 \amp 1 \\ 4 \amp -2 \end{bmatrix} \begin{bmatrix} v_1 \\ v_2 \end{bmatrix} = \begin{bmatrix} 0 \\ 0 \end{bmatrix}.
@@ -177,6 +178,7 @@
 						Choose <m>v_1 = 1</m>, giving eigenvector <m>\vec{v}_2 = \begin{bmatrix}1 \\ -2\end{bmatrix}</m>.
 					</li>
 				</ul>
+				</p>
 
 				<p>
 					Write the general solution.


### PR DESCRIPTION
# sec-solving-linear-systems — MC edit notes

## Scope

Mismatch/markup-safety pass under Looser Set v1.9 (FeedbackRepair/HintRepair available, but not used unless needed). Minimal changes to avoid drift.

## Applied edits (high confidence)

- Math punctuation: moved trailing period outside <md> block (prevents punctuation inside math).
- PTX list rule: wrapped solution <ul> in a minimal <p> container.
- PTX list rule: closed the minimal <p> wrapper after the solution <ul>.

## VERIFY-REQUIRED (no automatic change made)

- `<xref provisional="WORK-IN-PROGRESS"/>` remains in the introduction; intended target is unknown, so it was not replaced.