### PR TITLE
Update sec-into-the-laplace-domain.ptx

### DIFF
--- a/source/c11-ltm/sec-into-the-laplace-domain.ptx
+++ b/source/c11-ltm/sec-into-the-laplace-domain.ptx
@@ -105,7 +105,7 @@
 		</p>
 
 		<p>
-			Let's practice this with a one more example.
+			Let's practice this with one more example.
 		</p>
 		
 		<example xml:id="lt-forward-lt-example">
@@ -144,7 +144,7 @@
 				</p>
 
 				<me>
-					\left[s^2 Y(s) - s y(0) - y'(0)\right] -4\left[sY(s) - y(0)\right] + 6 Y(s) = \frac{1}{s^3}
+					\left[s^2 Y(s) - s y(0) - y'(0)\right] -4\left[sY(s) - y(0)\right] + 6 Y(s) = \frac{2}{s^3}
 				</me>.
 
 				<p>
@@ -166,20 +166,20 @@
 			</statement>
 			<choices randomize="yes">
 				<choice correct="yes">
-					<statement><m>\ds s^2Y - 4sY + 6Y - 2s + 1 = \frac{2}{s^3}</m></statement>
-					<feedback>This is the correct transformation using the Laplace transform and applying initial conditions.</feedback>
+					<statement><m>\ds s^2Y - 4sY + 6Y - 2s + 9 = \frac{2}{s^3}</m></statement>
+					<feedback>Correct: apply the transform rules for derivatives, substitute <m>y(0)=2</m>, <m>y'(0)=-1</m>, and use <m>\lap{t^2}=\dfrac{2}{s^3}</m>.</feedback>
 				</choice>
 				<choice>
-					<statement><m>\ds s^2Y - 4sY + 6Y - 2s = \frac{1}{s^3}</m></statement>
-					<feedback>This answer is missing a term.</feedback>
+					<statement><m>\ds s^2Y - 4sY + 6Y - 2s = \frac{2}{s^3}</m></statement>
+					<feedback>This answer is missing the constant term that comes from applying the initial conditions.</feedback>
 				</choice>
 				<choice>
-					<statement><m>\ds s^2Y - 4sY + 6Y + 2s - 1 = \frac{2}{s^3}</m></statement>
-					<feedback>Double check the signs of the initial conditions.</feedback>
+					<statement><m>\ds s^2Y - 4sY + 6Y - 2s + 7 = \frac{2}{s^3}</m></statement>
+					<feedback>Check the sign of the <m>y'(0)</m> term in <m>\lap{y''}</m>; with <m>y'(0)=-1</m> it contributes <m>+1</m>, not <m>-1</m>.</feedback>
 				</choice>
 				<choice>
-					<statement><m>\ds s^2Y - 4sY + 6Y + 1 = \frac{1}{s^3}</m></statement>
-					<feedback>This answer is missing a term.</feedback>
+					<statement><m>\ds s^2Y - 4sY + 6Y + 9 = \frac{2}{s^3}</m></statement>
+					<feedback>This answer is missing the <m>-2s</m> term that comes from the <m>-s y(0)</m> part of <m>\lap{y''}</m>.</feedback>
 				</choice>
 			</choices>
 		</exercise>
@@ -248,8 +248,8 @@
 		</exercise>
 
 		<p>
-            Since the Laplace transform only applies to functions, applying a <q>forward transform to a differential equation</q>, really means we are taking the Laplace transform to both sides of that equation. So, applying a forward transformation to the initial-value problem
-			<me>y' - 9 y= 10 e^{7t}, \quad y(0) = 1</me>
+            Since the Laplace transform only applies to functions, applying a <q>forward transform to a differential equation</q> really means we are taking the Laplace transform of both sides of that equation. So applying a forward transformation to the initial-value problem
+			<me>y' - 9y = 10 e^{7t}, \quad y(0) = 1</me>
 			implies that we multiply both sides of the equation by <m>e^{-st}</m> and integrate from <m>0</m> to <m>\infty</m>:
 		</p>
 

--- a/source/c11-ltm/sec-into-the-laplace-domain.ptx
+++ b/source/c11-ltm/sec-into-the-laplace-domain.ptx
@@ -86,7 +86,7 @@
 		</p>
 
 		<p>
-			Using the <xref ref="lt-P1" text="custom">linearity property</xref> we can see that the transform applies to each term:
+			Using the <xref ref="lt-P1" text="custom">linearity property</xref>, we can see that the transform applies to each term:
 			<me>\lap{y''} - 9\lap{y} = 10\lap{e^{2t}}.</me>
 		</p>
 
@@ -101,7 +101,7 @@
 		</p>
 
 		<p>
-			Our new unknown is <m>Y</m> and since the derivatives have been eliminated, we can use algebra to solve for it. In fact, the solution to our differential equation is actually hiding inside <m>Y</m>. So, by solving for <m>Y</m> you are also solving for <m>y(t)</m> at the same time!
+			Our new unknown is <m>Y</m>, and since the derivatives have been eliminated, we can use algebra to solve for it. In fact, the solution to our differential equation is actually hiding inside <m>Y</m>. So, by solving for <m>Y</m> you are also solving for <m>y(t)</m> at the same time!
 		</p>
 
 		<p>
@@ -248,7 +248,7 @@
 		</exercise>
 
 		<p>
-            Since the Laplace transform only applies to functions, applying a <q>forward transform to a differential equation</q> really means we are taking the Laplace transform of both sides of that equation. So applying a forward transformation to the initial-value problem
+      Since the Laplace transform only applies to functions, applying a <q>forward transform to a differential equation</q> really means we are taking the Laplace transform of both sides of that equation. So applying a forward transformation to the initial-value problem
 			<me>y' - 9y = 10 e^{7t}, \quad y(0) = 1</me>
 			implies that we multiply both sides of the equation by <m>e^{-st}</m> and integrate from <m>0</m> to <m>\infty</m>:
 		</p>


### PR DESCRIPTION
# c11 Chapter 12 — sec-into-the-laplace-domain
Date: 2026-01-20  
Edits: VR=0 | M=2 | C=2

## Math/logic (applied)
- M-001 | anchor: `\lap{t^2}` in example solution | corrected RHS from `\frac{1}{s^3}` to `\frac{2}{s^3}` | why: `\lap{t^2}=\dfrac{2}{s^3}`
- M-002 | anchor: `lt-method-step1-chkpt-1` | corrected the correct choice and updated distractors/feedback to match the forward-transformed equation `s^2Y - 4sY + 6Y - 2s + 9 = \frac{2}{s^3}` for `y'' - 4y' + 6y = t^2`, `y(0)=2`, `y'(0)=-1` | why: previous answer set had incorrect constant/RHS

## Copy edits (applied)
- C-001 | anchor: `Let's practice this with a one more example.` | removed extra article (`a one` → `one`)
- C-002 | anchor: `Since the Laplace transform only applies to functions, ...` | removed stray comma; clarified wording (`transform of both sides`); corrected spacing in displayed IVP (`9y =`)

## References
None (V0: in-file + direct verification).