### PR TITLE
Update sec-lncc-eqns.ptx

### DIFF
--- a/source/c9-uc/sec-lncc-eqns.ptx
+++ b/source/c9-uc/sec-lncc-eqns.ptx
@@ -16,11 +16,10 @@
 	<introduction>
 		<p>
 			You already know that a linear homogeneous constant coefficient (LHCC) equation has the form:
+			<me>
+				a_n y^{(n)} + a_{n-1} y^{(n-1)} + \cdots + a_1 y' + a_0 y = 0
+			</me>
 		</p>
-
-		<me>
-			a_n y^{(n)} + a_{n-1} y^{(n-1)} + \cdots + a_1 y' + a_0 y = 0
-		</me>
 
 		<p>
 			All the terms are on the left, and the right-hand side is zero. This equation is called <em>homogeneous</em> because the solution only includes terms that cancel each other out.
@@ -28,11 +27,10 @@
 
 		<p>
 			A linear nonhomogeneous constant coefficient (LNCC) equation looks almost the same, except the right-hand side is now a function:
+			<me>
+				a_n y^{(n)} + a_{n-1} y^{(n-1)} + \cdots + a_1 y' + a_0 y = f(x)
+			</me>
 		</p>
-
-		<me>
-			a_n y^{(n)} + a_{n-1} y^{(n-1)} + \cdots + a_1 y' + a_0 y = f(x)
-		</me>
 
 		<p>
 			The function <m>f(x)</m> is called the <term>forcing function</term> because it introduces an external input that <q>forces</q> the system to respond in a particular way.
@@ -121,6 +119,7 @@
 
 		<exercise label="lncc-equation-chkpt-2">
 			<title><e component="emoji">📖❓</e>  Select the most appropriate solution</title>
+
 			<statement>
 				<p>
 					Based on this logic, which function has the most appropriate form for a particular solution to the LNCC equation?
@@ -134,11 +133,7 @@
 			</statement>
 			<choices randomize="yes">
 				<choice correct="no">
-					<statement>
-						<p>
-							<m>\ds\quad e^{3x}</m>
-						</p>
-					</statement>
+					<statement><p><m>\quad e^{3x}</m></p></statement>
 					<feedback>
 						<p>
 							Incorrect. This function does not resemble the forcing function.
@@ -146,11 +141,7 @@
 					</feedback>
 				</choice>
 				<choice correct="no">
-					<statement>
-						<p>
-							<m>\ds\quad 3x^2 + 1 </m>
-						</p>
-					</statement>
+					<statement><p><m>\quad 3x^2 + 1 </m></p></statement>
 					<feedback>
 						<p>
 							Incorrect. Plugging <m>3x^2 + 1</m> into <m>y'' - 2y' + y</m> will not give you an <m>x^3</m> term you need to match the forcing function, <m>x^3 + x</m>.
@@ -158,11 +149,7 @@
 					</feedback>
 				</choice>
 				<choice correct="yes">
-					<statement>
-						<p>
-							<m>\ds\quad x^3 + 6x^2 + 19x + 26</m>
-						</p>
-					</statement>
+					<statement><p><m>\quad x^3 + 6x^2 + 19x + 26</m></p></statement>
 					<feedback>
 						<p>
 							Correct! This 3rd degree polynomial produces the forcing function, <m>x^3 + x</m>, when substituted into the left-hand side.
@@ -170,11 +157,7 @@
 					</feedback>
 				</choice>
 				<choice correct="no">
-					<statement>
-						<p>
-							<m>\ds\quad x^4 + x^2</m>
-						</p>
-					</statement>
+					<statement><p><m>\quad x^4 + x^2</m></p></statement>
 					<feedback>
 						<p>
 							Incorrect. Plugging <m>x^4 + x^2</m> into <m>y'' - 2y' + y</m> will leave you with an <m>x^4</m> term that does not exist in the forcing function, <m>x^3 + x</m>.
