### PR TITLE
Update sec-selecting-the-particular-soln.ptx

### DIFF
--- a/source/c9-uc/sec-selecting-the-particular-soln.ptx
+++ b/source/c9-uc/sec-selecting-the-particular-soln.ptx
@@ -37,45 +37,46 @@
 		<table xml:id="yp-forms-table">
 			<title> 
 				<m>y_p</m> forms based on <m>f(x)</m>, where <m>a, b, c, d, \alpha, \beta</m> are known constants. <m>A, B, C, D</m> must be determined. Degree 4+ polynomials follow a similar pattern.
-			 </title>
+			</title>
+
 			<tabular top="medium" left="medium" right="medium" bottom="minor">
 				<col halign="center" top="none" right="minor"/>
 				<col halign="center" right="minor"/>
 				<col halign="center"/>
 				<row left="none" bottom="medium">
-				<cell right="medium"/>
-				<cell><term>Forcing Function Type, </term><m>f(x)</m></cell>
-				<cell><term>Particular Solution Form, </term><m>y_p</m></cell>
+					<cell right="medium"/>
+					<cell><term>Forcing Function Type, </term><m>f(x)</m></cell>
+					<cell><term>Particular Solution Form, </term><m>y_p</m></cell>
 				</row>
 				<row>
-				<cell>1</cell>
-				<cell><m>a</m> (constant)</cell>
-				<cell><m>A</m></cell>
+					<cell>1</cell>
+					<cell><m>a</m> (constant)</cell>
+					<cell><m>A</m></cell>
 				</row>
 				<row>
-				<cell>2</cell>
-				<cell><m>ax + b</m></cell>
-				<cell><m>Ax + B</m></cell>
+					<cell>2</cell>
+					<cell><m>ax + b</m></cell>
+					<cell><m>Ax + B</m></cell>
 				</row>
 				<row>
-				<cell>3</cell>
-				<cell><m>ax^2 + bx + c</m></cell>
-				<cell><m>Ax^2 + Bx + C</m></cell>
+					<cell>3</cell>
+					<cell><m>ax^2 + bx + c</m></cell>
+					<cell><m>Ax^2 + Bx + C</m></cell>
 				</row>
 				<row>
-				<cell>4</cell>
-				<cell><m>ax^3 + bx^2 + cx + d</m></cell>
-				<cell><m>Ax^3 + Bx^2 + Cx + D</m></cell>
+					<cell>4</cell>
+					<cell><m>ax^3 + bx^2 + cx + d</m></cell>
+					<cell><m>Ax^3 + Bx^2 + Cx + D</m></cell>
 				</row>
 				<row>
-				<cell>5</cell>
-				<cell><m>a e^{\ds\alpha x}</m></cell>
-				<cell><m>A e^{\ds\alpha x}</m></cell>
+					<cell>5</cell>
+					<cell><m>a e^{\ds\alpha x}</m></cell>
+					<cell><m>A e^{\ds\alpha x}</m></cell>
 				</row>
 				<row bottom="medium">
-				<cell>6</cell>
-				<cell><m>a \sin(\beta x) + b \cos(\beta x)</m></cell>
-				<cell><m>A \sin(\beta x) + B \cos(\beta x)</m></cell>
+					<cell>6</cell>
+					<cell><m>a \sin(\beta x) + b \cos(\beta x)</m></cell>
+					<cell><m>A \sin(\beta x) + B \cos(\beta x)</m></cell>
 				</row>
 			</tabular>
 		</table>
@@ -170,6 +171,7 @@
 
 		<exercise label="selecting-the-particular-soln-chkpt-1">
 			<title><e component="emoji">📖❓</e>  Matching single term forcing functions to the particular form</title>
+
 			<statement>
 				<p>
 					Drag each forcing function on the left to the initial selection of <m>y_p</m> on the right.
@@ -214,16 +216,16 @@
 		</p>
 			
 		<p>
