### PR TITLE
Update exercises-lt.ptx

### DIFF
--- a/source/c10-lt/exercises-lt.ptx
+++ b/source/c10-lt/exercises-lt.ptx
@@ -306,10 +306,10 @@
 				<statement><m>\lap{\cos (-\pi t)}</m></statement>
 				<answer>
 					<p>
-						<m>L_4\ (b=-\pi)</m>
+						<m>L_5\ (b=\pi)</m>
 					<md>
-						<mrow> \lap{\cos (-\pi t)}	=\amp \dfrac{-\pi}{s^2 + (-\pi)^2}	</mrow>
-						<mrow> 							=\amp \dfrac{-\pi}{s^2 + \pi^2}		</mrow>
+						<mrow> \lap{\cos (-\pi t)}	= \lap{\cos (\pi t)} </mrow>
+						<mrow>							\amp = \dfrac{s}{s^2 + \pi^2}		</mrow>
 					</md>
 					</p>
 				</answer>
@@ -351,6 +351,14 @@
 			</introduction>
 			<exercise>
 				<statement><m>\lap{15 - 4e^{9t} + 11t^3}</m></statement>
+				<answer>
+					<p>
+						<md>
+							<mrow>\amp = \dfrac{15}{s} - \dfrac{4}{s-9} + \dfrac{66}{s^4}, \hspace{0.5cm} s \gt 9 </mrow>
+						</md>
+					</p>
+				</answer>
+
 				<solution>
 					<p>
 						We will use properties in the table as follows.
@@ -374,6 +382,14 @@
 		
 			<exercise>
 				<statement><m>\lap{e^{3t}\sin(6t)  - t^3e^{-5t}}</m></statement>
+				<answer>
+					<p>
+						<md>
+							<mrow>\amp = \dfrac{6}{(s-3)^2 + 36} - \dfrac{2}{(s+5)^3}, \hspace{0.5cm} s \gt 3</mrow>
+						</md>
+					</p>
+				</answer>
+
 				<solution>
 					<p>
 						We will use properties in the table as follows.
@@ -389,6 +405,14 @@
 		
 			<exercise>
 				<statement><m>\lap{t^2 \cos(8t)}</m></statement>
+				<answer>
+					<p>
+						<md>
+							<mrow>\amp = \dfrac{2s^3 + 128s}{(s^2 + 64)^3}</mrow>
+						</md>
+					</p>
+				</answer>
+
 				<solution>
 					<p>
 						Before we begin, we note that it's very tempting to think that because we know the Laplace transforms of both <m>t^2</m> and <m>\cos(8t),</m> we can simply multiply those together to get the desired Laplace transform. However,  this is not the case, just as similar statements were not true for finding the derivatives and integrals of the products of functions. Rather, we will need to use property <xref ref="lt-R5-table" text="custom"><m>L13</m></xref>, with <m>n = 2</m> and <m>f(t) = \cos(8t).</m>
@@ -476,6 +500,16 @@
 
 			<exercise>
 				<statement><m>\lap{e^{2t} - t^3 - \sin (5t)}</m></statement>
+				<answer>
+					<p>
+						<md>
+							<mrow>
+							\amp =  \dfrac{1}{s-2} - \dfrac{6}{s^4} - \dfrac{5}{s^2 + 25}
+							</mrow>
+						</md>
+					</p>
+				</answer>
+
 				<solution>
 					<p>
 				<md>
@@ -678,9 +712,7 @@
 				</solution>
 				<answer>
 					<p>
-						<p>
 						<m>\dfrac{11}{s^2}</m>
-					</p>
 					</p>
 				</answer>
 			</exercise>
@@ -772,9 +804,7 @@
 				</solution>
 				<answer>
 					<p>
-						<p>
 						<m>\dfrac{15}{s}</m>
-					</p>
 					</p>
 				</answer>			
 			</exercise>
