### PR TITLE
Update sec-laplace-transform-method.ptx

### DIFF
--- a/source/c11-ltm/sec-laplace-transform-method.ptx
+++ b/source/c11-ltm/sec-laplace-transform-method.ptx
@@ -15,7 +15,7 @@
 
 	<introduction>
 		<p>
-			This closing section is where the entire Laplace transform method comes together. You have already practiced each of the three steps in isolation. Now we will zoom out, remind ourselves of the big picture, and then walk through a variety of examples that illustrate how the method is applied from start to finish. These examples are meant to reinforce the process and highlight common patterns, strategies, and adjustments along the way.
+			This closing section is where the entire Laplace transform method comes together. You have already practiced each of the three steps in isolation. Now we will zoom out, review the big picture, and walk through a variety of examples that illustrate how the method is applied from start to finish. These examples are meant to reinforce the process and highlight common patterns, strategies, and adjustments along the way.
 		</p>
 	</introduction>
 
@@ -40,7 +40,7 @@
 					</p>
 					<p/>
 					<p>
-						<me>\DLBa\textbf{2️⃣  Laplace Domain}</me>
+						<me>\DLBa\textbf{2️⃣ Laplace Domain}</me>
 					</p>
 				</sidebyside>
 				<sidebyside widths="31% 18% 43%" valign="top">
@@ -140,7 +140,7 @@
 						<statement> Forward Transform  →  Find <m>Y(s)</m>  →  Prepare  →  Apply Inverse </statement>
 						<feedback>
 							<p>
-								Correct! The Laplace Transform Method involves applying the forward transform, solving for <m> Y(s) </m>, preparing for the backward transform, and applying the inverse transform to find <m> y(t) </m>.
+								Correct! The Laplace Transform Method involves applying the forward transform to obtain <m>Y(s)</m>, preparing for the backward transform, and applying the inverse transform to obtain <m>y(t)</m>.
 							</p>
 						</feedback>
 					</choice>
@@ -148,7 +148,7 @@
 						<statement> Differentiate  →  Forward Transform  →  Find <m>Y(s)</m>  →  Verify Solution </statement>
 						<feedback>
 							<p>
-								Not quite. The Laplace Transform Method does not involve differentiating the equation but rather applying the forward transform to convert it into an algebraic form.
+								Not quite. The Laplace Transform Method does not involve differentiating the equation; rather, it applies the forward transform to convert it into an algebraic form.
 							</p>
 						</feedback>
 					</choice>
@@ -359,7 +359,7 @@
 				<sidebyside widths="83% 17%" valign="middle">
 					<p>
 						<me>
-							Y(s) = \frac{1}{s + 2} + \frac{1}{s + 3}
+							Y(s) = \frac{5}{s + 2} + \frac{-3}{s + 3}
 						</me>
 					</p>
 					<p>Prepared <m>Y</m></p>
@@ -367,7 +367,7 @@
 
 				<p><em><xref ref="lt-step-3" text="title"/></em></p>
 				<md>
-					<mrow>y(t) = \ilap{Y(s)} = \ilap{\frac{1}{s + 2}} + \ilap{\frac{1}{s + 3}}</mrow>
+					<mrow>y(t) = \ilap{Y(s)} = 5\ilap{\frac{1}{s + 2}} - 3\ilap{\frac{1}{s + 3}}</mrow>
 				</md>
 
 				<p>

--- a/source/c11-ltm/sec-laplace-transform-method.ptx
+++ b/source/c11-ltm/sec-laplace-transform-method.ptx
@@ -93,30 +93,30 @@
 					y^{(n)} + a_{n-1}y^{(n-1)} + \dots + a_1y' + a_0y = g(t),
 				</me>
 				the particular solution is obtained through the following workflow:
