### PR TITLE
Update sec-leaving-the-laplace-domain.ptx

### DIFF
--- a/source/c11-ltm/sec-leaving-the-laplace-domain.ptx
+++ b/source/c11-ltm/sec-leaving-the-laplace-domain.ptx
@@ -215,7 +215,7 @@
 					<p/>
 					<sbsgroup widths="36% 15% 15% 15% 15%" valign="middle" margins="2% 2%">
 						<sidebyside widths="34% 62%">
-							<p><me>\ul{\hspace{50px} Y(S) \hspace{50px}}</me></p>
+							<p><me>\ul{\hspace{50px} Y(s) \hspace{50px}}</me></p>
 							<p><me>\ul{\hspace{170px} y(t) \hspace{170px}}</me></p>
 						</sidebyside>
 						<sidebyside>
@@ -313,10 +313,10 @@
 				\ilap{Y(s)} = \ilap{\frac{3}{s}} + \ilap{\frac{5}{s^2 + 16}}
 			</me>
 			<p>
-				The first term matches <xref ref="lt-L1" text="custom">L<m>_1</m></xref> and gives <m>3</m>. The second term matches <xref ref="lt-L4" text="custom">L<m>_4</m></xref> with <m>b = 4</m>, giving <m>5\sin(4t)</m>. So the solution is:
+				The first term matches <xref ref="lt-L1" text="custom">L<m>_1</m></xref> and gives <m>3</m>. The second term matches <xref ref="lt-L4" text="custom">L<m>_4</m></xref> with <m>b = 4</m>, giving <m>\frac{5}{4}\sin(4t)</m>. So the solution is:
 			</p>
 			<me>
-				y(t) = 3 + 5\sin(4t).
+				y(t) = 3 + \frac{5}{4}\sin(4t).
 			</me>
 			</solution>
 		</example>
@@ -330,20 +330,20 @@
 			</statement>
 			<choices randomize="yes">
 			<choice correct="yes">
-				<statement><m>6e^{2t} + 4\sin(3t)</m></statement>
-				<feedback>Perfect! The first term matches <m>\frac{1}{s - a}</m> and the second is a sine with <m>b = 3</m>.</feedback>
+				<statement><m>6e^{2t} + \frac{4}{3}\sin(3t)</m></statement>
+				<feedback>Perfect! The first term matches <m>\frac{1}{... - a}</m>. For the second, <m>\frac{4}{s^2 + 9}=\frac{4}{3}\cdot\frac{3}{s^2+9}</m>, so it inverts to <m>\frac{4}{3}\sin(3t)</m>.</feedback>
 			</choice>
 			<choice>
-				<statement><m>6e^{-2t} + 4\sin(3t)</m></statement>
+				<statement><m>6e^{-2t} + \frac{4}{3}\sin(3t)</m></statement>
 				<feedback>Double check the sign in <m>\frac{1}{s - 2}</m>. It corresponds to <m>e^{2t}</m>, not <m>e^{-2t}</m>.</feedback>
 			</choice>
 			<choice>
-				<statement><m>6e^{2t} + 4\cos(3t)</m></statement>
+				<statement><m>6e^{2t} + \frac{4}{3}\cos(3t)</m></statement>
 				<feedback>The second term matches a sine form, not cosine.</feedback>
 			</choice>
 			<choice>
 				<statement><m>6e^{2t} + 4t^3</m></statement>
-				<feedback><m>\frac{4}{s^2 + 9}</m> corresponds to <m>\sin(3t)</m>, not a polynomial term.</feedback>
+				<feedback><m>\frac{4}{s^2 + 9}</m> corresponds to <m>\frac{4}{3}\sin(3t)</m>, not a polynomial term.</feedback>
 			</choice>
 			</choices>
 		</exercise>

--- a/source/c11-ltm/sec-leaving-the-laplace-domain.ptx
+++ b/source/c11-ltm/sec-leaving-the-laplace-domain.ptx
@@ -15,11 +15,11 @@
 
 	<introduction>
 		<p>
-			Up to this point, we've been working inside the Laplace domain — a mathematical space where differential equations are replaced by algebraic ones. We used forward Laplace transforms to move from <m>y(t)</m> to <m>Y(s)</m>, solved for <m>Y(s)</m>, and simplified it to match known inverse forms.
+			Up to this point, we've been working inside the Laplace domain — a mathematical space where differential equations are replaced by algebraic ones. We used forward Laplace transforms to transform <m>y(t)</m> to <m>Y(s)</m>, solved for <m>Y(s)</m>, and simplified the result to match known inverse forms.
 		</p>
 
 		<p>
-			Now, it's time to take the final step: returning to the original domain where the solution is a function of time. To do this, we apply the <term>inverse Laplace transform</term>, denoted <m>\laplacesym^{-1}</m>, which undoes the effect of the forward transform.
+			Now, it's time to take the final step: returning to the original domain, where the solution depends on time. To do this, we apply the <term>inverse Laplace transform</term>, denoted <m>\laplacesym^{-1}</m>, which undoes the effect of the forward transform.
 		</p>
 	</introduction>
 
@@ -125,7 +125,7 @@
 		</p>
 
 		<p>
-			To return back this to the original domain we apply the inverse to both sides:
+			To return this to the original domain, we apply the inverse to both sides:
 			<me>\ilap{Y(s)} = \ilap{\frac{1}{s - 5}} \quad\Rightarrow\quad y(t) = \ilap{\frac{1}{s - 5}}</me>
 		</p>
 
