### PR TITLE
Update sec-lt-derivative-transfer.ptx

### DIFF
--- a/source/c10-lt/sec-lt-derivative-transfer.ptx
+++ b/source/c10-lt/sec-lt-derivative-transfer.ptx
@@ -215,8 +215,8 @@
 				</mrow>
 				<mrow>
 					\amp = e^{-sb} y(b) - y(0) + {\DLBa s} \int_{0}^{b} {\DLBa e^{-st}} y(t)\, dt
-				</mrow>.
-			</md>
+				</mrow>
+			</md>.
 		</p>
 
 		<p>

--- a/source/c10-lt/sec-lt-derivative-transfer.ptx
+++ b/source/c10-lt/sec-lt-derivative-transfer.ptx
@@ -15,7 +15,7 @@
 
 	<introduction>
 		<p>
-			Before we apply the Laplace transform to solve differential equations, we need to understand its foundational mechanism: transferring derivatives within an integral. This section begins with a quick refresher on integration by parts (IBP), emphasizing how derivatives applied to one function can be shifted to another. This transfer process is the key that unlocks the Laplace transform method.
+			Before we apply the Laplace transform to solve differential equations, we need to understand its fundamental mechanism: transferring derivatives within an integral. This section begins with a quick refresher on integration by parts (IBP), emphasizing how derivatives applied to one function can be shifted to another. This transfer process is the key that unlocks the Laplace transform method.
 		</p>
 	</introduction>
 
@@ -108,7 +108,7 @@
 		</p>
 
 		<p>
-			This simple idea of shifting derivatives is the basis for the Laplace transform method. We'll see it in action when one of the functions is <m>e^{-st}</m>.
+			This simple idea of shifting derivatives underlies the Laplace transform method. We'll see it in action when one of the functions is <m>e^{-st}</m>.
 		</p>
 		
 		<exercise label="derivative-transfer-chkpt-1">
@@ -139,7 +139,7 @@
 					<statement>Integration by Parts</statement>
 					<feedback>
 						<p>
-							Correct! Integration by parts is the key tool that shifts derivatives between functions inside integrals.
+							Correct! Integration by parts is the key tool for shifting derivatives between functions in integrals.
 						</p>
 					</feedback>
 				</choice>
@@ -147,7 +147,7 @@
 					<statement>Implicit Differentiation</statement>
 					<feedback>
 						<p>
-							Incorrect. Implicit differentiation helps with equations where the dependent variable isn't isolated.
+							Incorrect. Implicit differentiation is useful for equations where the dependent variable isn't isolated.
 						</p>
 					</feedback>
 				</choice>
@@ -290,7 +290,7 @@
 						<statement><m>\ds \int t^2 \ y'\ dt = t^2 y - \int y\ dt</m></statement>
 						<feedback>
 							<p>
-								Incorrect. A correct application of integration by parts must include the right choice of <m>u</m> and <m>dv</m>. Try again.
+								Incorrect. A correct application of integration by parts requires the proper choice of <m>u</m> and <m>dv</m>. Try again.
 							</p>
 						</feedback>
 					</choice>
@@ -298,7 +298,7 @@
 						<statement><m>\ds \int t^2 \ y'\ dt = t^2 y - \int t^2 y\ dt</m></statement>
 						<feedback>
 							<p>
-								Incorrect. Be sure you're transferring the derivative and integrating the right part.
+								Incorrect. Be sure you're transferring the derivative and integrating the correct part.
 							</p>
 						</feedback>
 					</choice>


### PR DESCRIPTION
# sec-lt-derivative-transfer_MC-edit Notes (v1.9)

C: Display-math punctuation fix: removed the stray period that appeared as a text node inside the <md> block (after </mrow>) and placed the period after </md>, keeping the sentence punctuation while avoiding punctuation inside the display-math environment.

## References (raw URLs)
(none)