-						<dl>
-				<li xml:id="lt-step-1">
-					<title>Step 1— Forward Transform</title>
-					<p>
-						Apply <m>\laplacesym</m> term-by-term.  
-						Powers of <m>s</m> replace derivatives, and the initial conditions drop in automatically.  
-						The result is a single algebraic (Laplace-domain) equation.
-					</p>
-				</li>
-
-				<li xml:id="lt-step-2">
-					<title>Step 2— Solve &amp; Prepare <m>Y(s)</m></title>
-					<p>
-						Isolate <m>Y(s)</m>, then reshape it so every term matches an entry in the transform table. This may require tools like partial-fraction decomposition and completing the square.
-					</p>
-				</li>
-
-				<li xml:id="lt-step-3">
-					<title>Step 3— Inverse Transform</title>
-					<p>
-						Apply <m>\laplacesym^{-1}</m> term-by-term.	The hidden original-domain solution <m>y(t)</m> is released, and the IVP is solved.
-					</p>
-				</li>
-			</dl>
+				<dl>
+					<li xml:id="lt-step-1">
+						<title>Step 1— Forward Transform</title>
+						<p>
+							Apply <m>\laplacesym</m> term-by-term.  
+							Powers of <m>s</m> replace derivatives, and the initial conditions drop in automatically.  
+							The result is a single algebraic (Laplace-domain) equation.
+						</p>
+					</li>
+	
+					<li xml:id="lt-step-2">
+						<title>Step 2— Solve &amp; Prepare <m>Y(s)</m></title>
+						<p>
+							Isolate <m>Y(s)</m>, then reshape it so every term matches an entry in the transform table. This may require tools like partial-fraction decomposition and completing the square.
+						</p>
+					</li>
+	
+					<li xml:id="lt-step-3">
+						<title>Step 3— Inverse Transform</title>
+						<p>
+							Apply <m>\laplacesym^{-1}</m> term-by-term.	The hidden original-domain solution <m>y(t)</m> is released, and the IVP is solved.
+						</p>
+					</li>
+				</dl>
 			</p>
 		</exploration>
 
@@ -215,13 +215,14 @@
 
 		<p>
 			The examples below walk through the full process, showing how to transform a differential equation, solve in the Laplace domain, and recover the final solution using the inverse transform. Each is annotated to show where each step begins and ends, so you can clearly see the roadmap in action. Here is a break down of what to expect:
-				<ul>
-			<li>Examples 1–2 ⟶ pure practice: constant-coefficient, homogeneous equations.</li>
-			<li>Examples 3–4 ⟶ common forcing terms: exponentials, polynomials, and sines/cosines.</li>
-			<li>Examples 5–6 ⟶ algebra heavyweights: repeated roots, mixed techniques, and higher order.</li>
-		</ul>
+			<ul>
+				<li>Examples 1–2 ⟶ pure practice: constant-coefficient, homogeneous equations.</li>
+				<li>Examples 3–4 ⟶ common forcing terms: exponentials, polynomials, and sines/cosines.</li>
+				<li>Examples 5–6 ⟶ algebra heavyweights: repeated roots, mixed techniques, and higher order.</li>
+			</ul>
 		</p>
-		<example><title>Basic Second-Order, Homogeneous</title>
+		<example>
+			<title>Basic Second-Order, Homogeneous</title>
 			<statement>
 				<p>
 					Solve the initial value problem using the Laplace transform:
@@ -321,18 +322,17 @@
 
 				<p>
 					Use partial fraction decomposition:
+					<me>
+						\frac{2s + 9}{(s + 2)(s + 3)} = \frac{A}{s + 2} + \frac{B}{s + 3}
+					</me>
 				</p>
-				<me>
-					\frac{2s + 9}{(s + 2)(s + 3)} = \frac{A}{s + 2} + \frac{B}{s + 3}
-				</me>
 
 				<p>
 					Multiply through by the denominator:
+					<me>
+						2s + 9 = A(s + 3) + B(s + 2)
+					</me>
 				</p>
-
-				<me>
-					2s + 9 = A(s + 3) + B(s + 2)
-				</me>
 
 				<p>
 					Strategically selecting <m>s</m>-values gives <m>A</m> and <m>B</m>:
