### PR TITLE
Update sec-lt-definition.ptx

### DIFF
--- a/source/c10-lt/sec-lt-definition.ptx
+++ b/source/c10-lt/sec-lt-definition.ptx
@@ -122,7 +122,7 @@
 						</me>.
 					</p>
 					<p>
-						Select variables/constants would you expect to see after computing the integral, <m>I</m>, but before taking the limit.
+						Select the variables/constants you would expect to see after computing the integral, <m>I</m>, but before taking the limit.
 					</p>
 					<p/>
 				</statement>
@@ -153,7 +153,7 @@
 		<title>👀 Quick Review: Exponential Properties</title>
 
 		<p>
-			To get through the transform rule derivations, you'll need to be familiar with some key exponential properties that will appear throughtout this chapter.
+			To get through the transform rule derivations, you'll need to be familiar with some key exponential properties that will appear throughout this chapter.
 		</p>
 
 		<paragraphs xml:id="exponential-antiderivative">
@@ -257,7 +257,7 @@
 				<title>Exponential End Behavior</title>
 				<statement>
 					<p>
-						Determine if each limit is -ထ, <m>0</m>, or ထ.
+						Determine if each limit is <m>-\infty</m>, <m>0</m>, or <m>\infty</m>.
 					</p>
 					<p>
 						Click on one of the three options next to each limit to select your answer.
@@ -467,7 +467,7 @@
 							</md>
 
 							<p> 
-								We find the limit using the <xref ref="exponential-end-behavior" text="custom">end behavior of the exponential</xref>. There are two possiblities:<fn> <m>s = 0</m> is excluded since it would lead to <me>\int_0^{\infty}5e^{-0t}\ dt = \int_0^{\infty}5\ dt = \infty</me></fn>
+								We find the limit using the <xref ref="exponential-end-behavior" text="custom">end behavior of the exponential</xref>. There are two possibilities:<fn> <m>s = 0</m> is excluded since it would lead to <me>\int_0^{\infty}5e^{-0t}\ dt = \int_0^{\infty}5\ dt = \infty</me></fn>
 								<ol marker="(1)">
 									<li> <m>s</m> is positive: <m>\ds\quad-sb \to -\infty \ \ \Rightarrow\ \ \lim_{b \to \infty}\ e^{-sb} = 0</m> </li>
 									<li> <m>s</m> is negative: <m>\ds\quad-sb \to +\infty \ \ \Rightarrow\ \ \lim_{b \to \infty}\ e^{-sb} = \infty</m> </li>
@@ -496,7 +496,7 @@
 							</p>
 
 							<p>
-								<proof xml:id="lt-example-t-IVP-details"><title>🔍 Computing <m>I</m> with integration by parts, gives us</title>
+								<proof xml:id="lt-example-t-IVP-details"><title>🔍 Computing <m>I</m> with integration by parts gives us</title>
 									<p>
 										🔍 Choosing
 										<md>
@@ -510,7 +510,7 @@
 													\amp = -\frac{t}{s}e^{-st} - \int_0^b \left( -\frac{1}{s}e^{-st} \right) dt
 											</mrow>
 											<mrow> 	
-													\amp = -\frac{t}{s}e^{-st}+ \frac{1}{s}\int_0^b e^{-st} dt
+													\amp = \left[-\frac{t}{s}e^{-st}\right]_0^b+ \frac{1}{s}\int_0^b e^{-st} dt
 											</mrow>
 											<mrow> 	
 													\amp = \left(-\frac{t}{s}e^{-st}- \frac{1}{s^2}e^{-st}\right) \Bigg|_0^b
@@ -569,7 +569,7 @@
 											</p>
 										</li>
 									</ul>
-									where <m>LH</m> denotes L'Hôpital's Rule was applied to the limit.
+									where <m>LH</m> denotes that L'Hôpital's Rule was applied to the limit.
 								</p>
 							</proof>
 

--- a/source/c10-lt/sec-lt-definition.ptx
+++ b/source/c10-lt/sec-lt-definition.ptx
@@ -109,7 +109,7 @@
 			</p>
 
 			<p>
-				The Laplace transform exists if this limit produces a finite value. Often, exponential decay from <m>e^{-st}</m> guarantees convergence when <m>s</m> is large enough.
+				The Laplace transform exists if this limit is finite. Often, exponential decay from <m>e^{-st}</m> guarantees convergence when <m>s</m> is large enough.
 			</p>
 
 			<exercise label="lt-definition-chkpt-2">
@@ -163,7 +163,7 @@
 				<me>
 					\int e^{Kt}\ dt = \frac1{K} e^{Kt} + C
 				</me>.
-				While this can be found by substituting <m>u=Kt</m>, it is such a common antiderivative that you should just know it without this extra step. 
+				While this can be found by substituting <m>u=Kt</m>, it is so common an antiderivative that you should just know it without this extra step. 
 			</p>	
 		</paragraphs>
 						


### PR DESCRIPTION
# sec-lt-definition_MC-edit Notes (v1.9)

M: In the “Laplace transform of \(t\)” example (integration by parts), corrected the definite-integration notation so the boundary term is properly evaluated: replaced bare \(-\frac{t}{s}e^{-st}\) with \(\left[-\frac{t}{s}e^{-st}\right]_0^b\) in the first two integration-by-parts lines.

M: Replaced corrupted infinity glyphs in the Exponential End Behavior checkpoint prompt (“-ထ … or ထ”) with explicit math: <m>-\infty</m>, <m>0</m>, <m>\infty</m>.

C: Fixed typos/grammar:
- “throughtout” → “throughout”
- “Select variables/constants would you expect …” → “Select the variables/constants you would expect …”
- “possiblities” → “possibilities”
- “where LH denotes L'Hôpital's Rule was applied …” → “where LH denotes that L'Hôpital's Rule was applied …”
- Removed comma in proof title: “integration by parts, gives us” → “integration by parts gives us”

## References (raw URLs)
(none)