-			Functions such as <m>\ln x</m>, <m>\tan x</m>, or <m>1/x</m> fall outside this category. For those, we'll need a different method entirely. But for the allowed types, this method offers a fast and reliable way to select <m>y_p</m>.
+			Functions such as <m>\ln x</m>, <m>\tan x</m>, or <m>1/x</m> fall outside this category. For those, we'll need a different method entirely. For the allowed types, this method provides a fast and reliable way to select <m>y_p</m>.
 		</p>
 
 		<exercise xml:id="selecting-the-particular-soln-chkpt-2">
 			<title><e component="emoji">📖❓</e>  When to Guess <m>y_p</m></title>
+
 			<statement>
 				<p>
 					Which types of forcing functions <m>f(x)</m> are suitable for the Method of Undetermined Coefficients?
 				</p>
-				<p/>
 			</statement>
 			<choices randomize="yes">
 				<choice correct="yes">
@@ -255,6 +257,7 @@
 
 		<example>
 			<title>Initial form of <m>y_p</m></title>
+
 			<statement>
 				<p>
 					Use <xref ref="yp-forms-table"/> to identify the appropriate form of <m>y_p</m> in each case.
@@ -301,7 +304,7 @@
 					<p>
 						<solution>
 							<p>
-								Cosines with different arguments requires the sum of two forms:
+								Cosines with different arguments require the sum of two forms:
 								<md>
 									<mrow> y_p = A\sin(3t) \amp + B\cos(3t) </mrow>
 									<mrow> \amp + C\sin(5t) + D\cos(5t) </mrow>
@@ -315,12 +318,11 @@
 
 		<exercise label="selecting-the-particular-soln-chkpt-3">
 			<title><e component="emoji">📖❓</e>  Sum of particular solution forms</title>
+
 			<statement>
 				<p>
 					Select the initial form of the particular solution for an LNCC equation with forcing function:
-					<me>
-						f(x) = 3e^{4x} + 2\sin(3x)
-					</me>.
+					<me>f(x) = 3e^{4x} + 2\sin(3x)</me>.
 				</p>
 			</statement>
 			<choices randomize="yes">
@@ -334,7 +336,7 @@
 				</choice>
 				<choice>
 					<statement><m>\ds\quad y_p = e^{4x}(A \sin(3x) + B \cos(3x))</m></statement>
-					<feedback>Incorrect. This form is inappropriate since the forcing function is not a product of an exponential function and sine or cosine functions.</feedback>
+					<feedback>Incorrect. This form is inappropriate because the forcing function is not a product of an exponential function and a sine or cosine function.</feedback>
 				</choice>
 				<choice correct="yes">
 					<statement><m>\ds\quad y_p = A e^{4x} + B \sin(3x) + C \cos(3x)</m></statement>
@@ -362,14 +364,14 @@
 		</p>
 
 		<p>
-			Since each pair can be merged as single coefficient, we just relabel them:
+			Since each pair can be merged as a single coefficient, we just relabel them:
 			<me>
 				y_p = (Ax^2 + Bx + C) e^{6x}
 			</me>
 		</p>
 
 		<p>
-			We'll use this simplification trick often. It keeps the form of <m>y_p</m> clean and will make solving for <m>A</m>, <m>B</m> and <m>C</m> much easier later.
+			We'll use this simplification trick often. It keeps the form of <m>y_p</m> clean and will make solving for <m>A</m>, <m>B</m>, and <m>C</m> much easier later.
 		</p>
 
 		<exercise label="selecting-the-particular-soln-chkpt-4">
@@ -444,14 +446,14 @@
 				<p>
 					<solution>
 						<p>
-							This is a 3rd degree polynomial times a cosine. So, initially we set:
+							This is a 3rd-degree polynomial multiplied by a cosine. So, initially we set:
 							<me>
 								y_p = (At^3 + Bt^2 + Ct + D)(E\sin t + F\cos t)
 							</me>.
 						</p>
 
 						<p>
-							Multiplying the polynomial onto sine and cosine, gives us
+							Multiplying the polynomial by sine and cosine gives us
 							<md>
 								<mrow>	y_p = (At^3	\amp + Bt^2 + Ct + D)E\sin t </mrow>
 								<mrow>				\amp + (At^3 + Bt^2 + Ct + D)F\cos t </mrow>