@@ -365,10 +365,12 @@
 					<p>Prepared <m>Y</m></p>
 				</sidebyside>
 
-				<p><em><xref ref="lt-step-3" text="title"/></em></p>
-				<md>
-					<mrow>y(t) = \ilap{Y(s)} = 5\ilap{\frac{1}{s + 2}} - 3\ilap{\frac{1}{s + 3}}</mrow>
-				</md>
+				<p>
+					<em><xref ref="lt-step-3" text="title"/></em>
+					<md>
+						<mrow>y(t) = \ilap{Y(s)} = 5\ilap{\frac{1}{s + 2}} - 3\ilap{\frac{1}{s + 3}}</mrow>
+					</md>
+				</p>
 
 				<p>
 					Using the table, the solution is:
@@ -475,13 +477,17 @@
 					</me>
 				</p>
 
-				<p>Take the inverse Laplace transform:</p>
-				<md>
-					<mrow>y(t) = \ilap{\frac{1}{(s-1)^2}} + \ilap{\frac{1}{(s-1)^3}}</mrow>
-				</md>
+				<p>
+					Take the inverse Laplace transform:
+					<md>
+						<mrow>y(t) = \ilap{\frac{1}{(s-1)^2}} + \ilap{\frac{1}{(s-1)^3}}</mrow>
+					</md>
+				</p>
 
-				<p>Therefore, the solution is:</p>
-				<me>y(t) = t e^{t} + \frac12 t^2 e^{t}</me>
+				<p>
+					Therefore, the solution is:
+					<me>y(t) = t e^{t} + \frac12 t^2 e^{t}</me>
+				</p>
 			</solution>
 		</example>
 
@@ -500,10 +506,10 @@
 			<statement>
 				<p>
 					Solve the initial value problem:
+					<me>
+						y'' + y = t^2, \quad y(0) = 1,\quad y'(0) = 0
+					</me>
 				</p>
-				<me>
-					y'' + y = t^2, \quad y(0) = 1,\quad y'(0) = 0
-				</me>
 			</statement>
 
 			<solution>
@@ -580,22 +586,25 @@
 				<p><em><xref ref="lt-step-2" text="title"/></em></p>
 				<p>
 					Break <m>Y(s)</m> into recognizable pieces:
+					<me>
+						Y(s) = \frac{s}{s^2 + 1} + \frac{2}{s^3(s^2 + 1)} = \frac{3s}{s^2 + 1} - \frac{2}{s} + \frac{2}{s^3}.
+					</me>
 				</p>
-
-				<me>
-					Y(s) = \frac{s}{s^2 + 1} + \frac{2}{s^3(s^2 + 1)} = \frac{3s}{s^2 + 1} - \frac{2}{s} + \frac{2}{s^3}.
-				</me>
 
 				<p>Each term now matches an entry in the Laplace transform table.</p>
 
 				<p><em><xref ref="lt-step-3" text="title"/></em></p>
-				<p>Take the inverse Laplace transform term by term:</p>
-				<md>
-					<mrow>y(t) = \ilap{\frac{3s}{s^2 + 1}} - \ilap{\frac{2}{s}} + \ilap{\frac{2}{s^3}}</mrow>
-				</md>
+				<p>
+					Take the inverse Laplace transform term by term:
+					<md>
+						<mrow>y(t) = \ilap{\frac{3s}{s^2 + 1}} - \ilap{\frac{2}{s}} + \ilap{\frac{2}{s^3}}</mrow>
+					</md>
+				</p>
 
-				<p>Therefore, the solution is:</p>
-				<me>y(t) = 3\cos(t) + t^2 - 2</me>
+				<p>
+					Therefore, the solution is:
+					<me>y(t) = 3\cos(t) + t^2 - 2</me>
+				</p>
 			</solution>
 		</example>
 
@@ -603,10 +612,10 @@
 			<statement>
 				<p>
 					Solve the initial value problem using the Laplace transform:
+					<me>
+						y'' + 6y' + 9y = 0, \quad y(0) = 3,\quad y'(0) = -3
+					</me>
 				</p>
