### PR TITLE
Update sec-uc-method.ptx

### DIFF
--- a/source/c9-uc/sec-uc-method.ptx
+++ b/source/c9-uc/sec-uc-method.ptx
@@ -108,7 +108,7 @@
 		</p>
 
 		<p>
-			Assuming the forcing function is of the type found in <xref ref="yp-forms-table"/>, this process should always lead to a single solution. If not, then double check your work and make sure the form of <m>y_p</m> was selected and modified correctly.
+			Assuming the forcing function is of the type found in <xref ref="yp-forms-table"/>, this process should always lead to a single solution. If not, then double-check your work and make sure the form of <m>y_p</m> was selected and modified correctly.
 		</p>
 
 		<exercise label="uc-method-chkpt-1">
@@ -833,12 +833,12 @@
 				<title><e component="emoji">🤔💭</e> SOV and Nonlinear Equations</title>
 				<statement correct="no">
 					<p>
-						The separation of variables method cannot be applied to non-linear differential equations.
+						The separation of variables method cannot be applied to nonlinear differential equations.
 					</p>
 				</statement>
 				<feedback>
 					<p>
-						Being able to solve non-linear differential equations is one of the strengths of the separation of variables method.
+						Solving nonlinear differential equations is one of the strengths of the separation of variables method.
 					</p>
 				</feedback>
 			</task>
@@ -847,7 +847,7 @@
 
 				<statement>
 					<p>
-						Suppose you want to use separation of variables method to determine the general solution of the differential equation
+						Suppose you want to use the separation of variables method to determine the general solution of the differential equation
 						<men xml:id="chkpt-uc-method-examples-1-eqn">
 							\ds \frac{dq}{dt} - 3qt^2 = 2q
 						</men>.
@@ -1061,7 +1061,7 @@
 						</statement>
 						<feedback>
 							<p>
-								Incorrect, you should not combine constants here since <m>\frac{c_1}{x}</m> is not constant. Instead your solution should be left as
+								Incorrect, you should not combine constants here since <m>\frac{c_1}{x}</m> is not constant. Instead, your solution should be left as
 								<md>
 									<mrow>	xy	\amp =	e^x + c_1													</mrow>
 									<mrow>	y	\amp =	\frac{e^x + c_1}{x}											</mrow>

--- a/source/c9-uc/sec-uc-method.ptx
+++ b/source/c9-uc/sec-uc-method.ptx
@@ -47,9 +47,9 @@
 		<p>
 			Now, pick <m>y_p</m> to match <m>f(x) = 2x^2 + 3x</m>. Since <m>f(x)</m> is a quadratic polynomial, we guess
 			<me> y_p = A x^2 + B x + C. </me>
-			<p>
-				Since <m>y_p</m> has no terms in common with <m>y_h</m>, no modification is needed.
-			</p>
+		</p>
+		<p>
+			Since <m>y_p</m> has no terms in common with <m>y_h</m>, no modification is needed.
 		</p>
 
 		<p>
@@ -140,7 +140,7 @@
 	</subsection>
 
 	<subsection label="uc-method-steps">
-		<title>Undetermined Coefficient Method Steps</title>
+		<title>Method of Undetermined Coefficients Steps</title>
 
 		<p>
 			Let's summarize the entire process of using the Method of Undetermined Coefficients. Your goal is to find the full general solution <m>y = y_h + y_p</m> by first solving the homogeneous equation and then selecting, modifying, and finding <m>y_p</m>.
@@ -154,7 +154,7 @@
 					a_n y^{(n)} + a_{n-1} y^{(n-1)} + \dots + a_1 y' + a_0 y = f(x)
 				</men>,
 				is determined from the following steps:
-			</p>
+
 
 			<dl width="narrow">
 				<li xml:id="uc-step-1">
@@ -195,6 +195,7 @@
 					</p>
 				</li>
 			</dl>
+			</p>
 		</exploration>
 
 		<p>
@@ -203,7 +204,7 @@
 
 		<exercise label="uc-method-steps-chkpt-bundle">
 			<task label="uc-method-chkpt-2">