@@ -495,6 +497,7 @@
 
 		<exercise label="selecting-the-particular-soln-chkpt-5">
 			<title><e component="emoji">📖❓</e>  Matching Forcing Function (with Products) to <m>y_p</m></title>
+
 			<statement>
 				<p>
 					By dragging from left to right, match the forcing functions to the appropriate initial form of <m>y_p</m>.
@@ -539,7 +542,6 @@
 		<p>
 			For example, consider:
 			<me> y'' - 4y' + 3y = e^{3x} </me>
-
 			The homogeneous solution and the initial particular solution are:
 			<me>
 				y_h = c_1 e^x + {\DLO c_2 e^{3x}}, \quad y_p = {\DLO A e^{3x}}
@@ -561,6 +563,7 @@
 
 		<assemblage xml:id="modifying-yp">
 			<title>Modification Rule for the Particular Solution</title>
+
 			<p>
 				If any term in your guess for <m>y_p</m> also appears in <m>y_h</m>, multiply that term by the independent variable <m>x</m>. Repeat as needed until all overlapping terms are eliminated.
 			</p>
@@ -568,6 +571,7 @@
 
 		<exercise label="selecting-the-particular-soln-chkpt-6">
 			<title><e component="emoji">📖❓</e>  Handling Like Terms</title>
+
 			<statement>
 				<p>What should you do if <m>y_p</m> contains a term also present in <m>y_h</m>?</p>
 			</statement>
@@ -645,7 +649,7 @@
 				</sidebyside>
 
 				<sidebyside widths="36% 62%" margins="2% 0%" valign="top">
-					<p><m>\ds y''' + 4y' = \cos(2x) - \sin(x)</m></p>
+					<p><m>y''' + 4y' = \cos(2x) - \sin(x)</m></p>
 					<p>
 						<solution>
 							<p>
@@ -653,13 +657,9 @@
 								<li>
 									<p>
 										Since the characteristic equation is
-										<me>
-											r^3 + 4r = 0
-										</me>,
+										<me>r^3 + 4r = 0</me>,
 										the roots are: <m>r = 0, \pm 2i</m> and
-										<me>
-											y_h = c_1 + c_2 \cos(2x) + c_3 \sin(2x)
-										</me>.
+										<me>y_h = c_1 + c_2 \cos(2x) + c_3 \sin(2x)</me>.
 									</p>
 								</li>
 								<li>
@@ -687,7 +687,7 @@
 				</sidebyside>
 
 				<sidebyside widths="36% 62%" margins="2% 0%" valign="top">
-					<p><m>\ds y'' + y = x e^x</m></p>
+					<p><m>y'' + y = x e^x</m></p>
 					<p>
 						<solution>
 							<p>
@@ -695,21 +695,15 @@
 									<li>
 										<p>
 											The characteristic equation
-											<me>
-												r^2 + 1 = 0
-											</me>,
+											<me>r^2 + 1 = 0</me>,
 											has roots: <m>r = \pm i</m>, leading to
-											<me>
-												y_h = c_1 \cos(x) + c_2 \sin(x)
-											</me>.
+											<me>y_h = c_1 \cos(x) + c_2 \sin(x)</me>.
 										</p>
 									</li>
 									<li>
 										<p>
 											The initial guess for <m>y_p</m> is
-											<me>
-												y_p = (Ax + B)\ e^x
-											</me>.
+											<me>y_p = (Ax + B)\ e^x</me>.
 										</p>
 									</li>
 									<li>
@@ -724,7 +718,7 @@
 				</sidebyside>
 
 				<sidebyside widths="36% 62%" margins="2% 0%" valign="top">
-					<p><m>\ds y'' - 6y' + 9y = x^2 e^{3x}</m></p>
+					<p><m>y'' - 6y' + 9y = x^2 e^{3x}</m></p>
 					<p>
 						<solution>
 							<p>