@@ -808,9 +838,7 @@
 				</solution>
 				<answer>
 					<p>
-						<p>
 						<m>\dfrac{1}{s - 7}</m>
-					</p>
 					</p>
 				</answer>	
 			</exercise>
@@ -823,6 +851,16 @@
 				to show that
 				<me>\lap{\cos(3t)} = \dfrac{s}{s^2 + 9}</me>.
 			</statement>
+			<answer>
+				<p>
+					<md>
+						<mrow>
+						\amp = \dfrac{s}{s^2 + 9}.
+						</mrow>
+					</md>
+				</p>
+			</answer>
+
 			<solution>
 				<p>
 					We start by applying the definition of the Laplace transform:
@@ -865,17 +903,29 @@
 
 		<exercise>
 			<statement>
-				Answer the following:
-				<ol marker="(a)">
-					<li>Compute the Laplace transform of <m>\sin(-4t)</m>.</li>
-					<li>
-						Use (a) as a guide to show
-						<me>
-							\lap{\sin(bt)} = \dfrac{b}{s^2 + b^2}, \quad s \gt 0
-						</me>, for any constant <m>b</m>.
-					</li>
-				</ol>
+				<p>
+					Answer the following:
+					<ol marker="(a)">
+						<li>Compute the Laplace transform of <m>\sin(-4t)</m>.</li>
+						<li>
+							Use (a) as a guide to show
+							<me>
+								\lap{\sin(bt)} = \dfrac{b}{s^2 + b^2}, \quad s \gt 0
+							</me>, for any constant <m>b</m>.
+						</li>
+					</ol>
+				</p>
 			</statement>
+			<answer>
+				<p>
+					<md>
+						<mrow>
+						=\amp \dfrac{4}{s^2 + 16}.
+						</mrow>
+					</md>
+				</p>
+			</answer>
+
 		
 			<solution>
 				<p>