-				<title><e component="emoji">📖❓</e>  Not A Step in the Undetermined Coefficient Method</title>
+				<title><e component="emoji">📖❓</e>  Steps for Finding <m>y_p</m></title>
 				<statement>
 					<p>
 						What are the main steps for finding <m>y_p</m> using the method of undetermined coefficients?
@@ -499,19 +500,19 @@
 						</p>
 					</sidebyside>
 					<sidebyside>
-						<p>substitute <m>y_p</m>, <m>y_p'</m>:</p>
+						<p>substitute <m>y_p</m>, <m>y_p''</m>:</p>
 						<p/>
 					</sidebyside>
 				</sbsgroup>
 
 				<me>
-					(-4A \cos 2x - 4B \sin 2x) + (-2A \sin 2x + 2B \cos 2x) = \cos 2x
+					(-4A \cos 2x - 4B \sin 2x) + (A \cos 2x + B \sin 2x) = \cos 2x
 				</me>
 
 				<sbsgroup widths="30% 66%" margins="2% 2%" valign="middle">
 					<sidebyside widths="24% 72%">
 						<p>group like-terms:</p>
-						<p><m>\ds (-4A + 2B) \cos 2x + (-2A - 4B) \sin 2x = \cos 2x </m></p>
+						<p><m>\ds (-3A) \cos 2x + (-3B) \sin 2x = \cos 2x </m></p>
 					</sidebyside>
 					<sidebyside widths="14% 27% 4% 27% 4% 20%">
 						<p>
@@ -519,41 +520,31 @@
 						</p>
 						<p>
 							<md>
-								<mrow> -4A + 2B	\amp = 1 </mrow>
-								<mrow> -2A - 4B	\amp = 0 </mrow>
+								<mrow> -3A	\amp = 1 </mrow>
+								<mrow> -3B	\amp = 0 </mrow>
 							</md>
 						</p>
 						<p>
 							<md>
 								<mrow>	\Rightarrow	</mrow>
-							</md>
-						</p>
-						<p>
-							<md>
-								<mrow> -4A + 2B	\amp = 1 </mrow>
-								<mrow> 4A + 8B	\amp = 0 </mrow>
-							</md>
-						</p>
-						<p>
-							<md>
 								<mrow>	\Rightarrow	</mrow>
 							</md>
 						</p>
 						<p>
 							<md>
-								<mrow> A	\amp = \sfrac{2}{10} </mrow>
-								<mrow> B	\amp = \sfrac{1}{10} </mrow>
+								<mrow> A	\amp = -\sfrac{1}{3} </mrow>
+								<mrow> B	\amp = 0 </mrow>
 							</md>
 						</p>
 					</sidebyside>
 					<sidebyside>
 						<p>particular solution:</p>
-						<p><m>\ds y_p = \frac{2}{10} \sin 2x + \frac{1}{10} \cos 2x </m></p>
+						<p><m>\ds y_p = -\frac{1}{3} \cos 2x </m></p>
 					</sidebyside>
 				</sbsgroup>
 
 				<p><xref ref="uc-step-5" text="title"/></p>
-				<me> y = c_1 \cos x + c_2 \sin x + \frac{2}{10} \sin 2x + \frac{1}{10} \cos 2x </me>
+				<me> y = c_1 \cos x + c_2 \sin x - \frac{1}{3} \cos 2x </me>
 			</solution>
 		</example>
 
@@ -734,7 +725,7 @@
 					<mrow>			\amp = (A + D)\cos x + (-B + C)\sin x + Cx\cos x - Ax\sin x </mrow>
 					<mrow> y_p''	\amp = -(A + D)\sin x + (-B + C)\cos x </mrow>
 					<mrow> 			\amp \hspace{4cm} + C\cos x - Cx\sin x - A\sin x - Ax\cos x </mrow>
-					<mrow>			\amp = (-B + 2C)\cos x + (-2A + D)\sin x - Ax\cos x - Cx\sin x</mrow>
+					<mrow>			\amp = (-B + 2C)\cos x + (-2A - D)\sin x - Ax\cos x - Cx\sin x</mrow>
 				</md>
 
 				<p>substitute <m>y_p''</m>, <m>y_p'</m>:</p>