@@ -732,29 +726,21 @@
 									<li>
 										<p>
 											The characteristic equation
-											<me>
-												r^2 - 6r + 9 = 0
-											</me>,
+											<me>r^2 - 6r + 9 = 0</me>,
 											has the repeated solution <m>r = 3</m>, so
-											<me>
-												y_h = (c_1 + c_2 x) e^{3x}
-											</me>.
+											<me>y_h = (c_1 + c_2 x) e^{3x}</me>.
 										</p>
 									</li>
 									<li>
 										<p>
 											The initial guess for <m>y_p</m> is:
-											<me>
-												y_p = (Ax^2 + Bx + C) e^{3x}
-											</me>.
+											<me>y_p = (Ax^2 + Bx + C) e^{3x}</me>.
 										</p>
 									</li>
 									<li>
 										<p>
 											Multiplying out <m>y_h</m> and <m>y_p</m> helps show that <m>e^{3x}</m> and <m>x e^{3x}</m> are conflicting terms. Multiplying all terms by <m>x^2</m> gives the correct form:
-											<me>
-												y_p = (Ax^4 + Bx^3 + Cx^2) e^{3x}
-											</me>.
+											<me>y_p = (Ax^4 + Bx^3 + Cx^2) e^{3x}</me>.
 										</p>
 									</li>
 								</ol>
@@ -771,34 +757,30 @@
 
 		<exercise label="selecting-the-particular-soln-chkpt-7">
 			<title><e component="emoji">📖❓</e>  Select the Correct Form of <m>y_p</m></title>
+
 			<statement>
 				<p>
 					Consider the linear non-homogeneous constant coefficient equation
-					<me>
-						y'' - 4y' + 3y = \frac12 e^x
-					</me>.
+					<me>y'' - 4y' + 3y = \frac12 e^x</me>.
 					Given that the homogeneous solution is
-					<m>
-						y_h = c_1 e^x + c_2 e^{3x}
-					</m>, 
-					select the form of the particular solution after any necessary modifications.
+					<m>y_h = c_1 e^x + c_2 e^{3x}</m>, select the form of the particular solution after any necessary modifications.
 				</p>
 			</statement>
 			<choices randomize="yes">
 				<choice>
-					<statement><m>\quad\ds y_p = Ae^x </m> </statement>
+					<statement><m>\quad y_p = Ae^x </m> </statement>
 					<feedback>Incorrect. This would be the correct initial form for the particular solution, but not the final form.</feedback>
 				</choice>
 				<choice>
-					<statement><m>\quad\ds y_p = Ae^x + Be^{3x} </m> </statement>
+					<statement><m>\quad y_p = Ae^x + Be^{3x} </m> </statement>
 					<feedback>Incorrect. Don't create the particular solution form based on the homogeneous solution.</feedback>
 				</choice>
 				<choice>
-					<statement><m>\quad\ds y_p = (Ax + B)e^x</m> </statement>
+					<statement><m>\quad y_p = (Ax + B)e^x</m> </statement>
 					<feedback>Incorrect. This form indicates the forcing function contains the product of a first degree polynomial and an exponential function.</feedback>
 				</choice>
 				<choice correct="yes">
-					<statement><m>\quad\ds y_p = Axe^{x} </m> </statement>
+					<statement><m>\quad y_p = Axe^{x} </m> </statement>
 					<feedback>Correct! The initial form would be <m>Ae^x</m>, but a like-term is also in <m>y_h</m>. One multiplication by <m>x</m> resolves this.</feedback>
 				</choice>
 			</choices>
@@ -809,6 +791,7 @@
 
 			<task label="selecting-the-particular-soln-cyu-1">
 				<title><e component="emoji">🤔💭</e> Match Forcing Function to <m>y_p</m> Form</title>
+
 				<statement>
 					<p>
 						Match each forcing function <m>f(x)</m> to its correct initial form of <m>y_p</m>.
@@ -848,6 +831,7 @@
 
 			<task label="selecting-the-particular-soln-cyu-2">
 				<title><e component="emoji">🤔💭</e> What is the Next Move?</title>
