### PR TITLE
Update sec-unit-step-functions.ptx

### DIFF
--- a/source/c12-ltp/sec-unit-step-functions.ptx
+++ b/source/c12-ltp/sec-unit-step-functions.ptx
@@ -386,7 +386,7 @@
 				</tabular>
 
 				<p>
-					Remember: <m>u(t)</m> is <m>0</m> before <m>t = 0</m> and <m>1</m> afterward.
+					Remember: <m>u(t)</m> is <m>0</m> before <m>t = 0</m> and <m>1</m> at and after <m>t = 0</m>.
 				</p>
 			</statement>
 			<evaluation>


### PR DESCRIPTION
# sec-unit-step-functions — v1.9 Revision Notes

## Summary
Section pass completed per LAW/SPEC/WORKFLOW v1.9.

## Changes
C-001: Clarified the reminder sentence about the value at <m>t=0</m> to match the definition (<m>u(0)=1</m>): “afterward” → “at and after <m>t=0</m>”.

## VERIFY-REQUIRED
(none)

## References
(none)