### PR TITLE
Update sec-piecewise-functions.ptx

### DIFF
--- a/source/c12-ltp/sec-piecewise-functions.ptx
+++ b/source/c12-ltp/sec-piecewise-functions.ptx
@@ -145,11 +145,7 @@
 				</match>
 				<match>
 					<premise><me> \big( u_0(t) - 1 \big) \sin t </me></premise>
-					<response><m>\left\{\begin{array}{ll} -\sin t \amp t \lt 0\\ 0 \amp \text{otherwise}\end{array}\right.</m></response>
-				</match>
-				<match>
 					<premise><me> \big( u_6(t) - u_0(t) \big) \sin t </me></premise>
-					<response><m>\left\{\begin{array}{ll} -\sin t \amp 0 \le t \lt 6\\ 0 \amp \text{otherwise}\end{array}\right.</m></response>
 				</match>
 			</cardsort>
 		</exercise>

--- a/source/c12-ltp/sec-piecewise-functions.ptx
+++ b/source/c12-ltp/sec-piecewise-functions.ptx
@@ -33,7 +33,7 @@
 					= \left\{
 					\begin{array}{ccccc}
 						\DLBb \sin t,	\amp \DLBb t \lt 0			\amp \\
-						\DLGa 2e^{-t},	\amp \DLGa 0 \ge t \lt 2	\amp \longrightarrow\\
+						\DLGa 2e^{-t},	\amp \DLGa 0 \le t \lt 2	\amp \longrightarrow\\
 						\DLO 1.5,		\amp \DLO t \ge 2			\amp
 					\end{array}
 					\right.
@@ -145,7 +145,11 @@
 				</match>
 				<match>
 					<premise><me> \big( u_0(t) - 1 \big) \sin t </me></premise>
-					<premise><m> \big( u_6(t) - u_0(t) \big) \sin t </m></premise>
+					<response><m>\left\{\begin{array}{ll} -\sin t \amp t \lt 0\\ 0 \amp \text{otherwise}\end{array}\right.</m></response>
+				</match>
+				<match>
+					<premise><me> \big( u_6(t) - u_0(t) \big) \sin t </me></premise>
+					<response><m>\left\{\begin{array}{ll} -\sin t \amp 0 \le t \lt 6\\ 0 \amp \text{otherwise}\end{array}\right.</m></response>
 				</match>
 			</cardsort>
 		</exercise>

--- a/source/c12-ltp/sec-piecewise-functions.ptx
+++ b/source/c12-ltp/sec-piecewise-functions.ptx
@@ -406,25 +406,25 @@
 			</statement>
 			<feedback>
 				<p>
-				These pairings are essential when converting a piecewise function into unit step form. The form you choose depends entirely on where each piece is active.
+					These pairings are essential for converting a piecewise function into unit-step form. The form you choose depends entirely on where each piece is active.
 				</p>
 			</feedback>
 			<cardsort>
 				<match>
-				<premise><m>t \lt 4</m></premise>
-				<response><m>1 - u_4(t)</m></response>
+					<premise><m>t \lt 4</m></premise>
+					<response><m>1 - u_4(t)</m></response>
 				</match>
 				<match>
-				<premise><m>t \ge 4</m></premise>
-				<response><m>u_4(t)</m></response>
+					<premise><m>t \ge 4</m></premise>
+					<response><m>u_4(t)</m></response>
 				</match>
 				<match>
-				<premise><m>2 \le t \lt 5</m></premise>
-				<response><m>u_2(t) - u_5(t)</m></response>
+					<premise><m>2 \le t \lt 5</m></premise>
+					<response><m>u_2(t) - u_5(t)</m></response>
 				</match>
 				<match>
-				<premise><m>t \lt 0</m></premise>
-				<response><m>1 - u_0(t)</m></response>
+					<premise><m>t \lt 0</m></premise>
+					<response><m>1 - u_0(t)</m></response>
 				</match>
 			</cardsort>
 		</exercise>
@@ -469,7 +469,7 @@
 		</p>
 
 		<p>
-			Like the piecewise form, plugging a specific <m>t</m> value into <m>g(t)</m> was the same as plugging it into just one of its three pieces. This observation highlights why the unit step form is equivalent to the piecewise form.
+			Like the piecewise form, plugging a specific <m>t</m> value into <m>g(t)</m> was the same as plugging it into just one of its three pieces. This observation explains why the unit-step form is equivalent to the piecewise form.
 		</p>
 
 		<assemblage xml:id="piecewise-to-unit-step">
@@ -514,7 +514,7 @@
 				<statement><p><m>1 - u_6(t)</m></p></statement>
 				<feedback>
 					<p>
-						This starts at <m>t = 6</m> and keeps going. It doesn't define an interval, it defines a forever switch.
+						This starts at <m>t = 6</m> and keeps going. It doesn't define an interval; it defines a forever switch.
 					</p>
 				</feedback>
 				</choice>


### PR DESCRIPTION
# sec-piecewise-functions — v1.9 Revision Notes

## Changes

C-001: Corrected interval in the introductory piecewise example from `0 \ge t \lt 2` to `0 \le t \lt 2`.
C-002: Repaired broken `<cardsort>` match (two merged `<premise>` entries with no `<response>`). Split into two matches and supplied the equivalent piecewise responses so the activity is complete and consistent with its prompt.

## VERIFY-REQUIRED

(none)

## References
(none)