@@ -275,10 +258,7 @@
 		<p>
 			This homogeneous solution, we'll call <m>y_h</m>, is given by
 			<me>y_h = c_1 e^{x} + c_2 e^{3x}</me>
-		</p>
-
-		<p>
-			and is the other half of the LNCC solution. It provides the terms that cancel out when plugged into <xref ref="lncc-example-eqn" text="custom">🍄</xref> and has no impact on the forcing function at all.
+			and is the other half of the LNCC solution. It provides the terms that cancel out when plugged into <xref ref="lncc-example-eqn" text="custom">🍄</xref> and have no impact on the forcing function.
 		</p>
 	</subsection>
 
@@ -286,7 +266,7 @@
 		<title>Combining the Parts Into a General Solution</title>
 
 		<p>
-			To summarize, the general solution of equation
+			To summarize, the general solution of the equation
 			<me>
 				y'' - 4y' + 3y = 9x + 6
 			</me>
@@ -344,23 +324,19 @@
 
 		<assemblage xml:id="lncc-equation-summary">
 			<title>✳️ LNCC General Solution Structure</title>
-			<p>
-				<p>
-					A linear nonhomogeneous constant coefficient (LNCC) equation has the form:
-				</p>
 
+			<p>
+				A linear nonhomogeneous constant coefficient (LNCC) equation has the form:
 				<men>
 					a_n y^{(n)} + a_{n-1} y^{(n-1)} + \cdots + a_0 y = f(x)
 				</men>
+			</p>
 
-				<p>
-					Its general solution is built from two parts:
-				</p>
-
+			<p>
+				Its general solution is built from two parts:
 				<men>
 					y = y_h + y_p
 				</men>
-
 				<ul marker="square">
 					<li>
 						<p>
@@ -368,7 +344,6 @@
 							<me> a_n y^{(n)} + \cdots + a_0 y = 0 </me>
 						</p>
 					</li>
-
 					<li><m>y_p</m> is the particular solution that produces the forcing function <m>f(x)</m>.</li>
 				</ul>
 			</p>
@@ -376,6 +351,7 @@
 
 		<exercise label="lncc-equation-chkpt-3">
 			<title><e component="emoji">📖❓</e>  Constructing the General Solution</title>
+
 			<statement>
 				<p>
 					Suppose the homogeneous and particular solutions of an LNCC equation are given by
@@ -387,23 +363,15 @@
 			</statement>
 			<choices randomize="yes">
 				<choice>
-					<statement>
-						<p>
-							<m>\ds\quad y = 5x - 3</m>.
-						</p>
-					</statement>
+					<statement><p><m>\quad y = 5x - 3</m>.</p></statement>
 					<feedback>
 						<p>
-							Incorrect. This is only the particular solution, not the complete general solution.
+							Incorrect. This is only a particular solution, not a complete general solution.
 						</p>
 					</feedback>
 				</choice>
 				<choice>
-					<statement>
-						<p>
-							<m>\ds\quad y = c_1e^{-x} + c_2x e^{2x} + 5x - 3</m>.
-						</p>
-					</statement>
+					<statement><p><m>\quad y = c_1e^{-x} + c_2x e^{2x} + 5x - 3</m>.</p></statement>
 					<feedback>
 						<p>
 							Incorrect. One of the terms in this expression is incorrect.
@@ -411,11 +379,7 @@
 					</feedback>
 				</choice>
 				<choice correct="yes">
-					<statement>
-						<p>
-							<m>\ds\quad y = c_1e^{-x} + c_2e^{2x} + 5x - 3</m>.
-						</p>
-					</statement>
+					<statement><p><m>\quad y = c_1e^{-x} + c_2e^{2x} + 5x - 3</m>.</p></statement>
 					<feedback>
 						<p>
 							Correct! The general solution is the sum of the homogeneous and particular solutions.
@@ -423,11 +387,7 @@
 					</feedback>
 				</choice>
 				<choice>
