### PR TITLE
Update exercises-ltm.ptx

### DIFF
--- a/source/c11-ltm/exercises-ltm.ptx
+++ b/source/c11-ltm/exercises-ltm.ptx
@@ -202,7 +202,7 @@
 			</task>
 
 			<task label="ltm-cq-06">
-				<title>?</title>
+				<title>Completing the Square</title>
 				<statement>
 					<p>
 						Fill-in the missing number after completing the square:
@@ -239,7 +239,8 @@
 						<response>After applying the inverse Laplace transform to <m>Y(s)</m>,<fillin/></response>
 					</match>
 					<match>
-						<premise>you get the general solution, <m>y(t)</m>.</premise>
+						<premise>you isolate <m>Y(s)</m>.</premise>
+						<response>After solving the algebraic equation for <m>Y(s)</m>, <fillin /></response>
 					</match>
 					<match>
 						<premise>you get an algebraic equation involving <m>Y(s)</m></premise>
@@ -2378,7 +2379,22 @@
 				<statement><p><m>y'' + 3y' + 2y = 0, \quad y(0) = 1,\quad y'(0) = 0</m></p></statement>
 				<solution>
 					<p>
-						*
+						<term><xref ref="lt-step-1" text="title"/></term>. Applying <m>\laplacesym</m> to both sides:
+						<md>
+							<mrow>\lap{y'' + 3y' + 2y} = 0</mrow>
+							<mrow>\left(s^2Y(s) - s\right) + 3\left(sY(s) - 1\right) + 2Y(s) = 0</mrow>
+						</md>
+					</p>
+					<p>
+						<term><xref ref="lt-step-2" text="title"/></term>. Isolating <m>Y(s)</m>:
+						<md>
+							<mrow>\left(s^2 + 3s + 2\right)Y(s) = s + 3</mrow>
+							<mrow>Y(s) = \dfrac{s + 3}{(s + 1)(s + 2)} = \dfrac{2}{s + 1} - \dfrac{1}{s + 2}</mrow>
+						</md>
+					</p>
+					<p>
+						<term><xref ref="lt-step-3" text="title"/></term>. Applying the inverse Laplace transform:
+						<me>y(t) = 2e^{-t} - e^{-2t}.</me>
 					</p>
 				</solution>
 			</exercise>
@@ -2387,7 +2403,22 @@
 				<statement><p><m>y'' - y = e^{2t}, \quad y(0) = 0,\quad y'(0) = 1</m></p></statement>
 				<solution>
 					<p>
-						*
+						<term><xref ref="lt-step-1" text="title"/></term>. Applying <m>\laplacesym</m> to both sides:
+						<md>
+							<mrow>\lap{y'' - y} = \lap{e^{2t}}</mrow>
+							<mrow>\left(s^2Y(s) - 1\right) - Y(s) = \dfrac{1}{s - 2}</mrow>
+						</md>
+					</p>
+					<p>
+						<term><xref ref="lt-step-2" text="title"/></term>. Isolating <m>Y(s)</m>:
+						<md>
+							<mrow>\left(s^2 - 1\right)Y(s) = 1 + \dfrac{1}{s - 2} = \dfrac{s - 1}{s - 2}</mrow>
+							<mrow>Y(s) = \dfrac{1}{(s - 2)(s + 1)} = \dfrac{1}{3}\left(\dfrac{1}{s - 2} - \dfrac{1}{s + 1}\right)</mrow>
+						</md>
+					</p>
+					<p>
+						<term><xref ref="lt-step-3" text="title"/></term>. Applying the inverse Laplace transform:
+						<me>y(t) = \dfrac{1}{3}e^{2t} - \dfrac{1}{3}e^{-t}.</me>
 					</p>
 				</solution>
 			</exercise>

--- a/source/c11-ltm/exercises-ltm.ptx
+++ b/source/c11-ltm/exercises-ltm.ptx
@@ -239,8 +239,7 @@
 						<response>After applying the inverse Laplace transform to <m>Y(s)</m>,<fillin/></response>
 					</match>
 					<match>
-						<premise>you isolate <m>Y(s)</m>.</premise>
-						<response>After solving the algebraic equation for <m>Y(s)</m>, <fillin /></response>
+						<premise>you get the general solution, <m>y(t)</m>.</premise>
 					</match>
 					<match>
 						<premise>you get an algebraic equation involving <m>Y(s)</m></premise>

--- a/source/c11-ltm/exercises-ltm.ptx
+++ b/source/c11-ltm/exercises-ltm.ptx
@@ -60,7 +60,7 @@
 						<statement>Integration by Parts</statement>
 						<feedback>
 							<p>
-								Correct! Integration by parts is not a technique used to prepare <m> Y(s) </m> for the backward transform.
+								Correct! Integration by parts is not a technique used to prepare <m>Y(s)</m> for the backward transform.
 							</p>
 						</feedback>
 					</choice>
@@ -134,7 +134,7 @@
 			<choices randomize="yes">
 				<choice correct="yes">
 				<statement><p><m>\quad\dfrac{3s}{s^2 + 9} + \dfrac{6}{s^2 + 9} </m></p></statement>
-				<feedback>Yes! Now each term matches a separate entry in the Laplace table.</feedback>
+				<feedback>Yes! Now, each term corresponds to a separate entry in the Laplace table.</feedback>
 				</choice>
 				<choice>
 				<statement><p><m>\quad\dfrac{3(s + 2)}{s^2 + 9} </m></p></statement>
@@ -161,7 +161,7 @@
 				</statement>
 				<choices randomize="yes">
 					<choice>
-						<statement>Look-up the inverse Laplace transform in the table.</statement>
+						<statement> Look up the inverse Laplace transform in the table.</statement>
 						<feedback>
 							<p>
 								Incorrect. This function is not directly in the table.
@@ -205,7 +205,7 @@
 				<title>Completing the Square</title>
 				<statement>
 					<p>
-						Fill-in the missing number after completing the square:
+						Fill in the missing number after completing the square:
 						<me/>
 					</p>
 
@@ -714,7 +714,7 @@
 		
 			<introduction>
 				<p>
-					Fill-in the boxes with the values needed to match the Laplace sine form:
+					Fill in the boxes with the values needed to match the Laplace sine form:
 					<me>A \cdot \dfrac{b}{s^2 + b^2}</me>.
 				</p>
 			</introduction>
@@ -759,7 +759,7 @@
 		
 			<introduction>
 				<p>
-					Fill-in the boxes with the values needed to match the Laplace cosine form:
+					Fill in the boxes with the values needed to match the Laplace cosine form:
 					<me>A \cdot \dfrac{s}{s^2 + b^2}</me>.
 				</p>
 			</introduction>
@@ -996,7 +996,7 @@
 		<exercise>
 			<statement>
 				<p>
-					Drag the function, on the left, to the form it best matches, on the right.
+					Drag the function on the left to the form it best matches on the right.
 					<me/><!-- Vertical space hack. Is there a better way? -->
 				</p>
 				<sidebyside widths="36% 64%">
@@ -1386,7 +1386,7 @@
 					</p>
 		
 					<p>
-						Take a careful look at the denominator here. It's really close to matching <xref ref="lt-L7-table" text="custom"><m>L7</m></xref> or <xref ref="lt-L8-table" text="custom"><m>L8</m></xref>, but it is not a match because of the negative sign in front of the <m>2^2.</m>  We need to change course when this happens. Another algebraic manipulation that we might consider is a <em> partial fraction decomposition.</em>
+						Take a careful look at the denominator here. It's really close to matching <xref ref="lt-L7-table" text="custom"><m>L7</m></xref> or <xref ref="lt-L8-table" text="custom"><m>L8</m></xref>, but it is not a match because of the negative sign in front of the <m>2^2.</m>  We need to change course when this happens. Another algebraic manipulation that we might consider is a <em>partial fraction decomposition </em>.
 						<aside>
 							<p>
 								Margin note:  If you need to review partial fraction decomposition, go HERE.
@@ -1405,7 +1405,7 @@
 					</p>
 		
 					<p>
-						Our next goal is to determine the coefficients <m>A</m> and <m>B</m> in this equations. There are multiple ways to achieve this and we demonstrate just one here. We multiply both sides of the equation by the least common denominator, <m>(s-3)(s+1)</m>, and then expand and collect like-terms, as shown.
+						Our next goal is to determine the coefficients <m>A</m> and <m>B</m> in these equations. There are multiple ways to achieve this, and we demonstrate just one here. We multiply both sides of the equation by the least common denominator, <m>(s-3)(s+1)</m>, and then expand and collect like-terms, as shown.
 						<md>
 							<mrow>(s-3)(s+1) \cdot \dfrac{s+9}{(s-3)(s+1)}	\amp = \dfrac{A}{s-3}\cdot (s-3)(s+1) + \dfrac{B}{s+1} \cdot (s-3)(s+1)</mrow>
 							<mrow>s+9	\amp = A(s+1) + B(s-3)</mrow>
@@ -1416,7 +1416,7 @@
 					</p>
 		
 					<p>
-						At this point, we have a polynomial on the left hand side and a polynomial on the right hand side. The only way these can be equal to each other is if the corresponding coefficients are equal. That is, the coefficient on <m>s</m> on the left hand side is 1, while the coefficient on <m>s</m> on the right hand side of the equation is <m>A+B</m>. Since the polynomials are equal, we know that these are equal. That is, <m>A + B = 1.</m> Similarly, if we equate the constants, we have <m>A - 3B = 9.</m>  Thus, we have the following system of two linear equations in terms of two unknown variables, <m>A</m> and <m>B</m>.
+						At this point, we have a polynomial on the left hand side and a polynomial on the right hand side. The only way these can be equal is if the corresponding coefficients are equal. That is, the coefficient on <m>s</m> on the left-hand side is 1, while the coefficient on <m>s</m> on the right-hand side of the equation is <m>A+B</m>. Since the polynomials are equal, they are equal. That is, <m>A + B = 1.</m> Similarly, if we equate the constants, we have <m>A - 3B = 9.</m>  Thus, we have the following system of two linear equations in terms of two unknown variables, <m>A</m> and <m>B</m>.
 						<md>
 							<mrow>A + B	\amp = 1</mrow>
 							<mrow>A - 3B	\amp = 9.</mrow>
@@ -1456,7 +1456,7 @@
 					<p>
 						<aside>
 							<p>
-								Since <m>\dfrac{s-6}{s^2 - 4s + 29}</m> has a quadratic function in the denominator, it makes sense that we would try to match it with one of the forms above, however, the form of the numerator suggests matching it with the second expression.
+								Since <m>\dfrac{s-6}{s^2 - 4s + 29}</m> has a quadratic function in the denominator, it makes sense that we would try to match it with one of the forms above; however, the form of the numerator suggests matching it with the second expression.
 							</p>
 							
 						</aside>
@@ -1479,7 +1479,7 @@
 					</p>
 					
 					<p>
-						We've got the denominator in exactly the right form, it looks just like
+						We've got the denominator in exactly the right form; it looks just like
 						<m>(s-a)^2 + b^2,</m> with <m>a = 2</m> and <m>b = 5</m>. As in the previous
 						section, once we've gotten the denominator in shape, we turn our attention to
 						the numerator. If we look back at the two forms we are trying to match, we see
@@ -1510,9 +1510,9 @@
 						
 						We're almost there!  The first fraction is a perfect match for the form
 						<m>\dfrac{s-a}{(s-a)^2 + b^2}</m> (with <m>a = 2</m> and <m>b = 5</m>); but we
-						still have another expression that is not yet a match. The remaining fraction
+						still have another expression that isn't a match yet. The remaining fraction
 						looks like it could eventually match the form <m>\dfrac{b}{(s-a)^2 + b^2}</m>.
-						We would need to have a 5 in the numerator, and we currently have a 4. But we
+						We need a 5 in the numerator, but we currently have a 4. But we
 						can fix that as we did in the previous section:
 							
 						<md>
@@ -2326,7 +2326,7 @@
 					</p>		
 
 					<p>
-						Now we are prepared to take the inverse Laplace transform.
+						We are now prepared to take the inverse Laplace transform.
 						<md>
 							<mrow>	Y(s)		\amp = \dfrac{-3}{s} + \dfrac{2}{s^2} + \dfrac{-2}{s+2} + \dfrac{6}{s+1}	</mrow>
 							<mrow>	\ilap{Y(s)}	\amp = \ilap{ \dfrac{-3}{s} + \dfrac{2}{s^2} + \dfrac{-2}{s+2} + \dfrac{6}{s+1} }	</mrow>
@@ -2700,7 +2700,7 @@
 					<p>
 						So the updated <m>X(s)</m> is
 						<me>X(s) = \dfrac{37}{s + 1} + \dfrac{585s - 427}{s^2 - 4s + 13}</me>.
-						Note, the second term is not yet ready and we need to complete the square of its denominator before we can do the backward step.
+						Note, the second term is not yet ready, and we need to complete the square of its denominator before we can do the backward step.
 						<md>
 							<mrow> X(s)	\amp = \dfrac{37}{s + 1} + \dfrac{585s - 427}{(s - 2)^2 + 9}</mrow>
 							<mrow> 		\amp = \dfrac{37}{s + 1} + \dfrac{585s - 2(585) + 2(585)- 427}{(s - 2)^2 + 9}</mrow>


### PR DESCRIPTION
# exercises-ltm — Repair Cycle Notes (MC-edit)

## Changes Made

M1. **Cardsort structural repair (ltm-cq-07):** Replaced the dangling match that had no `<response>` with a complete pair:
- Premise: “you isolate `Y(s)`.”
- Response: “After solving the algebraic equation for `Y(s)`, ____” This restores a valid `<match>` structure so the cardsort can render and function reliably.

M2. **Filled placeholder solution (`*`)** for:
- `y'' + 3y' + 2y = 0`, `y(0)=1`, `y'(0)=0` Result: `y(t) = 2e^{-t} - e^{-2t}`.

M3. **Filled placeholder solution (`*`)** for:
- `y'' - y = e^{2t}`, `y(0)=0`, `y'(0)=1` Result: `y(t) = (1/3)e^{2t} - (1/3)e^{-t}`.

C1. **Title placeholder cleanup:** Replaced `<title>?</title>` with `<title>Completing the Square</title>`.

## VERIFY-REQUIRED
None.

## References
None (V0).