+
 				<statement>
 					<p>
 						Which statement best describes the next action you should take when the particular solution, <m>y_p</m>, has a like-term with the homogeneous solution, <m>y_h</m>?
@@ -877,7 +861,7 @@
 				<title>Modify <m>y_p</m></title>
 				<statement>
 					<p>
-						If an equation has the forcing function and homogeneous solution,
+						If an equation has a forcing function and a homogeneous solution,
 						<me>
 							f(x) = x^2 e^{3x}\quad \text{and} \quad y_h = (c_1 + c_2 x) e^{3x}
 						</me>,
@@ -886,19 +870,19 @@
 				</statement>
 				<choices randomize="yes">
 					<choice>
-						<statement><m>\ds\quad y_p = A x^2 e^{3x}</m></statement>
+						<statement><m>\quad y_p = A x^2 e^{3x}</m></statement>
 						<feedback>Incorrect. The form of <m>y_p</m> should be modified until there are no terms in common with <m>y_h</m>.</feedback>
 					</choice>
 					<choice correct="yes">
-						<statement><m>\ds\quad y_p = (A x^4 + B x^3 + C x^2) e^{3x}</m></statement>
+						<statement><m>\quad y_p = (A x^4 + B x^3 + C x^2) e^{3x}</m></statement>
 						<feedback>Correct! The modified form of <m>y_p</m> is <m>(A x^4 + B x^3 + C x^2) e^{3x}</m>.</feedback>
 					</choice>
 					<choice>
-						<statement><m>\ds\quad y_p = (A x^3 + B x^2) e^{3x}</m></statement>
+						<statement><m>\quad y_p = (A x^3 + B x^2) e^{3x}</m></statement>
 						<feedback>Incorrect. The form of <m>y_p</m> should be modified until there are no terms in common with <m>y_h</m>.</feedback>
 					</choice>
 					<choice>
-						<statement><m>\ds\quad y_p = (A x^2 + B x) e^{3x}</m></statement>
+						<statement><m>\quad y_p = (A x^2 + B x) e^{3x}</m></statement>
 						<feedback>Incorrect. The form of <m>y_p</m> should be modified until there are no terms in common with <m>y_h</m>.</feedback>
 					</choice>
 				</choices>
@@ -906,19 +890,15 @@
 
 			<task label="selecting-the-particular-soln-cyu-4">
 				<title><e component="emoji">🤔💭</e> Match the Scenario to the Correct Action</title>
+
 				<statement>
 					<p>
 						The homogeneous solution to the LNCC equation
-						<me>
-							y'' - 2y' + y = f(x)
-						</me>
+						<me>y'' - 2y' + y = f(x)</me>
 						is given by
-						<me>
-							y_h = c_1 e^{2x} + c_2 x e^{2x}
-						</me>.
-						
-
+						<me>y_h = c_1 e^{2x} + c_2 x e^{2x}</me>.
 					</p>
+
 					<p>
 						On the left side are initial <m>y_p</m> forms for various forcing functions, <m>f(x)</m>.
 					</p>
@@ -958,6 +938,7 @@
 
 			<task label="selecting-the-particular-soln-cyu-5">
 				<title><e component="emoji">🤔💭</e> REVIEW: Valid Forcing Functions for Undetermined Coefficients</title>
+
 				<statement>
 					<p>
 						Which of the following are valid types of forcing functions for the Method of Undetermined Coefficients?

--- a/source/c9-uc/sec-selecting-the-particular-soln.ptx
+++ b/source/c9-uc/sec-selecting-the-particular-soln.ptx
@@ -261,12 +261,12 @@
 				</p>
 
 				<sidebyside widths="38% 60%" margins="2% 0%" valign="top">
-					<p><m>\ds y'' + 2y' + 3y = 2e^{w} - 1</m></p>
+					<p><m>\ds y'' + 2y' + 3y = 2e^{x} - 1</m></p>
 					<p>
 						<solution>
 							<p>
