### PR TITLE
Update sec-lt-properties.ptx

### DIFF
--- a/source/c10-lt/sec-lt-properties.ptx
+++ b/source/c10-lt/sec-lt-properties.ptx
@@ -64,8 +64,8 @@
 			<md>
 				<mrow xml:id="lt-P1">
 					\text{P}_{1}:\quad\lap{af(t) \pm bg(t)} = a \lap{f(t)} \pm b \lap{g(t)}\quad (a, b\ \text{constants})
-				</mrow>.
-			</md>
+				</mrow>
+			</md>.
 		</p>
 
 		<p>
@@ -108,8 +108,8 @@
 					</mrow>
 					<mrow>
 						\amp = \frac{15}{s} + \frac{6}{s-7} - \frac{11}{s^2}, \quad s \gt 7
-					</mrow>.
-				</md>
+					</mrow>
+				</md>.
 				<p>
 					We use <m>s \gt 7</m>, because it guarantees that <m>s \gt 0</m> is also true.
 				</p>
@@ -232,8 +232,8 @@
 				integration by parts gives
 				<md>
 					<mrow>
-						\lap{ t^{n} }
-						\amp = \lim_{b \to \infty} \left[f(t)e^{-sb}\Bigg|_0^b - \int_0^b f(t)\cdot\left(-se^{-st}\right)\ dt\right]
+						\lap{ f'(t) }
+						\amp = \lim_{b \to \infty} \left[e^{-st}f(t)\Big|_0^b - \int_0^b f(t)\cdot\left(-se^{-st}\right)\ dt\right]
 					</mrow>
 					<mrow>
 						\amp = \lim_{b \to \infty} \left[\left(f(b)e^{-sb} - f(0)e^{0}\right) + s\int_0^b e^{-st}\cdot f(t)\ dt\right]
@@ -242,12 +242,12 @@
 						\amp = \lim_{b \to \infty} \left[f(b)e^{-sb} - f(0) + s\int_0^b e^{-st}\cdot f(t)\ dt\right]
 					</mrow>
 					<mrow>
-						\amp = \lim_{b \to \infty} \left[f(b)e^{-sb}\right] - f(0) +  s\lim_{b \to \infty} \left[\int_0^b e^{-st}\cdot f(t)\ dt\right]
+						\amp = \lim_{b \to \infty} \left[f(b)e^{-sb}\right] - f(0) + s\lim_{b \to \infty} \left[\int_0^b e^{-st}\cdot f(t)\ dt\right]
 					</mrow>
 					<mrow>
-						\amp = \lim_{b \to \infty} \left[f(b)e^{-sb}\right] - f(0) +  s\ub{\int_\infty^b e^{-st}\cdot f(t)\ dt}_{\large\lap{f(t)}}
-					</mrow>.
-				</md>
+						\amp = \lim_{b \to \infty} \left[f(b)e^{-sb}\right] - f(0) + s\ub{\int_0^\infty e^{-st}\cdot f(t)\ dt}_{\large\lap{f(t)}}
+					</mrow>
+</md>
 			</p>
 
 			<p>


### PR DESCRIPTION
# sec-lt-properties_MC-edit Notes (v1.9)

M: In the proof “Click here for more details” for \(\lap{f'(t)}\), corrected the integration-by-parts derivation block:
- Replaced the incorrect leading expression \(\lap{t^n}\) with \(\lap{f'(t)}\).
- Corrected the boundary term to \(e^{-st}f(t)\big|_0^b\) (instead of \(f(t)e^{-sb}\big|_0^b\)).
- Corrected the final Laplace-transform identification to use \(\int_0^\infty\) (removed the incorrect \(\int_\infty^b\)).
- Retained the standard conclusion \(\lap{f'(t)} = s\lap{f(t)} - f(0)\).

C: Display-math punctuation fixes (2 places): moved periods that appeared as text nodes inside <md> blocks (after </mrow>) to immediately after </md>.

## References (raw URLs)
(none)