-					<statement>
-						<p>
-							<m>\ds\quad y = c_1e^{-x} + c_2e^{2x} + c_3(5x - 3)</m>.
-						</p>
-					</statement>
+					<statement><p><m>\quad y = c_1e^{-x} + c_2e^{2x} + c_3(5x - 3)</m>.</p></statement>
 					<feedback>
 						<p>
 							Incorrect. You do not multiply the particular solution by a constant.
@@ -441,59 +401,47 @@
 			Here's a quick example to help solidify this concept.
 		</p>
 	
-		<example><title>Finding the general solution, given <m>y_p</m></title>
-			<p>
-				<statement>
-					<p>
-						Find the general solution to the differential equation
-						<me>
-							y'' - 4y' - 12y = 3{e^{5t}}
-						</me>
-						given that the particular solution is known to be <m>y_p(t) =  -\frac{3}{7}{{e}^{5t}}</m>.
-					</p>
-				</statement>
-			</p>
+		<example>
+			<title>Finding the general solution, given <m>y_p</m></title>
+
+			<statement>
+				<p>
+					Find the general solution to the differential equation
+					<me>
+						y'' - 4y' - 12y = 3{e^{5t}}
+					</me>
+					given that the particular solution is known to be <m>y_p(t) =  -\frac{3}{7}{{e}^{5t}}</m>.
+				</p>
+			</statement>
 			<solution>
 				<p>
-					The general solution has the form:
+					The general solution has the form: <me>y = y_h + y_p</me>.
 				</p>
-
-				<me>
-					y = y_h + y_p
-				</me>
 
 				<p>
 					Since <m>y_p</m> is given, we only need to solve the homogeneous equation:
+					<me>y'' - 4y' - 12y = 0</me>.
 				</p>
-
-				<me>
-					y'' - 4y' - 12y = 0
-				</me>
 
 				<p>
 					Using the characteristic equation:
+					<md>
+						<mrow> r^2 - 4r - 12 	\amp = 0 </mrow>
+						<mrow> (r - 6)(r + 2) 	\amp = 0 \quad \Rightarrow \quad r_1 = 6, r_2 = -2 </mrow>
+					</md>
 				</p>
-
-				<md>
-					<mrow> r^2 - 4r - 12 	\amp = 0											</mrow>
-					<mrow> (r - 6)(r + 2) 	\amp = 0 \quad \Rightarrow \quad r_1 = 6, r_2 = -2	</mrow>
-				</md>
 
 				<p>
 					The homogeneous solution is:
+					<me>y_h(t) = c_1e^{-2t} + c_2e^{6t}</me>.
 				</p>
-
-				<me>
-					y_h(t) = c_1e^{-2t} + c_2e^{6t}
-				</me>
 
 				<p>
 					Therefore, the general solution is:
+					<me>
+						y(t) = \ub{c_1e^{-2t} + c_2e^{6t}\vphantom{\frac{3}{7}}}_{\Large y_h}\ \ub{-\frac{3}{7}{e^{5t}}}_{\Large y_p}
+					</me>
 				</p>
-
-				<me>
-					y(t) = \ub{c_1e^{-2t} + c_2e^{6t}\vphantom{\frac{3}{7}}}_{\Large y_h}\ \ub{-\frac{3}{7}{e^{5t}}}_{\Large y_p}
-				</me>
 			</solution>
 		</example>
 
@@ -506,6 +454,7 @@
 
 			<task label="lncc-equation-cyu-1">
 				<title><e component="emoji">🤔💭</e> Role of the Particular Solution</title>
+
 				<statement>
 					<p>
 						Which statement best describes the role of the particular solution to an LNCC equation?
@@ -565,6 +514,7 @@
 
 			<task label="lncc-equation-cyu-2">
 				<title><e component="emoji">🤔💭</e> Particular Solution Properties</title>
