### PR TITLE
Update sec-piecewise-transform-rules.ptx

### DIFF
--- a/source/c12-ltp/sec-piecewise-transform-rules.ptx
+++ b/source/c12-ltp/sec-piecewise-transform-rules.ptx
@@ -137,7 +137,7 @@
 					<statement><p><m>\ds \frac{e^{-5}}{s}</m></p></statement>
 					<feedback>
 						<p>
-							Close, but <m>s</m> is a variable in the Laplace domain, it doesn't get replaced by a number here.
+							Close, but <m>s</m> is a variable in the Laplace domain; it doesn't get replaced by a number here.
 						</p>
 					</feedback>
 				</choice>
@@ -211,26 +211,23 @@
 					</p>
 
 					<p>
-						Using this idea, leads to the desired transform:
+						Using this idea leads to the desired transform:
+						<md>
+							<mrow>
+								\int_{c}^{\infty} f(t)\ e^{-st}\ dt 
+								\amp \os{\large\DLBb \text{A}}{=} \int_{0}^{\infty} f(t + c)\ e^{-s(t + c)}\ dt
+							</mrow>
+							<mrow>
+								\amp \os{\large\DLBb \text{B}}{=} \int_0^\infty f(t + c) \left(e^{-st} \cdot e^{-sc}\right)\ dt
+							</mrow>
+							<mrow>
+								\amp \os{\large\DLBb \text{C}}{=} e^{-cs} \int_0^\infty f(t + c) e^{-st}\ dt
+							</mrow>
+							<mrow>
+								\amp = e^{-cs} \lap{f(t + c)}
+							</mrow>
+						</md>
 					</p>
-
-
-
-					<md>
-						<mrow>
-							\int_{c}^{\infty} f(t)\ e^{-st}\ dt 
-							\amp \os{\large\DLBb \text{A}}{=} \int_{0}^{\infty} f(t + c)\ e^{-s(t + c)}\ dt
-						</mrow>
-						<mrow>
-							\amp \os{\large\DLBb \text{B}}{=} \int_0^\infty f(t + c) \left(e^{-st} \cdot e^{-sc}\right)\ dt
-						</mrow>
-						<mrow>
-							\amp \os{\large\DLBb \text{C}}{=} e^{-cs} \int_0^\infty f(t + c) e^{-st}\ dt
-						</mrow>
-						<mrow>
-							\amp = e^{-cs} \lap{f(t + c)}
-						</mrow>
-					</md>
 
 					<proof><title><m>\DLBb \text{A}, \text{B}, \text{C}</m> Details</title>
 						<p>
@@ -344,10 +341,14 @@
 			</task>
 			<task label="chkpt-ft-uc">
 				<title><e component="emoji">📖❓</e> Next Step for the <m>f(t) u_c(t)</m> Rule</title>
+
 				<statement>
 					<p>
 						Suppose you want use <xref ref="lt-L10" text="custom">L<m>_{10}</m></xref> to find
-						<me>\lap{15t^2 u_2(t)}</me>.  
+						<me>\lap{15t^2 u_2(t)}</me>.
+					</p>
+
+					<p>
 						You note that <m>c=2</m> and update the rule as follows:
 						<me>\lap{f(t)u_2(t)} = e^{-2s}\lap{f(t+2)}</me>.
 						What's the best next step from here?
@@ -405,20 +406,19 @@
 
 					<p>
 						To show this, we will start with the integral on the left and show it leads to the integral on the right.
+						<md>
+							<mrow>
+								\int_{0}^{\infty} f(t-c) u_c(t) e^{-st}\ dt 
+								\amp \os{\large\DLBb \text{A}}{=} \int_{c}^{\infty} f(t-c) e^{-st}\ dt
+							</mrow>
+							<mrow>
+								\amp \os{\large\DLBb \text{B}}{=} \int_{0}^{\infty} f(t)\ e^{-s(t+c)}\ dt 
+							</mrow>
+							<mrow>
+								\amp \os{\large\DLBb \text{C}}{=} e^{-cs} \int_0^\infty f(t) e^{-st} \, du
+							</mrow>
+						</md>
 					</p>
-
-					<md>
-						<mrow>
-							\int_{0}^{\infty} f(t-c) u_c(t) e^{-st}\ dt 
-							\amp \os{\large\DLBb \text{A}}{=} \int_{c}^{\infty} f(t-c) e^{-st}\ dt
-						</mrow>
-						<mrow>
-							\amp \os{\large\DLBb \text{B}}{=} \int_{0}^{\infty} f(t)\ e^{-s(t+c)}\ dt 
-						</mrow>
-						<mrow>
-							\amp \os{\large\DLBb \text{C}}{=} e^{-cs} \int_0^\infty f(t) e^{-st} \, du
-						</mrow>
-					</md>
 
 					<proof><title><m>\DLBb \text{A}, \text{B}, \text{C}</m> Details</title>
 						<p>
@@ -462,7 +462,7 @@
 				</p>
 			</statement>
 			<choices randomize="yes">
-			    <choice correct="yes">
+			  <choice correct="yes">
 					<statement><m>\ (t + 3)^2</m></statement>
 					<feedback>Good! The rule requires replacing <m>t</m> with <m>t + c</m> when multiplying by <m>u_c(t)</m>.</feedback>
 				</choice>

--- a/source/c12-ltp/sec-piecewise-transform-rules.ptx
+++ b/source/c12-ltp/sec-piecewise-transform-rules.ptx
@@ -20,13 +20,13 @@
 
 		<p>
 			This section develops the Laplace transform rules for unit step functions:
-		</p>
-
 		<ul marker="square">
 			<li><m>\lap{u_c(t)}</m> – how to transform a single step switch.</li>
 			<li><m>\lap{f(t) u_c(t)}</m> – how to transform a function that is switched ON at <m>t=c</m>.</li>
 			<li><m>\lap{f(t-c) u_c(t)}</m> – how to transform a shifted function that starts at <m>t=c</m>.</li>
 		</ul>
+
+		</p>
 
 		<p>
 			These rules are the backbone for handling piecewise functions with Laplace methods.


### PR DESCRIPTION
# sec-piecewise-transform-rules — v1.9 Revision Notes

## Summary
Section pass completed per LAW/SPEC/WORKFLOW v1.9.

## Changes
C-001: List-in-<p> repair — moved 1 <ul> block(s) into the immediately preceding <p> (minimal structural repair).

## VERIFY-REQUIRED
(none)

## References
(none)