-								This matches is exponential plus constant, so:
-								<me> y_p = Ae^{w} + B </me>.
+								This matches an exponential plus constant, so:
+								<me> y_p = Ae^{x} + B </me>.
 							</p>
 						</solution>
 					</p>
@@ -529,7 +529,7 @@
 		<title>Modifying Particular Solutions</title>
 
 		<p>
-			We now know how to choose a form for <m>y_p</m> based on the structure of <m>f(x)</m>, but there's one final complication: If a term in <m>y_p</m> a term in the homogeneous solution <m>y_h</m>, then that term cannot contribute to generating <m>f(x)</m>. Instead, it will give zero, since that is what terms in <m>y_h</m> do when substituted into the differential equation.
+			We now know how to choose a form for <m>y_p</m> based on the structure of <m>f(x)</m>, but there's one final complication: If a term in <m>y_p</m> is also a term in the homogeneous solution <m>y_h</m>, then that term cannot contribute to generating <m>f(x)</m>. Instead, it will give zero, since that is what terms in <m>y_h</m> do when substituted into the differential equation.
 		</p>
 
 		<p>
@@ -547,7 +547,7 @@
 		</p>
 
 		<p>
-			Notice that <m>y_h</m> and  in <m>y_p</m> contain the like terms: <m>c_2 e^{3x}</m> and <m>A e^{3x}</m>. This means that plugging <m>y_p</m> into the left side of the equation will simplify to <m>0</m>, not <m>e^{3x}</m>, as required. 
+			Notice that <m>y_h</m> and <m>y_p</m> contain the like terms: <m>c_2 e^{3x}</m> and <m>A e^{3x}</m>. This means that plugging <m>y_p</m> into the left side of the equation will simplify to <m>0</m>, not <m>e^{3x}</m>, as required. 
 		</p>
 
 		<p>
@@ -648,7 +648,8 @@
 					<p><m>\ds y''' + 4y' = \cos(2x) - \sin(x)</m></p>
 					<p>
 						<solution>
-							<ol marker="a.">
+							<p>
+								<ol marker="a.">
 								<li>
 									<p>
 										Since the characteristic equation is
@@ -680,6 +681,7 @@
 									</p>
 								</li>
 							</ol>
+							</p>
 						</solution>
 					</p>
 				</sidebyside>


### PR DESCRIPTION
# sec-selecting-the-particular-soln_MC-edit notes
Set: v1.9 (LAW+SPEC+WORKFLOW) | Folder: c9 / Chapter Ten | Date: 2026-01-18 Applied totals: VR=4 | M=1 | C=4

## VERIFY-REQUIRED (applied) — FIRST
VR-001 | cardsort in chkpt-1 | <match> block missing <premise> and has multiple <response> | conf(H) | verify: ensure cardsort pairs | refs:— VR-002 | cardsort in chkpt-5 | multiple <match> blocks missing <premise> and/or have multiple <response>; one response uses sin(2x)/cos(2x) with premise x sin x | conf(M) | verify: rebuild cardsort mapping | refs:— VR-003 | example (Modifying the Initial Form of y_p), first sidebyside solution | nested <li><li> structure inside <ol> likely invalid PTX | conf(H) | verify: remove extra <li> wrapper | refs:— VR-004 | reading question cyu-4 cardsort | several <match> blocks missing <premise> (responses only) and first match has two <premise> | conf(H) | verify: complete premise/response pairs | refs:—

## Math/logic (applied)
M-001  | example in 'Combining Basic Forms via Addition' | changed e^{w}→e^{x} in equation and y_p (w was inconsistent with y'') | why: variable consistency

## Copy edits (applied)
C-001 | same example | 'This matches is' → 'This matches an' C-002 | solution under y''' + 4y' example | wrapped <ol> in <p> (PreTeXt list-in-<p> requirement) C-003 | Modifying Particular Solutions paragraph | inserted missing words: 'is also' C-004 | Modifying Particular Solutions paragraph | restored missing y_p in 'Notice that y_h and y_p…'

## References
(none — V0 consistency checks only)