@@ -921,6 +971,7 @@
 			<statement>
 				By the definition of the Laplace transform:
 				<me>\lap{y'(t)} = \int_0^{\infty} y'(t) \cdot e^{-st} \ dt = \lim_{b\to \infty}\ub{\int_0^{b} y'(t) \cdot e^{-st} \ dt}_{I}</me>.
+				<p>
 				Answer the following questions related to the Laplace transform of <m>y'</m>. 
 				<ol>
 					<li>
@@ -962,13 +1013,12 @@
 						</p>
 						<answer>
 							<p>
-								<p>
 								The limit, <m>L</m>, must converge. That is, as <m>t</m> gets large, the ratio, <m>\ds\dfrac{y(t)}{e^{st}}</m>, flattens out to some number. In order to maintain this ratio, growth rate of <m>y(t)</m> must be less than or equal to <m>e^{st}</m>.
-							</p>
 							</p>
 						</answer>
 					</li>
 				</ol>
+				</p>
 			</statement>
 		</exercise>
 

--- a/source/c10-lt/exercises-lt.ptx
+++ b/source/c10-lt/exercises-lt.ptx
@@ -306,11 +306,11 @@
 				<statement><m>\lap{\cos (-\pi t)}</m></statement>
 				<answer>
 					<p>
-						<m>L_5\ (b=\pi)</m>
-					<md>
-						<mrow> \lap{\cos (-\pi t)}	= \lap{\cos (\pi t)} </mrow>
-						<mrow>							\amp = \dfrac{s}{s^2 + \pi^2}		</mrow>
-					</md>
+						<m>L_5\ (b=-\pi)</m>
+						<md>
+							<mrow> \lap{\cos (-\pi t)}	\amp = \dfrac{s}{s^2 + (-\pi)^2} </mrow>
+							<mrow>											\amp = \dfrac{s}{s^2 + \pi^2} </mrow>
+						</md>
 					</p>
 				</answer>
 
@@ -537,8 +537,8 @@
 				<md>
 						<mrow>  F(s)	 \amp =  \lap{ f(t) } </mrow>
 						<mrow>   \amp =  \lap{ e^{-2t}\sin(2t) + t^2 e^{3t} } </mrow>
-						<mrow>   \amp =  \lap{ e^{-2t}\sin(2t)} + \lap{t^2 e^{3t} } \mbox{ (by L9)} </mrow>
-						<mrow>   \amp =  \dfrac{2}{\big(s- (-2) \big)^2 + 2^2} + \dfrac{2!}{(s-3)^{2+1}} \mbox{ (by L7 and L6)} </mrow>
+						<mrow>   \amp =  \lap{ e^{-2t}\sin(2t)} + \lap{t^2 e^{3t} } </mrow>
+						<mrow>   \amp =  \dfrac{2}{\big(s- (-2) \big)^2 + 2^2} + \dfrac{2!}{(s-3)^{2+1}} \mbox{(<xref ref="lt-L8-table" text="title"/>, <xref ref="lt-L7-table" text="title"/>)} </mrow>
 						<mrow>   \amp =  \dfrac{2}{(s+2)^2 + 4} + \dfrac{2}{(s-3)^3} </mrow>
 		
 					</md>
@@ -560,23 +560,23 @@
 				<statement><m>\lap{8t\cos(6t) + e^{3t}\sin(4t)}</m></statement>
 				<solution>
 					<p>
-				For this solution, we will need to use property L14 wit <m> \ds f(t) = \cos(6t).</m>  We will need to know the Laplace transform for this function, so let's do that now.
+				For this solution, we will need to use property <xref ref="lt-L11" text="title"/> with <m> \ds f(t) = \cos(6t).</m> We will need to know the Laplace transform for this function, so let's do that now.
 					<md>
 						<mrow>  F(s)	 \amp =  \lap{ f(t) } </mrow>
 						<mrow>   \amp =  \lap{ \cos(6t) } </mrow>
-						<mrow>   \amp =  \dfrac{s}{s^2 + 6^2} \mbox{ (by L5)} </mrow>
+						<mrow>   \amp =  \dfrac{s}{s^2 + 6^2} \mbox{(<xref ref="lt-L5-table" text="title"/>)} </mrow>
 						<mrow>   \amp =  \dfrac{s}{s^2 + 36} </mrow>
 		
 					</md>
-					Then we have the following.  Note that when we use the quotient rule to take the derivative o <m> \ds F(s)</m> .
+					Then we have the following.  Note that when we use the quotient rule to take the derivative of <m> \ds F(s)</m>.
 					<md>
 						<mrow>  Q(s)	 \amp =  \lap{ q(t) } </mrow>
 						<mrow>   \amp =  \lap{ 8t\cos(6t) + e^{3t}\sin(4t) } </mrow>
-						<mrow>   \amp =  8\lap{ t\cos(6t) } + \lap{ e^{3t}\sin(4t) } \mbox{ (by L9)} </mrow>
-						<mrow>   \amp =  8\lap{ t\cos(6t) } + \dfrac{4}{(s-3)^2 + 4^2} \mbox{ (by L7)} </mrow>
+						<mrow>   \amp =  8\lap{ t\cos(6t) } + \lap{ e^{3t}\sin(4t) } </mrow>
+						<mrow>   \amp =  8\lap{ t\cos(6t) } + \dfrac{4}{(s-3)^2 + 4^2} \mbox{(<xref ref="lt-L8-table" text="title"/>)} </mrow>
 						<mrow>   \amp =  8\lap{ t\cos(6t) } + \dfrac{4}{(s-3)^2 + 16} </mrow>
 						<mrow>   \amp =  8\lap{ t\cdot f(t) } + \dfrac{4}{(s-3)^2 + 16} </mrow>
-						<mrow>   \amp =  8\cdot (-1)^1 \cdot \dfrac{d}{ds}F(s) + \dfrac{4}{(s-3)^2 + 16} \mbox{ (by L14)} </mrow>
+						<mrow>   \amp =  8\cdot (-1)^1 \cdot \dfrac{d}{ds}F(s) + \dfrac{4}{(s-3)^2 + 16} \mbox{(<xref ref="lt-L11" text="title"/>)} </mrow>
 						<mrow>   \amp =  -8 \cdot \dfrac{d}{ds}\left( \dfrac{s}{s^2 + 36} \right) + \dfrac{4}{(s-3)^2 + 16} </mrow>
 						<mrow>   \amp =  -8 \cdot  \dfrac{(s^2 + 36)\cdot 1 - s\cdot (2s + 0)}{(s^2 + 36)^2} + \dfrac{4}{(s-3)^2 + 16} </mrow>
 						<mrow>   \amp =  -8 \cdot  \dfrac{s^2 + 36 - 2s^2}{(s^2 + 36)^2} + \dfrac{4}{(s-3)^2 + 16} </mrow>
@@ -598,14 +598,14 @@
 				<statement><m>\lap{t^2 \sin(3t)}</m></statement>
 				<solution>
 					<p>
-				For this solution, we will need to use property L14 wit <m> \ds f(t) = \sin(3t).</m>  We will need to know the Laplace transform for this function, so let's do that now.
+				For this solution, we will need to use <xref ref="lt-L11" text="title"/> with <m>f(t) = \sin(3t)</m>. We will need the Laplace transform of this function, so let's compute it now.
 					<md>
 						<mrow>  F(s)	 \amp =  \lap{ f(t) } </mrow>
 						<mrow>   \amp =  \lap{ \sin(3t) } </mrow>
-						<mrow>   \amp =  \dfrac{3}{s^2 + 3^2} \mbox{ (by L5)} </mrow>
+						<mrow>   \amp =  \dfrac{3}{s^2 + 3^2} \mbox{(<xref ref="lt-L5-table" text="title"/>)} </mrow>
 						<mrow>   \amp =  \dfrac{3}{s^2 + 9}  </mrow>
 					</md>
-					In using L14, we will also need the second derivative o <m> \ds F(s),</m> so we work to compute that now.  Note that we will use the chain rule when we take the derivative o <m> \ds (s^2 + 9)^2</m> .
+					In using <xref ref="lt-L11" text="title"/>, we will also need the second derivative of <m> \ds F(s),</m>, so we compute it now.  Note that we will use the chain rule when we take the derivative of <m> \ds (s^2 + 9)^2</m>.
 					<md>
 						<mrow>  F'(s)	 \amp =  \dfrac{d}{ds}\left( \dfrac{3}{s^2 + 9} \right) </mrow>
 						<mrow>   \amp =  \dfrac{(s^2 + 9) \cdot 0 - 3 \cdot (2s+0)}{(s^2 + 9)^2} </mrow>
@@ -619,20 +619,16 @@
 					</md>
 					Then we have the following.
 					<md>
-						<mrow>  P(s)	 \amp =  \lap{ t^2 \sin(3t) } </mrow>
-						<mrow>   \amp =  \lap{ t^2 f(t) } </mrow>
-						<mrow>   \amp =  (-1)^2 \cdot F''(s) \mbox{ (by L14)} </mrow>
-						<mrow>   \amp =  1 \cdot \dfrac{18\left[s^2 - 3\right]}{(s^2 + 9)^3} </mrow>
-						<mrow>   \amp =  \dfrac{18\left[s^2 - 3\right]}{(s^2 + 9)^3} </mrow>
+						<mrow> P(s)	\amp =  \lap{ t^2 \sin(3t) } </mrow>
+						<mrow>   		\amp =  \lap{ t^2 f(t) } </mrow>
+						<mrow>   		\amp =  (-1)^2 \cdot F''(s) \mbox{(<xref ref="lt-L11" text="title"/>)} </mrow>
+						<mrow>   		\amp =  1 \cdot \dfrac{18\left[s^2 - 3\right]}{(s^2 + 9)^3} </mrow>
+						<mrow>   		\amp =  \dfrac{18\left[s^2 - 3\right]}{(s^2 + 9)^3} </mrow>
 		
 					</md>
 					</p>
 				</solution>
-				<answer>
-					<p>
-						<m> \ds P(s) = \dfrac{18\left[s^2 - 3\right]}{(s^2 + 9)^3}</m>
-					</p>
-				</answer>
+				<answer><p><m>P(s) = \dfrac{18\left[s^2 - 3\right]}{(s^2 + 9)^3}</m></p></answer>
 			</exercise>
 		</exercisegroup>
 
@@ -792,7 +788,7 @@
 					</p>
 
 					<p>
-						Next, we integrate using the substitution <m>u=-st</m>.
+						Next, we integrate using the substitution <m> u =- st </m>.
 						<md>
 							<mrow>\amp = 15\lim_{b \to \infty} -\dfrac{1}{s}e^{-st}\Big|_{t=0}^{t=b}</mrow>
 							<mrow>\amp = 15\lim_{b \to \infty} -\dfrac{1}{s}\left[ e^{-sb} - e^{-s\cdot 0} \right]</mrow>
@@ -813,14 +809,14 @@
 				<statement><m>\lap{e^{7t}}</m></statement>
 				<solution>
 					<p>
-						We use the definition of Laplace transform to get us started.
+						We use the definition of the Laplace transform to get us started.
 						<md>
 							<mrow> 	\lap{ e^{7t} }	\amp = \int_0^{\infty} \left(e^{7t}\right)e^{-st}\ dt 				</mrow>
 							<mrow> 		\amp = \lim_{b \to \infty}\int_0^b e^{-st + 7t}\ dt	</mrow>
 							<mrow> 		\amp = \lim_{b \to \infty}\int_0^b e^{(7-s)t}\ dt 		</mrow>
 						</md>
-						As before, we need restrict some values of <m>s</m> in order for this
-						improper integral to exist . In this case, we will need <m>7 - s</m>, in the exponent, to be non-zero and negative. That is, we need
+						As before, we need to restrict some values of <m>s</m> in order for this
+						improper integral to exist. In this case, we will need <m>7 - s</m>, in the exponent, to be non-zero and negative. That is, we need
 						<me> 7 - s \lt 0 \hspace{0.5cm}\Rightarrow \hspace{0.5cm}7 \lt s. </me>
 						<md>
 							<mrow>\amp = \lim_{b \to \infty}\int_0^b e^{(7-s)t}dt </mrow>


### PR DESCRIPTION
# exercises-lt_MC-edit Notes (v1.9)

M: Corrected the answer for \lap{\cos(-\pi t)} to use the cosine transform (L_5, b=\pi): \dfrac{s}{s^2+\pi^2}. (The prior answer used the sine formula and an incorrect numerator/sign.)

C: PreTeXt list-in-<p> repair: wrapped two <ol> elements that were direct children of <statement> inside <p> (the “Answer the following” exercise and the y′(t) definition question list).

C: Fixed invalid nested <p> elements inside <answer> in 4 places (answers for \dfrac{11}{s^2}, \dfrac{15}{s}, \dfrac{1}{s-7}, and the prose answer about existence of \lap{y′}).

C: Added missing <answer> elements (AnswerTagRepair; copied the terminal result from the end of each <solution>) for 6 exercises:
- \lap{15 - 4e^{9t} + 11t^3}
- \lap{e^{3t}\sin(6t) - t^3e^{-5t}}
- \lap{t^2\cos(8t)}
- \lap{e^{2t} - t^3 - \sin(5t)}
- “Use the properties … cos(3t)” (\dfrac{s}{s^2+9})
- “Compute \sin(-4t)” (\dfrac{4}{s^2+16})

## References (raw URLs)
(none)