+
 				<statement>
 					<p>
 						Which statements are true about the particular solution, <m>y_p</m>, of

--- a/source/c9-uc/sec-lncc-eqns.ptx
+++ b/source/c9-uc/sec-lncc-eqns.ptx
@@ -123,7 +123,7 @@
 			<title><e component="emoji">📖❓</e>  Select the most appropriate solution</title>
 			<statement>
 				<p>
-					Based on this logic, which function is the only possible candidate for the solution to the LNCC equation?
+					Based on this logic, which function has the most appropriate form for a particular solution to the LNCC equation?
 				</p>
 				<me>
 					y'' - 2y' + y = x^3 + x
@@ -160,12 +160,12 @@
 				<choice correct="yes">
 					<statement>
 						<p>
-							<m>\ds\quad x^3 + 6x^2 + 18x + 24</m>
+							<m>\ds\quad x^3 + 6x^2 + 19x + 26</m>
 						</p>
 					</statement>
 					<feedback>
 						<p>
-							Correct! This 3rd degree polynomial has the same polynomial structure as the forcing function, <m>x^3 + x</m>.
+							Correct! This 3rd degree polynomial produces the forcing function, <m>x^3 + x</m>, when substituted into the left-hand side.
 						</p>
 					</feedback>
 				</choice>
@@ -278,7 +278,7 @@
 		</p>
 
 		<p>
-			and is the other half of LNCC solution. They provide the terms that cancel out when plugged into <xref ref="lncc-example-eqn" text="custom">🍄</xref> and have no impact on the forcing function at all.
+			and is the other half of the LNCC solution. It provides the terms that cancel out when plugged into <xref ref="lncc-example-eqn" text="custom">🍄</xref> and has no impact on the forcing function at all.
 		</p>
 	</subsection>
 
@@ -311,11 +311,11 @@
 		</p>
 
 		<p>
-			Now, we will now show that the homogeneous terms, 1️⃣, simplify to zero:
+			Now, we will show that the homogeneous terms, 1️⃣, simplify to zero:
 			<md>
 				<mrow>\text{1️⃣}:\ y_h'' - 4y_h' + 3y_h \amp = \left(c_1e^{x} + c_2e^{3x}\right)'' - 4\left(c_1e^{x} + c_2e^{3x}\right)' + 3\left(c_1e^{x} + c_2e^{3x}\right) </mrow>
 				<mrow> \amp = c_1e^{x} + 9c_2e^{3x} - 4\left(c_1e^{x} + 3c_2e^{3x}\right) + 3\left(c_1e^{x} + c_2e^{3x}\right) </mrow>
-				<mrow> \amp = c_1e^{x} + 9c_2e^{3x} - 4c_1e^{x} + 12c_2e^{3x} + 3c_1e^{x} + 3c_2e^{3x} </mrow>
+				<mrow> \amp = c_1e^{x} + 9c_2e^{3x} - 4c_1e^{x} - 12c_2e^{3x} + 3c_1e^{x} + 3c_2e^{3x} </mrow>
 				<mrow> \amp = 0 \quad \text{✅}</mrow>
 			</md>
 		</p>
@@ -369,13 +369,13 @@
 						</p>
 					</li>
 
-					<li><m>y_p</m> the particular solution that produces the forcing function <m>f(x)</m>.</li>
+					<li><m>y_p</m> is the particular solution that produces the forcing function <m>f(x)</m>.</li>
 				</ul>
 			</p>
 		</assemblage>
 
 		<exercise label="lncc-equation-chkpt-3">
-			<title><e component="emoji">📖❓</e>  Contructing the General Solution</title>
+			<title><e component="emoji">📖❓</e>  Constructing the General Solution</title>
 			<statement>
 				<p>
 					Suppose the homogeneous and particular solutions of an LNCC equation are given by
@@ -580,7 +580,7 @@
 								It is part of the general solution.
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Correct. <m>y_p</m> is part of <m>y_h+y_p</m>.</p></feedback>
 						</choice>
 					<choice correct="no">
 						<statement>