@@ -138,7 +138,8 @@
 			<me>y(t) = e^{5t}</me>
 		</p>
 
-		<example><title>Inverses using the Laplace Transform Table</title>
+		<example>
+			<title>Inverses using the Laplace Transform Table</title>
 			<statement>
 				<p>
 					Apply the inverse transform to reveal the solution, <m>y(t)</m>, in the original domain.
@@ -278,7 +279,7 @@
 		</exercise>
 
 		<p>
-			So far, we've only dealt with expressions that match a single row in the transform table. But most Laplace domain solutions are a sum of multiple terms. Fortunately, we don't need to invert the entire thing at once. We'll use linearity to handle those in the next section.
+			So far, we've only dealt with expressions that match a single row in the transform table. But most Laplace-domain solutions are sums of multiple terms. Fortunately, we don't need to invert the entire thing at once. We'll use linearity to handle those in the next section.
 		</p>
 	</subsection>
 
@@ -301,23 +302,23 @@
 		<example xml:id="lt-inverse-linearity-example">
 			<title>Inverse Transform of a Sum</title>
 			<statement>
-			<p>
-				Find <m>y(t)</m> if <m>Y(s) = \dfrac{3}{s} + \dfrac{5}{s^2 + 16}</m>.
-			</p>
+				<p>
+					Find <m>y(t)</m> if <m>Y(s) = \dfrac{3}{s} + \dfrac{5}{s^2 + 16}</m>.
+				</p>
 			</statement>
 			<solution>
-			<p>
-				We break this into two parts and use the transform table to invert each one.
-			</p>
-			<me>
-				\ilap{Y(s)} = \ilap{\frac{3}{s}} + \ilap{\frac{5}{s^2 + 16}}
-			</me>
-			<p>
-				The first term matches <xref ref="lt-L1" text="custom">L<m>_1</m></xref> and gives <m>3</m>. The second term matches <xref ref="lt-L4" text="custom">L<m>_4</m></xref> with <m>b = 4</m>, giving <m>\frac{5}{4}\sin(4t)</m>. So the solution is:
-			</p>
-			<me>
-				y(t) = 3 + \frac{5}{4}\sin(4t).
-			</me>
+				<p>
+					We split this into two parts and use the transform table to invert each.
+					<me>
+						\ilap{Y(s)} = \ilap{\frac{3}{s}} + \ilap{\frac{5}{s^2 + 16}}
+					</me>
+				</p>
+				<p>
+					The first term matches <xref ref="lt-L1" text="custom">L<m>_1</m></xref> and gives <m>3</m>. The second term matches <xref ref="lt-L4" text="custom">L<m>_4</m></xref> with <m>b = 4</m>, giving <m>\frac{5}{4}\sin(4t)</m>. So the solution is:
+					<me>
+						y(t) = 3 + \frac{5}{4}\sin(4t).
+					</me>
+				</p>
 			</solution>
 		</example>
 
@@ -339,7 +340,7 @@
 			</choice>
 			<choice>
 				<statement><m>6e^{2t} + \frac{4}{3}\cos(3t)</m></statement>
-				<feedback>The second term matches a sine form, not cosine.</feedback>
+				<feedback>The second term matches a sine form, not a cosine.</feedback>
 			</choice>
 			<choice>
 				<statement><m>6e^{2t} + 4t^3</m></statement>
@@ -382,7 +383,7 @@
 			</p>
 
 			<p> 
-				The first term perfectly matches, the second term needs <m>b=2</m> in the numerator. Missing numbers in the numerator is common with inverse transforms, but there is an easy fix. We multiply numerator and denominator by the missing number:
+				The first term perfectly matches, the second term needs <m>b=2</m> in the numerator. Missing numbers in the numerator is common with inverse transforms, but there is an easy fix. We multiply the numerator and denominator by the missing number:
 				<me>
 					Y(s) 
 					= 2\frac{s}{s^2 + 4} + 5\frac{1}{s^2 + 4} \cdot \us{\ds 🚩}{\boxed{\frac{2}{2}}} 
@@ -518,7 +519,7 @@
 				<title><e component="emoji">📖❓</e> Give the Numerator of the Split Fractions</title>
 				<statement>
 					<p>
-						After adjusting the numerator to match <xref ref="lt-L8-table" text="custom">L<m>_8</m></xref> and separating the fractions, type-in the numerators of the separated fractions?
+						After adjusting the numerator to match <xref ref="lt-L8-table" text="custom">L<m>_8</m></xref> and separating the fractions, type in the numerators of the separated fractions?
 					</p>
 					<sidebyside widths="10% 18% 5% 18% 5% 18%" valign="middle" margins="10% 10%">
 						<p><me>Y(s)=</me></p>


### PR DESCRIPTION
# sec-leaving-the-laplace-domain — MC Edit Notes (v1.9)

## Changes
- M-001: Corrected inverse Laplace of 5/(s^2+16): 5\sin(4t) → (5/4)\sin(4t); updated resulting y(t).
- M-002: Corrected linearity checkpoint inversion for 4/(s^2+9): updated correct choice to (4/3)sin(3t) and adjusted related feedback/distractors for consistency.
- C-001: Changed Y(S) → Y(s) in a table header to match standard Laplace variable notation.

## VERIFY-REQUIRED
- None.

## References
- https://tutorial.math.lamar.edu/Classes/DE/Laplace_Table.aspx
- https://en.wikipedia.org/wiki/Laplace_transform