-				<me>
-					y'' + 6y' + 9y = 0, \quad y(0) = 3,\quad y'(0) = -3
-				</me>
 			</statement>
 
 			<solution>
@@ -681,22 +690,26 @@
 				</sidebyside>
 
 				<p><em><xref ref="lt-step-2" text="title"/></em></p>
-				<p>Separate the numerator:</p>
-
-				<me>
-					Y(s) = \frac{3(s + 3) - 24}{(s + 3)^2} = \frac{3}{s + 3} - \frac{24}{(s + 3)^2}.
-				</me>
+				<p>
+					Separate the numerator:
+					<me>
+						Y(s) = \frac{3(s + 3) - 24}{(s + 3)^2} = \frac{3}{s + 3} - \frac{24}{(s + 3)^2}.
+					</me>
+				</p>
 
 				<p>Now each term matches an entry in the Laplace table.</p>
 
 				<p><em><xref ref="lt-step-3" text="title"/></em></p>
-				<p>Take the inverse Laplace transform term by term:</p>
-				<md>
-					<mrow>y(t) = \ilap{\frac{3}{s + 3}} - \ilap{\frac{24}{(s + 3)^2}}</mrow>
-				</md>
+				<p>
+					Take the inverse Laplace transform term by term:
+					<md>
+						<mrow>y(t) = \ilap{\frac{3}{s + 3}} - \ilap{\frac{24}{(s + 3)^2}}</mrow>
+					</md>
+				</p>
 
-				<p>So</p>
-				<me>y(t) = (3 - 24t)e^{-3t}</me>
+				<p>
+					So <me>y(t) = (3 - 24t)e^{-3t}</me>
+				</p>
 			</solution>
 		</example>
 
@@ -704,10 +717,10 @@
 			<statement>
 				<p>
 					Solve the initial value problem using the Laplace transform:
+					<me>
+						y''' + y'' - y' - y = 0,\quad y(0) = -1,\quad y'(0) = 0,\quad y''(0) = -1
+					</me>
 				</p>
-				<me>
-					y''' + y'' - y' - y = 0,\quad y(0) = -1,\quad y'(0) = 0,\quad y''(0) = -1
-				</me>
 			</statement>
 
 			<solution>
@@ -784,44 +797,51 @@
 				</p>
 
 				<p><em><xref ref="lt-step-2" text="title"/></em></p>
-				<p>This denominator factors by grouping:</p>
-				<md>
-					<mrow> s^3 + s^2 - s - 1	\amp = s^2(s + 1) - (s + 1)</mrow>
-					<mrow>						\amp = (s^2 - 1)(s + 1) = (s - 1)(s + 1)^2</mrow>.
-				</md>
+				<p>
+					This denominator factors by grouping:
+					<md>
+						<mrow> s^3 + s^2 - s - 1	\amp = s^2(s + 1) - (s + 1)</mrow>
+						<mrow>						\amp = (s^2 - 1)(s + 1) = (s - 1)(s + 1)^2</mrow>.
+					</md>
+				</p>
 
-				<p>Before jumping to PFD, simplify <m>Y</m> as much as possible first:</p>
-				<me>
-					Y(s) = \frac{-s^2 - s}{(s - 1)(s + 1)^2} = \frac{-s(s + 1)}{(s - 1)(s + 1)^2} = \frac{-s}{(s - 1)(s + 1)}
-				</me>
+				<p>
+					Before jumping to PFD, simplify <m>Y</m> as much as possible first:</p>
+					<me>
+						Y(s) = \frac{-s^2 - s}{(s - 1)(s + 1)^2} = \frac{-s(s + 1)}{(s - 1)(s + 1)^2} = \frac{-s}{(s - 1)(s + 1)}
+					</me>
+				</p>
 
 				<p>
 					Now PFD is a little easier. Here is the general form:
+					<me>
+						Y(s) = \frac{-s}{(s - 1)(s + 1)} = \frac{A}{s - 1} + \frac{B}{s + 1}
+					</me>
 				</p>