@@ -588,7 +588,7 @@
 								All of its terms simplify to <m>0</m> when plugged into the equation.
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Incorrect. That property describes <m>y_h</m>.</p></feedback>
 					</choice>
 					<choice correct="no">
 						<statement>
@@ -596,7 +596,7 @@
 								It is constructed from the roots of a characteristic equation.
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Incorrect. Roots/characteristic equation come from <m>y_h</m>.</p></feedback>
 					</choice>
 					<choice correct="yes">
 						<statement>
@@ -604,7 +604,7 @@
 								It mimics the structure of the forcing function, <m>f(x)</m>.
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Correct. <m>y_p</m> is chosen to match <m>f(x)</m>.</p></feedback>
 					</choice>
 					<choice correct="no">
 						<statement>
@@ -612,7 +612,7 @@
 								It contains constants of integration (e.g., <m>c_1</m>, <m>c_2</m>, etc.).
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Incorrect. <m>y_p</m> has no arbitrary constants.</p></feedback>
 					</choice>
 				</choices>
 			</task>
@@ -634,7 +634,7 @@
 								It is part of the general solution.
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Correct. <m>y_h</m> is part of <m>y_h+y_p</m>.</p></feedback>
 					</choice>
 					<choice correct="yes">
 						<statement>
@@ -642,7 +642,7 @@
 								All of its terms simplify to <m>0</m> when plugged into the equation.
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Correct. <m>y_h</m> makes the left side simplify to <m>0</m>.</p></feedback>
 					</choice>
 					<choice correct="yes">
 						<statement>
@@ -650,7 +650,7 @@
 								It is constructed from the roots of a characteristic equation.
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Correct. <m>y_h</m> comes from the characteristic equation.</p></feedback>
 					</choice>
 					<choice correct="no">
 						<statement>
@@ -658,7 +658,7 @@
 								It mimics the structure of the forcing function, <m>f(x)</m>.
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Incorrect. Mimicking <m>f(x)</m> is for <m>y_p</m>.</p></feedback>
 					</choice>
 					<choice correct="yes">
 						<statement>
@@ -666,7 +666,7 @@
 								It contains constants of integration (e.g., <m>c_1</m>, <m>c_2</m>, etc.).
 							</p>
 						</statement>
-						<feedback><p>selected.</p></feedback>
+						<feedback><p>Correct. <m>y_h</m> includes constants like <m>c_1</m>, <m>c_2</m>.</p></feedback>
 					</choice>
 				</choices>
 			</task>


### PR DESCRIPTION
# c9 Chapter Ten — sec-lncc-eqns (Set v1.9)

Totals: VR=0 | M=6 | C=4

## VERIFY-REQUIRED (applied)
- (none)

## Math/logic (applied)
M-001 | lncc-equation-chkpt-2 | corrected polynomial choice to satisfy forcing | why:choice must satisfy DE M-002 | lncc-equation-chkpt-2 | clarified prompt to “particular solution” | why:solution wording misleading M-003 | lncc-equation-chkpt-2 correct feedback | updated to reflect actual substitution result | why:feedback must match key M-004 | 1️⃣ derivation line | fixed sign on -4y_h′ expansion | why:must cancel to 0 M-005 | lncc-equation-cyu-2 | replaced placeholder feedback (“selected.”) | why:feedback must be diagnostic M-006 | lncc-equation-cyu-3 | replaced placeholder feedback (“selected.”) | why:feedback must be diagnostic

## Copy edits (applied)
C-001 | lncc-equation-chkpt-3 title | Contructing→Constructing C-002 | “Now, we will now show” | removed duplicate “now” C-003 | “other half of LNCC solution” | added “the” + singular agreement C-004 | LNCC summary bullet | inserted “is” after <m>y_p</m>

## References
- (none; V0 in-file verification)