@@ -746,8 +737,8 @@
 				<p>group like-terms:</p>
 				<md>
 					<mrow> \amp (-B + 2C - 10A - 10D)\cos x </mrow>
-					<mrow> \amp +\ (-2A + D + 10B - 10C)\sin x </mrow>
-					<mrow> \amp +\ (-A + C)\ x\cos x + {\DLO (-C - A)}\ x\sin x = {\DLO 1} x \sin x </mrow>
+					<mrow> \amp +\ (10B - 2A - D - 10C)\sin x </mrow>
+					<mrow> \amp +\ (-A - 10C)\ x\cos x + {\DLO (10A - C)}\ x\sin x = {\DLO 1} x \sin x </mrow>
 				</md>
 
 				<p>
@@ -758,7 +749,7 @@
 						<p>
 							<md>
 								<mrow> -B + 2C - 10A - 10D	\amp = 0 </mrow>
-								<mrow> -2A + D + 10B - 10C	\amp = 0 </mrow>
+								<mrow> 10B - 2A - D - 10C	\amp = 0 </mrow>
 							</md>
 						</p>
 						<p/>
@@ -768,8 +759,8 @@
 						<p/>
 						<p>
 							<md>
-								<mrow> -A + C			\amp = 0 </mrow>
-								<mrow> {\DLO -C - A}	\amp = {\DLO 1} </mrow>
+								<mrow> -A - 10C			\amp = 0 </mrow>
+								<mrow> {\DLO 10A - C}	\amp = {\DLO 1} </mrow>
 							</md>
 						</p>
 						<p>
@@ -779,22 +770,22 @@
 						</p>
 						<p>
 							<md>
-								<mrow> A	\amp = \sfrac12 </mrow>
-								<mrow> C	\amp = \sfrac12 </mrow>
+								<mrow> A	\amp = \sfrac{10}{101} </mrow>
+								<mrow> C	\amp = -\sfrac{1}{101} </mrow>
 							</md>
 						</p>
 					</sidebyside>
 				</p>
 
 				<p>
-					Substituting <m>A = \sfrac12</m> and <m>C = \sfrac12</m> into the first two equations gives:
+					Substituting <m>A = \sfrac{10}{101}</m> and <m>C = -\sfrac{1}{101}</m> into the first two equations gives:
 				</p>
 
 				<sidebyside widths="30% 4% 30% 4% 20%" valign="middle" margins="6% 6%">
 					<p>
 						<md>
-							<mrow> -B - 10D	\amp = 4 </mrow>
-							<mrow> 10B + D	\amp = 6 </mrow>
+							<mrow> -B - 10D	\amp = \sfrac{102}{101} </mrow>
+							<mrow> 10B - D	\amp = \sfrac{10}{101} </mrow>
 						</md>
 					</p>
 					<p>
@@ -804,8 +795,8 @@
 					</p>
 					<p>
 						<md>
-							<mrow> -10B - 100D	\amp = 40 </mrow>
-							<mrow> 10B + D	\amp = 6 </mrow>
+							<mrow> -10B - 100D	\amp = \sfrac{1020}{101} </mrow>
+							<mrow> 10B - D	\amp = \sfrac{10}{101} </mrow>
 						</md>
 					</p>
 					<p>
@@ -815,19 +806,19 @@
 					</p>
 					<p>
 						<md>
-							<mrow> B	\amp = \sfrac{64}{99} </mrow>
-							<mrow> D	\amp = \sfrac{46}{99} </mrow>
+							<mrow> B	\amp = -\sfrac{2}{10201} </mrow>
+							<mrow> D	\amp = -\sfrac{1030}{10201} </mrow>
 						</md>
 					</p>
 				</sidebyside>
 
 				<p>particular solution:</p>