-
-				<me>
-					Y(s) = \frac{-s}{(s - 1)(s + 1)} = \frac{A}{s - 1} + \frac{B}{s + 1}
-				</me>
 
 				<p>
 					Applying the standard process gives: <m>A = -\sfrac12</m>, <m>B = -\sfrac12</m>
 				</p>
+
 				<p>
 					So the prepared <m>Y</m> is:
+					<me>
+						Y(s) = \frac{-\sfrac12}{s - 1} + \frac{-\sfrac12}{s + 1}
+					</me>
 				</p>
-
-				<me>
-					Y(s) = \frac{-\sfrac12}{s - 1} + \frac{-\sfrac12}{s + 1}
-				</me>
 				
 				<p><em><xref ref="lt-step-3" text="title"/></em></p>
-				<p>Take the inverse Laplace transform term by term:</p>
-				<md>
-					<mrow>y(t) = -\frac12\ilap{\frac{1}{s - 1}} - \frac12\ilap{\frac{1}{s + 1}}</mrow>
-				</md>
+				<p>
+					Take the inverse Laplace transform term by term:
+					<md>
+						<mrow>y(t) = -\frac12\ilap{\frac{1}{s - 1}} - \frac12\ilap{\frac{1}{s + 1}}</mrow>
+					</md>
+				</p>
 
-				<p>giving us the solution:</p>
-				<me>y(t) = -\frac12e^{t} - \frac12e^{-t}</me>
+				<p>
+					giving us the solution:
+					<me>y(t) = -\frac12e^{t} - \frac12e^{-t}</me>
+				</p>
 			</solution>
 		</example>
 
@@ -829,10 +849,10 @@
 			<statement>
 				<p>
 					Solve the initial value problem using the Laplace transform:
+					<me>
+						y'' + 2y = e^t \cos(3t), \quad y(0) = 0, \quad y'(0) = 0
+					</me>.
 				</p>
-				<me>
-					y'' + 2y = e^t \cos(3t), \quad y(0) = 0, \quad y'(0) = 0
-				</me>
 			</statement>
 
 			<solution>

--- a/source/c11-ltm/sec-laplace-transform-method.ptx
+++ b/source/c11-ltm/sec-laplace-transform-method.ptx
@@ -15,7 +15,7 @@
 
 	<introduction>
 		<p>
-			This closing section is where the entire Laplace transform method comes together. You have already practiced each of the three steps in isolation. Now we will zoom out, remind ourselves of the big picture, and then run walk through a variety of examples that illustrate how the method is applied from start to finish. These examples are meant to reinforce the process and highlight common patterns, strategies, and adjustments along the way.
+			This closing section is where the entire Laplace transform method comes together. You have already practiced each of the three steps in isolation. Now we will zoom out, remind ourselves of the big picture, and then walk through a variety of examples that illustrate how the method is applied from start to finish. These examples are meant to reinforce the process and highlight common patterns, strategies, and adjustments along the way.
 		</p>
 	</introduction>
 
@@ -93,9 +93,7 @@
 					y^{(n)} + a_{n-1}y^{(n-1)} + \dots + a_1y' + a_0y = g(t),
 				</me>
 				the particular solution is obtained through the following workflow:
-			</p>
-
-			<dl>
+						<dl>
 				<li xml:id="lt-step-1">
 					<title>Step 1— Forward Transform</title>
 					<p>
@@ -119,6 +117,7 @@
 					</p>
 				</li>
 			</dl>
+			</p>
 		</exploration>
 
 		<exercise label="lt-method-steps-examples-quick-recap-chkpt-bundle">
@@ -178,7 +177,7 @@
 				<cardsort>
 					<match>
 						<premise>Apply initial conditions</premise>
-						<premise>Match terms of <m>y(t)</m> the table</premise>
+						<premise>Match terms of <m>y(t)</m> to the table</premise>
 						<response>Step 1 — Forward Transform</response>
 					</match>
 					<match>
