### PR TITLE
Update sec-lt-library.ptx

### DIFF
--- a/source/c10-lt/sec-lt-library.ptx
+++ b/source/c10-lt/sec-lt-library.ptx
@@ -210,7 +210,7 @@
 							<cell>R<m>_{4}</m></cell>
 							<cell><me>e^{at} f(t)</me></cell>
 							<cell><me>F(s-a)</me></cell>
-							<cell><me>s &gt; 0</me></cell>
+							<cell><me>s &gt; a</me></cell>
 						</row>
 						<row bottom="major">
 							<cell>R<m>_{5}</m></cell>

--- a/source/c10-lt/sec-lt-library.ptx
+++ b/source/c10-lt/sec-lt-library.ptx
@@ -15,7 +15,7 @@
 
 	<introduction>
 		<p>
-			In this final section, we summarize everything we've done. Below, you will find tables for the most common Laplace transforms and the properties used to combine and manipulate them. These will provide a useful resource in the next chapter where we begin solving differential equations using the Laplace transform method.
+			In this final section, we summarize everything we've done. Below, you will find tables for the most common Laplace transforms and the properties used to combine and manipulate them. These will provide a useful resource in the next chapter, where we begin solving differential equations using the Laplace transform method.
 		</p>
 	</introduction>
 


### PR DESCRIPTION
# sec-lt-library_MC-edit Notes (v1.9)

M: In the “Table of Laplace Transform Rules” (R₄, frequency shift), corrected the existence condition for \(\lap{e^{at}f(t)} = F(s-a)\) from <m>s &gt; 0</m> to <m>s &gt; a</m>, consistent with the reference table’s convention for exponentials (e.g., \(\lap{e^{at}}\) requires <m>s &gt; a</m>).

## References (raw URLs)
(none)