-				<me> y_p = \left(\frac{1}{2} + \frac{64}{99}x\right) \cos x + \left(\frac{1}{2} + \frac{46}{99}x\right) \sin x </me>
+				<me> y_p = \left(\frac{10}{101}x - \frac{2}{10201}\right) \cos x + \left(-\frac{1}{101}x - \frac{1030}{10201}\right) \sin x </me>
 				
 				<p><xref ref="uc-step-5" text="title"/></p>
 
 				<p> General solution:</p>
-				<me> y = c_1 \cos x + c_2 \sin x + \left(\frac{1}{2} + \frac{64}{99}x\right) \cos x + \left(\frac{1}{2} + \frac{46}{99}x\right) \sin x </me>
+				<me> y = c_1 + c_2 e^{10x} + \left(\frac{10}{101}x - \frac{2}{10201}\right) \cos x + \left(-\frac{1}{101}x - \frac{1030}{10201}\right) \sin x </me>
 			</solution>
 		</example>
 
@@ -856,7 +847,7 @@
 
 				<statement>
 					<p>
-						CONVERT TO PARSONS.. Suppose you want to use separation of variables method to determine the general solution of the differential equation
+						Suppose you want to use separation of variables method to determine the general solution of the differential equation
 						<men xml:id="chkpt-uc-method-examples-1-eqn">
 							\ds \frac{dq}{dt} - 3qt^2 = 2q
 						</men>.
@@ -924,7 +915,7 @@
 					<match>
 						<premise>
 							<p>
-								<line><m>\ds \ln|q| = 2t^2 + t^3 + c</m></line>
+								<line><m>\ds \ln|q| = 2t + t^3 + c</m></line>
 							</p>
 						</premise>
 						<response>
@@ -936,7 +927,7 @@
 					<match>
 						<premise>
 							<p>
-								<line><m>\ds q = c e\vphantom{|}^{\large 2t^2 + t^3}</m></line>
+								<line><m>\ds q = c e\vphantom{|}^{\large 2t + t^3}</m></line>
 							</p>
 						</premise>
 						<response>
@@ -972,10 +963,10 @@
 							<p>
 								Correct, since
 								<md>
-									<mrow>	|y|	\amp =,	e^{2x + c_1}										</mrow>
-									<mrow>	y	\amp =,	\pm e^{2x + c_1}									</mrow>
-									<mrow>	y	\amp =,	\pm e^{2x} \cdot e^{c_1}							</mrow>
-									<mrow>	y	\amp =,	c_2 e^{2x}	\quad \text{where } c_2 = \pm e^{c_1}	</mrow>
+									<mrow>	|y|	\amp =	e^{2x + c_1}										</mrow>
+									<mrow>	y	\amp =	\pm e^{2x + c_1}									</mrow>
+									<mrow>	y	\amp =	\pm e^{2x} \cdot e^{c_1}							</mrow>
+									<mrow>	y	\amp =	c_2 e^{2x}	\quad \text{where } c_2 = \pm e^{c_1}	</mrow>
 								</md>
 							</p>
 						</feedback>
@@ -996,9 +987,9 @@
 							<p>
 								Correct, since
 								<md>
-									<mrow>	\frac{y^2}{2}	\amp =,	\sin(x) + c_1									</mrow>
-									<mrow>	y^2				\amp =,	\sin(x) + 2c_1									</mrow>
-									<mrow>	y^2				\amp =,	2\sin(x) + c_2	\quad \text{where } c_2 = 2c_1	</mrow>
+									<mrow>	\frac{y^2}{2}	\amp =	\sin(x) + c_1									</mrow>
+									<mrow>	y^2				\amp =	\sin(x) + 2c_1									</mrow>
+									<mrow>	y^2				\amp =	2\sin(x) + c_2	\quad \text{where } c_2 = 2c_1	</mrow>
 								</md>
 							</p>
 						</feedback>
@@ -1023,8 +1014,8 @@
 							<p>
 								Your solution should be written as
 								<md>
-									<mrow>	y^2	\amp =,	2\sin(x) + c_2											</mrow>
-									<mrow>	y	\amp =,	\pm\sqrt{2\sin(x) + c_2}\quad \leftarrow\text{ done}	</mrow>
+									<mrow>	y^2	\amp =	2\sin(x) + c_2											</mrow>
+									<mrow>	y	\amp =	\pm\sqrt{2\sin(x) + c_2}\quad \leftarrow\text{ done}	</mrow>
 								</md>
 							</p>
 						</feedback>
