### PR TITLE
Update sec-common-transforms.ptx

### DIFF
--- a/source/c10-lt/sec-common-transforms.ptx
+++ b/source/c10-lt/sec-common-transforms.ptx
@@ -212,7 +212,7 @@
 				</p>
 
 				<p>
-					<proof xml:id="lt-example-2-details"><title>🔍 Focusing just on the integral, we let <m>u=7-s</m> and apply <m>u</m>-substitution:</title>
+					<proof xml:id="lt-example-2-details"><title>🔍 Focusing just on the integral, we let <m>u=(7-s)t</m> and apply <m>u</m>-substitution:</title>
 						<p>
 							👉 Using <m>u</m>-substitution with
 							<md>
@@ -223,17 +223,17 @@
 									du	\amp = (7-s)dt \quad \Rightarrow \quad dt = \frac{du}{7-s}
 								</mrow>
 							</md>
-							the integral is compute as
+							the integral is computed as
 							<md>
 								<mrow>
-									\int_0^b e^{(7-s)t}\ dt	= \int_{t=0}^{t=b} e^{u}\frac{du}{7-s}
-									\amp = \frac{1}{7-s}\int_{t=0}^{t=b} e^{u}\ du
+									\int_0^b e^{(7-s)t}\ dt	= \int_{u=0}^{u=(7-s)b} e^{u}\frac{du}{7-s}
+									\amp = \frac{1}{7-s}\int_{u=0}^{u=(7-s)b} e^{u}\ du
 								</mrow>
 								<mrow>
-									\amp = \frac{1}{7-s} \left[ e^{u} - 1 \right]\Bigg|_{t=0}^{t=b}
+									\amp = \frac{1}{7-s} \left[ e^{u} \right]\Bigg|_{u=0}^{u=(7-s)b}
 								</mrow>
 								<mrow>
-									\amp = \frac{1}{7-s} \left[ e^{7-s} - 1 \right]\Bigg|_{0}^{b}
+									\amp = \frac{1}{7-s} \left[ e^{(7-s)b} - 1 \right]
 								</mrow>
 							</md>.
 						</p>

--- a/source/c10-lt/sec-common-transforms.ptx
+++ b/source/c10-lt/sec-common-transforms.ptx
@@ -15,11 +15,11 @@
 	
 	<introduction>
 		<p>
-			Now that we've defined the Laplace transform, the next step is to build a basic toolkit of common transforms. These are formulas for frequently encountered functions like constants, exponentials, powers of <m>t</m>, and trigonometric functions. Learning these transforms will allow you to compute Laplace transforms quickly, without evaluating integrals from scratch each time.
+			Now that we've defined the Laplace transform, the next step is to build a basic toolkit of common transforms. These are formulas for frequently encountered functions, such as constants, exponentials, powers of <m>t</m>, and trigonometric functions. Learning these transforms will allow you to compute Laplace transforms quickly, without having to evaluate integrals from scratch each time.
 		</p>
 
 		<p>
-			We'll derive these formulas using straightforward examples and then generalize the results. You'll see how the Laplace transform simplifies when applied to each type of function and how certain patterns repeat across different cases.
+			We'll derive these formulas using straightforward examples and then generalize the results. You'll see how the Laplace transform simplifies for each type of function and how certain patterns repeat across cases.
 		</p>
 	</introduction>
 
@@ -88,7 +88,7 @@
 						<statement>limit</statement>
 						<feedback>
 							<p>
-								No, <m>s</m> is not a limit of integration, it appears inside the integrand.
+								No, <m>s</m> is not a limit of integration; it appears inside the integrand.
 							</p>
 						</feedback>
 					</choice>
@@ -188,7 +188,7 @@
 		</assemblage>
 
 		<p>
-			Although this transform is specific to the contant function <m>1</m>, we will see later that it will serve as the transform formula for all constant functions. 
+			Although this transform is specific to the constant function <m>1</m>, we will see later that it will serve as the transform formula for all constant functions. 
 		</p>
 	</subsection>
 
@@ -203,7 +203,7 @@
 			<me>\lap{e^{7t}} = \frac{1}{s - 7}, \quad s \gt 7</me>
 			<solution xml:id="common-exp-7t-details">
 				<p>
-					Using the definition of the Laplace transform we get
+					Using the definition of the Laplace transform, we get
 					<me>
 						\lap{ e^{7t} }
 						= \int_0^{\infty} e^{-st} \cdot e^{7t}\ dt
@@ -396,7 +396,7 @@
 				<li><m>n=0:\qquad\lap{t^0} = \lap{1} = \dfrac{1}{s}</m></li>
 				<li><m>n=1:\qquad\lap{t^1} = \lap{t} = \dfrac{1}{s^2}</m></li>
 			</ul>
-			We could find <m>\lap{t^2}</m> next, but it is more instructive to show following relationship:
+			We could find <m>\lap{t^2}</m> next, but it is more instructive to show the following relationship:
 		</p>
 
 		<p>
@@ -487,12 +487,14 @@
 				</p>
 
 				<p>
-					<proof xml:id="lt-example-tnth-IVP-details"><title>🔍 Apply integration by parts to <m>I</m></title>
+					<proof xml:id="lt-example-tnth-IVP-details">
+						<title>🔍 Apply integration by parts to <m>I</m></title>
 						<p>
+							Using the substitution:
 							<md>
 								<mrow> u = t^n,				\quad\amp	dv = e^{-st}dt, 		</mrow>
 								<mrow> du = nt^{n-1}\ dt,	\quad\amp	v = -\frac{1}{s}e^{-st}	</mrow>
-							</md>
+							</md>, 
 							integration by parts gives
 							<md>
 								<mrow>
@@ -566,7 +568,7 @@
 		</p>
 
 		<p>
-			To get the general formula we apply this relationship repeatedly for increasing <m>n</m>:
+			To get the general formula, we apply this relationship repeatedly for increasing <m>n</m>:
 			<me> 
 				\begin{array}{crcl}
 					n=1:	\amp \DLO\lap{t} \amp =	\amp 
@@ -744,7 +746,7 @@
 						The derivation of L<m>_4</m> mirrors the solution to <m>\lap{\cos(3t)}</m>. Just swap <m>3</m> with <m>b</m> and <m>9</m> with <m>b^2</m>. 
 					</p>
 					<p>
-						The derivation of L<m>_5</m> follows a similar approach to L<m>_4</m> and is left as exercise for you to try on your own.
+						The derivation of L<m>_5</m> follows a similar approach to L<m>_4</m> and is left as an exercise for you to try on your own.
 					</p>
 				</proof>
 			</p>


### PR DESCRIPTION
# sec-common-transforms_MC-edit Notes (v1.9)

M: Corrected the u-substitution setup in the “Focusing just on the integral” proof for \(\int_0^b e^{(7-s)t}\,dt\): fixed the substitution variable to \(u=(7-s)t\), corrected the u-limits (0 to \((7-s)b\)), and corrected the evaluated expression to \(\frac{1}{7-s}(e^{(7-s)b}-1)\).

M: Grammar fix in the same proof: “the integral is compute as” → “the integral is computed as”.

## References (raw URLs)
(none)