@@ -187,7 +186,7 @@
 						<response>Step 2 — Solve &amp; Prepare <m>Y(s)</m></response>
 					</match>
 					<match>
-						<premise>Match terms of <m>Y(s)</m> the table</premise>
+						<premise>Match terms of <m>Y(s)</m> to the table</premise>
 						<response>Step 3 — Inverse Transform</response>
 					</match>
 				</cardsort>
@@ -216,14 +215,12 @@
 
 		<p>
 			The examples below walk through the full process, showing how to transform a differential equation, solve in the Laplace domain, and recover the final solution using the inverse transform. Each is annotated to show where each step begins and ends, so you can clearly see the roadmap in action. Here is a break down of what to expect:
-		</p>
-
-		<ul>
+				<ul>
 			<li>Examples 1–2 ⟶ pure practice: constant-coefficient, homogeneous equations.</li>
 			<li>Examples 3–4 ⟶ common forcing terms: exponentials, polynomials, and sines/cosines.</li>
 			<li>Examples 5–6 ⟶ algebra heavyweights: repeated roots, mixed techniques, and higher order.</li>
 		</ul>
-
+		</p>
 		<example><title>Basic Second-Order, Homogeneous</title>
 			<statement>
 				<p>
@@ -250,7 +247,7 @@
 									<mrow>\small \os{\large 🔺 🔺 🔺 🔺 🔺}{\text{Differential Equation}}</mrow>
 									<mrow/>
 									<mrow>\small \us{\large 🔻 🔻 🔻 🔻 🔻}{\text{Solution}}</mrow>
-									<mrow>\small y = e^{3t} + 2e^{-3t} - 2e^{2t}</mrow>
+									<mrow>\small y(t) = e^{-2t} + e^{-3t}</mrow>
 								</md>
 							</p>
 							<p>
@@ -524,7 +521,7 @@
 									<mrow>\small \os{\large 🔺 🔺 🔺 🔺 🔺}{\text{Differential Equation}}</mrow>
 									<mrow/>
 									<mrow>\small \us{\large 🔻 🔻 🔻 🔻 🔻}{\text{Solution}}</mrow>
-									<mrow>\small y(t) = 1 + \cos(t) + t\sin(t)</mrow>
+									<mrow>\small y(t) = 3\cos(t) + t^2 - 2</mrow>
 								</md>
 							</p>
 							<p>
@@ -544,9 +541,9 @@
 										<md>
 											<mrow>\amp\small\DLBa s^2Y - sy(0) - y'(0) + Y = \frac{2}{s^3}</mrow>
 											<mrow>\amp\small\qquad\qquad {\Big\downarrow}\quad\text{Solve for}\ Y</mrow>
-											<mrow>\amp\small\DLBa Y(s) = \frac{2 + s}{s(s^2 + 1)}</mrow>
+											<mrow>\amp\small\DLBa Y(s) = \frac{s}{s^2 + 1} + \frac{2}{s^3(s^2 + 1)}</mrow>
 											<mrow>\amp\small\qquad\qquad {\Big\downarrow}\ \ \text{Prepare for Inverse}</mrow>
-											<mrow>\amp\small\DLBa Y(s) = \frac{1}{s} + \frac{s}{s^2 + 1} + \frac{1}{(s^2 + 1)^2}</mrow>
+											<mrow>\amp\small\DLBa Y(s) = \frac{3s}{s^2 + 1} - \frac{2}{s} + \frac{2}{s^3}</mrow>
 										</md>
 									</p>
 								</assemblage>
@@ -573,7 +570,7 @@
 					<p>
 						<md>
 							<mrow>(s^2 + 1) Y \amp = \frac{2}{s^3} + s</mrow>
-							<mrow>Y(s) \amp = \frac{2 + s^4}{s^3 (s^2 + 1)} = \frac{s(s^3 + 2)}{s^3 (s^2 + 1)} = \frac{2 + s}{s(s^2 + 1)}</mrow>
+							<mrow>Y(s) \amp = \frac{s}{s^2 + 1} + \frac{2}{s^3(s^2 + 1)}</mrow>
 						</md>
 					</p>
 					<p>Isolated <m>Y(s)</m></p>