@@ -1050,8 +1041,8 @@
 							<p>
 								Your solution should be
 								<md>
-									<mrow>	e^y	\amp =,	3y + c_1									</mrow>
-									<mrow>	y	\amp =,	\ln(3y + c_1)\quad \leftarrow\text{ done}	</mrow>
+									<mrow>	e^y	\amp =	3y + c_1									</mrow>
+									<mrow>	y	\amp =	\ln(3y + c_1)\quad \leftarrow\text{ done}	</mrow>
 								</md>
 							</p>
 						</feedback>
@@ -1072,9 +1063,9 @@
 							<p>
 								Incorrect, you should not combine constants here since <m>\frac{c_1}{x}</m> is not constant. Instead your solution should be left as
 								<md>
-									<mrow>	xy	\amp =,	e^x + c_1													</mrow>
-									<mrow>	y	\amp =,	\frac{e^x + c_1}{x}											</mrow>
-									<mrow>	y	\amp =,	\frac{e^x}{x} + \frac{c_1}{x}\quad \leftarrow\text{ done}	</mrow>
+									<mrow>	xy	\amp =	e^x + c_1													</mrow>
+									<mrow>	y	\amp =	\frac{e^x + c_1}{x}											</mrow>
+									<mrow>	y	\amp =	\frac{e^x}{x} + \frac{c_1}{x}\quad \leftarrow\text{ done}	</mrow>
 								</md>
 							</p>
 						</feedback>
@@ -1095,10 +1086,10 @@
 							<p>
 								Correct, since
 								<md>
-									<mrow>	\sqrt{y}	\amp =,	c_1e^{3x}									</mrow>
-									<mrow>	y			\amp =,	(c_1e^{3x})^2								</mrow>
-									<mrow>	y			\amp =,	c_1^2(e^{3x})^2								</mrow>
-									<mrow>	y			\amp =,	c_2\, e^{6x}\quad \text{where } c_2 = c_1^2	</mrow>
+									<mrow>	\sqrt{y}	\amp =	c_1e^{3x}									</mrow>
+									<mrow>	y			\amp =	(c_1e^{3x})^2								</mrow>
+									<mrow>	y			\amp =	c_1^2(e^{3x})^2								</mrow>
+									<mrow>	y			\amp =	c_2\, e^{6x}\quad \text{where } c_2 = c_1^2	</mrow>
 								</md>
 							</p>
 						</feedback>


### PR DESCRIPTION
# sec-uc-method — MC-edit notes (2026-01-19)

Totals: VR=0 | M=3 | C=6

## Math/logic (applied)
M-001 | Trigonometric Forcing Function | corrected substitution to use y_p and y_p'' for y''+y, re-solved coefficients, updated y_p and general solution | why:objective DE substitution M-002 | Forcing Function as a Product | corrected y_p'' simplification, regrouped coefficients, solved system, updated y_p and general solution (incl. y_h = c_1 + c_2 e^{10x}) | why:objective algebra/ODE structure M-003 | cardsort “ln|q|” | corrected ∫(2+3t^2)dt to 2t + t^3 (and updated exponent) | why:integration error

## Copy edits / PTX-safety (applied)
C-001 | “Now, pick y_p …” | repaired invalid nested <p> by splitting into two paragraphs
C-002 | “is determined from the following steps:” | List-in-<p> repair: moved <dl> into preceding <p> and closed </p> after </dl>
C-003 | “CONVERT TO PARSONS..” | removed internal dev note from student-facing text C-004 | subsection title | “Undetermined Coefficient…” → “Method of Undetermined Coefficients…” C-005 | uc-method-chkpt-2 title | aligned title with actual prompt (steps for finding y_p) C-006 | multiple | removed stray commas after equals in aligned math (“\amp =,” → “\amp =”)

## References
None (V0 in-file proof only)