@@ -585,7 +582,7 @@
 				</p>
 
 				<me>
-					Y(s) = \frac{2 + s}{s(s^2 + 1)} = \frac{1}{s} + \frac{s}{s^2 + 1} + \frac{1}{(s^2 + 1)^2}.
+					Y(s) = \frac{s}{s^2 + 1} + \frac{2}{s^3(s^2 + 1)} = \frac{3s}{s^2 + 1} - \frac{2}{s} + \frac{2}{s^3}.
 				</me>
 
 				<p>Each term now matches an entry in the Laplace transform table.</p>
@@ -593,11 +590,11 @@
 				<p><em><xref ref="lt-step-3" text="title"/></em></p>
 				<p>Take the inverse Laplace transform term by term:</p>
 				<md>
-					<mrow>y(t) = \ilap{\frac{1}{s}} + \ilap{\frac{s}{s^2 + 1}} + \ilap{\frac{1}{(s^2 + 1)^2}}</mrow>
+					<mrow>y(t) = \ilap{\frac{3s}{s^2 + 1}} - \ilap{\frac{2}{s}} + \ilap{\frac{2}{s^3}}</mrow>
 				</md>
 
 				<p>Therefore, the solution is:</p>
-				<me>y(t) = 1 + \cos(t) + t\sin(t)</me>
+				<me>y(t) = 3\cos(t) + t^2 - 2</me>
 			</solution>
 		</example>
 

--- a/source/c11-ltm/sec-laplace-transform-method.ptx
+++ b/source/c11-ltm/sec-laplace-transform-method.ptx
@@ -247,7 +247,7 @@
 									<mrow>\small \os{\large 🔺 🔺 🔺 🔺 🔺}{\text{Differential Equation}}</mrow>
 									<mrow/>
 									<mrow>\small \us{\large 🔻 🔻 🔻 🔻 🔻}{\text{Solution}}</mrow>
-									<mrow>\small y(t) = e^{-2t} + e^{-3t}</mrow>
+									<mrow>\small y(t) = 5e^{-2t} - 3e^{-3t}</mrow>
 								</md>
 							</p>
 							<p>
@@ -373,13 +373,14 @@
 				<p>
 					Using the table, the solution is:
 					<me>
-						y(t) = e^{-2t} + e^{-3t}
+						y(t) = 5e^{-2t} - 3e^{-3t}
 					</me>
 				</p>
 			</solution>
 		</example>
 
-		<example><title>Nonhomogeneous Forcing Function</title>
+		<example>
+			<title>Nonhomogeneous Forcing Function</title>
 			<p>
 				<statement>
 					<p>


### PR DESCRIPTION
# sec-laplace-transform-method — MC-edit notes (v1.9)

VR1 (Math correctness) — Example “Forcing with a Polynomial” (`y'' + y = t^2`, `y(0)=1`, `y'(0)=0`):
- Repaired incorrect Laplace-domain algebra and decomposition. Updated `Y(s)` and inverse steps so the recovered solution is `y(t)=3\cos(t)+t^2-2` (replacing the incorrect `1+\cos(t)+t\sin(t)`), and synchronized the “Specific‑Roadmap” diagram’s displayed solution and prepared `Y(s)` accordingly.

C1 (PreTeXt list placement) — List-in-<p> repairs:
- Moved the `<dl>` (three-step roadmap) into the immediately preceding `<p>` inside `<exploration xml:id="lt-method">`.
- Moved the `<ul>` that enumerates the worked-example groupings into the immediately preceding `<p>`.

M1 (Copy/clarity) — Minor wording/typo fixes:
- “then run walk through” → “then walk through”.
- Cardsort premises: “Match terms … the table” → “Match terms … **to** the table”.

References:
- PreTeXt list-in-<p> requirement as enforced by this project’s v1.9 governing files (no external refs).