### PR TITLE
Update exercises-ltp.ptx

### DIFF
--- a/source/c12-ltp/exercises-ltp.ptx
+++ b/source/c12-ltp/exercises-ltp.ptx
@@ -19,6 +19,7 @@
 
 		<aside>
 			<title>Abbreviations</title>
+
 			<tabular>
 				<col width="10%" />
 				<col width="90%" />
@@ -37,77 +38,80 @@
 
 			<task label="ltp-cq-01">
 				<title>Unit Step Behavior</title>
+
 				<statement>
 					<p>What is the only possible set of values that any unit step function <m>u_c(t)</m> can take?</p>
 				</statement>
 				<choices randomize="yes">
 					<choice>
-					<statement><p>1 only</p></statement>
-					<feedback><p>Unit step functions are OFF before <m>t = c</m>, so they can also be 0.</p></feedback>
+						<statement><p>1 only</p></statement>
+						<feedback><p>Unit step functions are OFF before <m>t = c</m>, so they can also be 0.</p></feedback>
 					</choice>
 					<choice correct="yes">
-					<statement><p>0 and 1</p></statement>
-					<feedback><p>Correct! Unit step functions are always either 0 (OFF) or 1 (ON).</p></feedback>
+						<statement><p>0 and 1</p></statement>
+						<feedback><p>Correct! Unit step functions are always either 0 (OFF) or 1 (ON).</p></feedback>
 					</choice>
 					<choice>
-					<statement><p>any real number</p></statement>
-					<feedback><p>No, unit step functions are discrete switches, not continuous functions.</p></feedback>
+						<statement><p>any real number</p></statement>
+						<feedback><p>No, unit step functions are discrete switches, not continuous functions.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p>any nonnegative number</p></statement>
-					<feedback><p>Even though the values are nonnegative, only 0 and 1 are ever used.</p></feedback>
+						<statement><p>any nonnegative number</p></statement>
+						<feedback><p>Even though the values are nonnegative, only 0 and 1 are ever used.</p></feedback>
 					</choice>
 				</choices>
 			</task>
 
 			<task label="ltp-cq-02">
 				<title>Rewriting an ON Interval</title>
+
 				<statement>
 					<p>Which expression represents a function that is ON from <m>t = 1</m> to <m>t = 4</m> and OFF otherwise?</p>
 				</statement>
 				<choices randomize="yes">
 					<choice correct="yes">
-					<statement><p><m>\quad u_1(t) - u_4(t)</m></p></statement>
-					<feedback><p>This expression turns ON at <m>t = 1</m> and back OFF at <m>t = 4</m>.</p></feedback>
+						<statement><p><m>\quad u_1(t) - u_4(t)</m></p></statement>
+						<feedback><p>This expression turns ON at <m>t = 1</m> and back OFF at <m>t = 4</m>.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad u_1(t)</m></p></statement>
-					<feedback><p>This stays ON after <m>t = 1</m>, but never switches OFF at <m>t = 4</m>.</p></feedback>
+						<statement><p><m>\quad u_1(t)</m></p></statement>
+						<feedback><p>This stays ON after <m>t = 1</m>, but never switches OFF at <m>t = 4</m>.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad 1 - u_4(t)</m></p></statement>
-					<feedback><p>This is ON before <m>t = 4</m>, but never turns ON at <m>t = 1</m>.</p></feedback>
+						<statement><p><m>\quad 1 - u_4(t)</m></p></statement>
+						<feedback><p>This is ON before <m>t = 4</m>, but never turns ON at <m>t = 1</m>.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad u_4(t) - u_1(t)</m></p></statement>
-					<feedback><p>That would actually be negative during the interval from <m>t = 1</m> to <m>t = 4</m>, not what we want.</p></feedback>
+						<statement><p><m>\quad u_4(t) - u_1(t)</m></p></statement>
+						<feedback><p>That would actually be negative during the interval from <m>t = 1</m> to <m>t = 4</m>, not what we want.</p></feedback>
 					</choice>
 				</choices>
 			</task>
 
 			<task label="ltp-cq-03">
 				<title>Multiplying by a Step Function</title>
+
 			<statement>
 				<p>
-				What is the effect of multiplying a function <m>f(t)</m> by <m>u_6(t)</m>?
+					What is the effect of multiplying a function <m>f(t)</m> by <m>u_6(t)</m>?
 				</p>
 			</statement>
 			<choices randomize="yes">
 				<choice>
-				<statement><p>It shifts <m>f(t)</m> 6 units to the left.</p></statement>
-				<feedback><p>Shifting the input would require <m>f(t + 6)</m>, not multiplication by <m>u_6(t)</m>.</p></feedback>
+					<statement><p>It shifts <m>f(t)</m> 6 units to the left.</p></statement>
+					<feedback><p>Shifting the input would require <m>f(t + 6)</m>, not multiplication by <m>u_6(t)</m>.</p></feedback>
 				</choice>
 				<choice correct="yes">
-				<statement><p>It keeps <m>f(t)</m> OFF before <m>t = 6</m> and turns it ON at <m>t = 6</m>.</p></statement>
-				<feedback><p>Correct. <m>u_6(t)</m> acts as a switch that activates <m>f(t)</m> at <m>t = 6</m>.</p></feedback>
+					<statement><p>It keeps <m>f(t)</m> OFF before <m>t = 6</m> and turns it ON at <m>t = 6</m>.</p></statement>
+					<feedback><p>Correct. <m>u_6(t)</m> acts as a switch that activates <m>f(t)</m> at <m>t = 6</m>.</p></feedback>
 				</choice>
 				<choice>
-				<statement><p>It subtracts 6 from the output of <m>f(t)</m>.</p></statement>
-				<feedback><p>Step functions don't affect the output directly, they control when the function is active.</p></feedback>
+					<statement><p>It subtracts 6 from the output of <m>f(t)</m>.</p></statement>
+					<feedback><p>Step functions don't affect the output directly, they control when the function is active.</p></feedback>
 				</choice>
 				<choice>
-				<statement><p>It delays <m>f(t)</m> by 6 units.</p></statement>
-				<feedback><p>Delaying would require rewriting the input as <m>f(t - 6)</m>, not just multiplying by <m>u_6(t)</m>.</p></feedback>
+					<statement><p>It delays <m>f(t)</m> by 6 units.</p></statement>
+					<feedback><p>Delaying would require rewriting the input as <m>f(t - 6)</m>, not just multiplying by <m>u_6(t)</m>.</p></feedback>
 				</choice>
 			</choices>
 			</task>
@@ -116,33 +120,33 @@
 				<title>Equivalent to Piecewise Form</title>
 			<statement>
 				<p>
-				Which step-function expression is equivalent to the piecewise function
-				<me>
-					f(t) = \left\{
-					\begin{array}{ll}
-					3, \amp 0 \le t \lt 2 \\
-					0, \amp \text{otherwise}
-					\end{array}
-					\right.
-				</me>
+					Which step-function expression is equivalent to the piecewise function
+					<me>
+						f(t) = \left\{
+						\begin{array}{ll}
+						3, \amp 0 \le t \lt 2 \\
+						0, \amp \text{otherwise}
+						\end{array}
+						\right.
+					</me>
 				</p>
 			</statement>
 			<choices randomize="yes">
 				<choice correct="yes">
-				<statement><p><m>\quad 3 \cdot (u_0(t) - u_2(t))</m></p></statement>
-				<feedback><p>This turns 3 ON at <m>t = 0</m> and OFF again at <m>t = 2</m>.</p></feedback>
+					<statement><p><m>\quad 3 \cdot (u_0(t) - u_2(t))</m></p></statement>
+					<feedback><p>This turns 3 ON at <m>t = 0</m> and OFF again at <m>t = 2</m>.</p></feedback>
 				</choice>
 				<choice>
-				<statement><p><m>\quad 3 \cdot u_2(t)</m></p></statement>
-				<feedback><p>This turns ON at <m>t = 2</m>, not <m>t = 0</m>.</p></feedback>
+					<statement><p><m>\quad 3 \cdot u_2(t)</m></p></statement>
+					<feedback><p>This turns ON at <m>t = 2</m>, not <m>t = 0</m>.</p></feedback>
 				</choice>
 				<choice>
-				<statement><p><m>\quad 3 \cdot (1 - u_2(t))</m></p></statement>
-				<feedback><p>This would be ON before <m>t = 2</m>, but it wouldn't stop at <m>t = 0</m>, it's ON too early.</p></feedback>
+					<statement><p><m>\quad 3 \cdot (1 - u_2(t))</m></p></statement>
+					<feedback><p>This would be ON before <m>t = 2</m>, but it wouldn't stop at <m>t = 0</m>, it's ON too early.</p></feedback>
 				</choice>
 				<choice>
-				<statement><p><m>\quad 3 \cdot u_0(t)</m></p></statement>
-				<feedback><p>This is ON at <m>t = 0</m>, but it stays ON forever, it doesn't turn OFF at <m>t = 2</m>.</p></feedback>
+					<statement><p><m>\quad 3 \cdot u_0(t)</m></p></statement>
+					<feedback><p>This is ON at <m>t = 0</m>, but it stays ON forever, it doesn't turn OFF at <m>t = 2</m>.</p></feedback>
 				</choice>
 			</choices>
 			</task>
@@ -154,20 +158,20 @@
 				</statement>
 				<choices randomize="yes">
 					<choice correct="yes">
-					<statement><p><m>\quad t \lt 6</m></p></statement>
-					<feedback><p><m>1 - u_6(t)</m> is ON before <m>t = 6</m> and OFF afterward.</p></feedback>
+						<statement><p><m>\quad t \lt 6</m></p></statement>
+						<feedback><p><m>1 - u_6(t)</m> is ON before <m>t = 6</m> and OFF afterward.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad t \gt 6</m></p></statement>
-					<feedback><p>That would be true of <m>u_6(t)</m>, not its reversal.</p></feedback>
+						<statement><p><m>\quad t \gt 6</m></p></statement>
+						<feedback><p>That would be true of <m>u_6(t)</m>, not its reversal.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad t = 6</m> only</p></statement>
-					<feedback><p>This is a step function, not a spike, it applies to intervals, not points.</p></feedback>
+						<statement><p><m>\quad t = 6</m> only</p></statement>
+						<feedback><p>This is a step function, not a spike, it applies to intervals, not points.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad t \ge 6</m></p></statement>
-					<feedback><p>Again, that's when <m>u_6(t)</m> turns ON, not when its complement is active.</p></feedback>
+						<statement><p><m>\quad t \ge 6</m></p></statement>
+						<feedback><p>Again, that's when <m>u_6(t)</m> turns ON, not when its complement is active.</p></feedback>
 					</choice>
 				</choices>
 			</task>
@@ -176,134 +180,122 @@
 				<title>Using the Shift Rule</title>
 			<statement>
 				<p>
-				Suppose <m>\lap{f(t)} = F(s)</m>. What is <m>\lap{f(t)\cdot u_4(t)}</m>?
+					Suppose <m>\lap{f(t)} = F(s)</m>. What is <m>\lap{f(t)\cdot u_4(t)}</m>?
 				</p>
 			</statement>
 			<choices randomize="yes">
 				<choice correct="yes">
-				<statement><p><m>\quad e^{-4s} \cdot \lap{f(t+4)}</m></p></statement>
-				<feedback><p>This is the shift rule in action: delay the function, then shift its input left.</p></feedback>
+					<statement><p><m>\quad e^{-4s} \cdot \lap{f(t+4)}</m></p></statement>
+					<feedback><p>This is the shift rule in action: delay the function, then shift its input left.</p></feedback>
 				</choice>
 				<choice>
-				<statement><p><m>\quad e^{4s} \cdot F(s)</m></p></statement>
-				<feedback><p>The exponent should be negative, delaying adds <m>e^{-cs}</m>.</p></feedback>
+					<statement><p><m>\quad e^{4s} \cdot F(s)</m></p></statement>
+					<feedback><p>The exponent should be negative, delaying adds <m>e^{-cs}</m>.</p></feedback>
 				</choice>
 				<choice>
-				<statement><p><m>\quad \lap{f(t - 4)}</m></p></statement>
-				<feedback><p>This shifts the function right but doesn't match the form used in the shift rule.</p></feedback>
+					<statement><p><m>\quad \lap{f(t - 4)}</m></p></statement>
+					<feedback><p>This shifts the function right but doesn't match the form used in the shift rule.</p></feedback>
 				</choice>
 				<choice>
-				<statement><p><m>\quad \lap{f(t)} \cdot u_4(t)</m></p></statement>
-				<feedback><p>The Laplace transform applies to the whole product, you can't apply it to one piece separately.</p></feedback>
+					<statement><p><m>\quad \lap{f(t)} \cdot u_4(t)</m></p></statement>
+					<feedback><p>The Laplace transform applies to the whole product, you can't apply it to one piece separately.</p></feedback>
 				</choice>
 			</choices>
 			</task>
 
 			<task label="ltp-cq-07">
 				<title>Shifting Inside the Transform</title>
-			<statement>
-				<p>
-				Which of the following is equal to <m>\lap{(t^2)\cdot u_2(t)}</m>?
-				</p>
-			</statement>
-			<choices randomize="yes">
-				<choice correct="yes">
-				<statement><p><m>\quad e^{-2s} \cdot \lap{(t + 2)^2}</m></p></statement>
-				<feedback><p>This follows directly from the shift rule, replace <m>t</m> with <m>t + 2</m>.</p></feedback>
-				</choice>
-				<choice>
-				<statement><p><m>\quad e^{-2s} \cdot \lap{t^2}</m></p></statement>
-				<feedback><p>We must shift the input, <m>t^2</m> becomes <m>(t + 2)^2</m>.</p></feedback>
-				</choice>
-				<choice>
-				<statement><p><m>\quad \lap{t^2} \cdot u_2(t)</m></p></statement>
-				<feedback><p>You can't break apart the transform like this, it applies to the whole product.</p></feedback>
-				</choice>
-				<choice>
-				<statement><p><m>\quad e^{-2s} \cdot (t^2 + 4t + 4)</m></p></statement>
-				<feedback><p>That's the shifted polynomial, but we want the Laplace transform of that expression, not the polynomial itself.</p></feedback>
-				</choice>
-			</choices>
+
+				<statement>
+					<p>
+						Which of the following is equal to <m>\lap{(t^2)\cdot u_2(t)}</m>?
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement><p><m>\quad e^{-2s} \cdot \lap{(t + 2)^2}</m></p></statement>
+						<feedback><p>This follows directly from the shift rule, replace <m>t</m> with <m>t + 2</m>.</p></feedback>
+					</choice>
+					<choice>
+						<statement><p><m>\quad e^{-2s} \cdot \lap{t^2}</m></p></statement>
+						<feedback><p>We must shift the input, <m>t^2</m> becomes <m>(t + 2)^2</m>.</p></feedback>
+					</choice>
+					<choice>
+						<statement><p><m>\quad \lap{t^2} \cdot u_2(t)</m></p></statement>
+						<feedback><p>You can't break apart the transform like this, it applies to the whole product.</p></feedback>
+					</choice>
+					<choice>
+						<statement><p><m>\quad e^{-2s} \cdot (t^2 + 4t + 4)</m></p></statement>
+						<feedback><p>That's the shifted polynomial, but we want the Laplace transform of that expression, not the polynomial itself.</p></feedback>
+					</choice>
+				</choices>
 			</task>
 
 			<task label="ltp-cq-08">
 				<title>Interpreting a Full Step Form</title>
-			<statement>
-				<p>
-				The function <m>f(t)</m> is written as:
-				<me>
-					f(t) = 2t \cdot u_0(t) + (3 - 2t) \cdot u_1(t) - 3 \cdot u_4(t)
-				</me>
-				What can you infer about the original piecewise function?
-				</p>
-			</statement>
-			<choices randomize="yes">
-				<choice correct="yes">
+
 				<statement>
 					<p>
-					It had three intervals: <m>0 \le t \lt 1</m>, <m>1 \le t \lt 4</m>, and <m>t \ge 4</m>.
+						The function <m>f(t)</m> is written as:
+						<me>
+							f(t) = 2t \cdot u_0(t) + (3 - 2t) \cdot u_1(t) - 3 \cdot u_4(t)
+						</me>
+						What can you infer about the original piecewise function?
 					</p>
 				</statement>
-				<feedback><p>Each change in step function corresponds to a new piece of the function.</p></feedback>
-				</choice>
-				<choice>
-				<statement><p>It is active only for <m>t \ge 1</m>.</p></statement>
-				<feedback><p>No, <m>u_0(t)</m> activates the function at <m>t = 0</m>.</p></feedback>
-				</choice>
-				<choice>
-				<statement><p>It is always equal to <m>2t</m>.</p></statement>
-				<feedback><p>Only the first term is <m>2t</m>, and it gets overridden by the later terms.</p></feedback>
-				</choice>
-				<choice>
-				<statement><p>The function turns off completely at <m>t = 1</m>.</p></statement>
-				<feedback><p>It doesn't turn OFF at <m>t = 1</m>, it switches to a new expression.</p></feedback>
-				</choice>
-			</choices>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>
+							<p>
+							It had three intervals: <m>0 \le t \lt 1</m>, <m>1 \le t \lt 4</m>, and <m>t \ge 4</m>.
+							</p>
+						</statement>
+						<feedback><p>Each change in the step function corresponds to a new piece of the function.</p></feedback>
+					</choice>
+					<choice>
+						<statement><p>It is active only for <m>t \ge 1</m>.</p></statement>
+						<feedback><p>No, <m>u_0(t)</m> activates the function at <m>t = 0</m>.</p></feedback>
+					</choice>
+					<choice>
+						<statement><p>It is always equal to <m>2t</m>.</p></statement>
+						<feedback><p>Only the first term is <m>2t</m>, and it gets overridden by the later terms.</p></feedback>
+					</choice>
+					<choice>
+						<statement><p>The function turns off completely at <m>t = 1</m>.</p></statement>
+						<feedback><p>It doesn't turn OFF at <m>t = 1</m>, it switches to a new expression.</p></feedback>
+					</choice>
+				</choices>
 			</task>
 		
 			<task label="ltp-cq-09">
 				<title>Transform of a function that turns off</title>
+
 				<statement>
 					Which of the following expressions is equivalent to the Laplace transform of <m>t(1 - u_4(t))</m>?
 				</statement>
 				<choices randomize="yes">
-				<choice correct="yes">
-					<statement>
-						<p>          
-				<m>\lap{t} - \lap{t \cdot u_4(t)}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+					<choice correct="yes">
+						<statement><p><m>\lap{t} - \lap{t \cdot u_4(t)}</m></p></statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-				<m>\lap{t \cdot u_4(t)}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement><p><m>\lap{t \cdot u_4(t)}</m></p></statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-				<m>e^{-4s} \lap{t}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement><p><m>e^{-4s} \lap{t}</m></p></statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-				<m>\lap{0}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement><p><m>\lap{0}</m></p></statement>
+						<feedback>	</feedback>
 					</choice>
 				</choices>
 			</task>
 
 			<task label="ltp-cq-10">
 				<title>Multiplying a Function by <m>u_c(t)</m></title>
+
 				<statement>
 					<p>
 						Consider the parabola multiplied by two different shifted unit step functions:
@@ -330,156 +322,135 @@
 		<exercise>
 			<task label="ltp-drill-01">
 				<title>Laplace of a Shifted Step</title>
+
 				<statement>
-					<p>
-					What is <m>\lap{u_3(t)}</m>?
-					</p>
+					<p>What is <m>\lap{u_3(t)}</m>?</p>
 				</statement>
 				<choices randomize="yes">
 					<choice correct="yes">
-					<statement><p><m>\quad \dfrac{e^{-3s}}{s}</m></p></statement>
-					<feedback><p>This is the standard formula for the Laplace transform of <m>u_c(t)</m>.</p></feedback>
+						<statement><p><m>\quad \dfrac{e^{-3s}}{s}</m></p></statement>
+						<feedback><p>This is the standard formula for the Laplace transform of <m>u_c(t)</m>.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad \dfrac{1}{s + 3}</m></p></statement>
-					<feedback><p>This is the transform of <m>e^{-3t}</m>, not a step function.</p></feedback>
+						<statement><p><m>\quad \dfrac{1}{s + 3}</m></p></statement>
+						<feedback><p>This is the transform of <m>e^{-3t}</m>, not a step function.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad \dfrac{1}{s} - e^{-3s}</m></p></statement>
-					<feedback><p>This isn't a correct transformation of a step function, it doesn't match the form.</p></feedback>
+						<statement><p><m>\quad \dfrac{1}{s} - e^{-3s}</m></p></statement>
+						<feedback><p>This isn't a correct transformation of a step function, it doesn't match the form.</p></feedback>
 					</choice>
 					<choice>
-					<statement><p><m>\quad \dfrac{s}{e^{3s}}</m></p></statement>
-					<feedback><p>This inverts the formula incorrectly, look carefully at the units and exponents.</p></feedback>
+						<statement><p><m>\quad \dfrac{s}{e^{3s}}</m></p></statement>
+						<feedback><p>This inverts the formula incorrectly, look carefully at the units and exponents.</p></feedback>
 					</choice>
 				</choices>
 			</task>
 
 			<task label="ltp-drill-02">
 				<title>Select the Transform</title>
+
 				<statement>
 					<p><m>\lap{(t - 1) u_1(t)} = </m> <fillin characters="15" /></p>
 				</statement>
 				<choices randomize="yes">
-				<choice correct="yes">
-					<statement>
-						<p>          
-				<m>\dfrac{e^{-s}}{s^2}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+					<choice correct="yes">
+						<statement><p><m>\dfrac{e^{-s}}{s^2}</m></p></statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-				<m>\dfrac{1}{s^2} - \dfrac{e^{-s}}{s^2}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement><p><m>\dfrac{1}{s^2} - \dfrac{e^{-s}}{s^2}</m></p></statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-				<m>\dfrac{1}{s^2}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement><p><m>\dfrac{1}{s^2}</m></p></statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-				<m>\dfrac{e^{-s}}{s}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement><p><m>\dfrac{e^{-s}}{s}</m></p></statement>
+						<feedback>	</feedback>
 					</choice>
 				</choices>
 			</task>
 
 			<task label="ltp-drill-03">
 				<title>Select the Transform</title>
+
 				<statement>
 					<p><m>\lap{(1 - t)(1 - u_1(t))} = </m> <fillin characters="15" /></p>
 				</statement>
 				<choices randomize="yes">
 					<choice>
-					<statement>
-						<p>          
-				<m>\dfrac{1}{s} - \dfrac{1}{s^2} - \dfrac{e^{-s}}{s^2}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement>
+							<p><m>\dfrac{1}{s} - \dfrac{1}{s^2} - \dfrac{e^{-s}}{s^2}</m></p>
+						</statement>
+						<feedback>	</feedback>
 					</choice>
-				<choice correct="yes">
-					<statement>
-						<p>          
-				<m>\dfrac{1}{s} - \dfrac{1}{s^2} + \dfrac{e^{-s}}{s^2}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+					<choice correct="yes">
+						<statement>
+							<p><m>\dfrac{1}{s} - \dfrac{1}{s^2} + \dfrac{e^{-s}}{s^2}</m></p>
+						</statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-				<m>\dfrac{e^{-s}}{s^2} - \dfrac{1}{s}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement>
+							<p><m>\dfrac{e^{-s}}{s^2} - \dfrac{1}{s}</m></p>
+						</statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-				<m>\dfrac{e^{-s}}{s^2}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement>
+							<p><m>\dfrac{e^{-s}}{s^2}</m></p>
+						</statement>
+						<feedback>	</feedback>
 					</choice>
 				</choices>
 			</task>
 
 			<task label="ltp-drill-04">
 				<title>Select the Transform</title>
+
 				<statement>
 					<p><m>\lap{t\, [u_1(t) - u_3(t)]} = </m> <fillin characters="15" /></p>
 				</statement>
 				<choices randomize="yes">
-				<choice correct="yes">
-					<statement>
-						<p>          
-							<m>e^{-s} \left( \dfrac{1}{s^2} + \dfrac{1}{s} \right) - e^{-3s} \left( \dfrac{1}{s^2} + \dfrac{3}{s} \right)</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+					<choice correct="yes">
+						<statement>
+							<p>          
+								<m>e^{-s} \left( \dfrac{1}{s^2} + \dfrac{1}{s} \right) - e^{-3s} \left( \dfrac{1}{s^2} + \dfrac{3}{s} \right)</m>
+							</p>
+						</statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-							<m>\dfrac{1}{s^2} \cdot (e^{-s} - e^{-3s})</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement>
+							<p>          
+								<m>\dfrac{1}{s^2} \cdot (e^{-s} - e^{-3s})</m>
+							</p>
+						</statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-							<m>e^{-s} \cdot \dfrac{1}{s^2}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement>
+							<p>          
+								<m>e^{-s} \cdot \dfrac{1}{s^2}</m>
+							</p>
+						</statement>
+						<feedback>	</feedback>
 					</choice>
 					<choice>
-					<statement>
-						<p>          
-							<m>e^{-3s} \cdot \dfrac{1}{s^2}</m>
-						</p>
-					</statement>
-					<feedback>	</feedback>
+						<statement>
+							<p>          
+								<m>e^{-3s} \cdot \dfrac{1}{s^2}</m>
+							</p>
+						</statement>
+						<feedback>	</feedback>
 					</choice>
 				</choices>
 			</task>
 				
 			<task label="ltp-drill-05">
 				<title>Piecewise to Laplace</title>
+
 				<statement>
 					<p>
 						A function is defined as:
@@ -638,9 +609,7 @@
 				<answer>
 					<p>
 						Since <m>t = 2.7 \ge 0</m> (positive),
-						<me>
-							u_0(2.7) = 1
-						</me>.
+						<me>u_0(2.7) = 1</me>.
 					</p>
 				</answer>
 			</exercise>
@@ -650,9 +619,7 @@
 				<answer>
 					<p>
 						Since <m>-5.32 &lt; 0</m> (negative),
-						<me>
-							u_0(-5.32) = 0
-						</me>.
+						<me>u_0(-5.32) = 0</me>.
 					</p>
 				</answer>
 			</exercise>
@@ -661,9 +628,7 @@
 				<statement><p><m>u_0(2)\cdot f(2)</m></p></statement>
 				<answer>
 					<p>
-						<me>
-							u_0(2)\cdot f(2) = 1\cdot f(2) = (2)^2 - 2 = (4 - 2) = 2
-						</me>.
+						<me>u_0(2)\cdot f(2) = 1\cdot f(2) = (2)^2 - 2 = (4 - 2) = 2</me>.
 					</p>
 				</answer>
 			</exercise>
@@ -706,6 +671,7 @@
 
 		<exercisegroup cols="2">
 			<title>Sketch &amp; Transform the Step Functions</title>
+
 			<introduction>
 				<p>
 					Sketch the graph of the given function and determine its Laplace transform.
@@ -783,35 +749,33 @@
 						The second term requires the new rule with <m>c=1</m>, which gives us
 					</p>
 
-					<p>
-						<sidebyside widths="58% 42%">
-							<p>
-								<md>
-									<mrow>
-										\lap{{\DLO e^{3t}} \cdot u_1(t)}
-										\amp = e^{-s} \lap{{\DLO f(t + 1)}}
-									</mrow>
-									<mrow>
-										\amp = e^{-s} \lap{{\DLO e^{3t} \cdot e^{3}}}
-									</mrow>
-									<mrow>
-										\amp = e^{-s} \cdot e^{3} \lap{e^{3t}}
-									</mrow>
-									<mrow>
-										\amp = e^{-s + 3} \left(\dfrac{1}{s - 3}\right)
-									</mrow>
-								</md>
-							</p>
-							<p>
-								<md>
-									<mrow>\DLO f(t)\ 	\amp\DLO = e^{3t}</mrow>
-									<mrow>\DLO f(t + 1)\ 	\amp\DLO = e^{3(t + 1)} </mrow>
-									<mrow>				\amp\DLO = e^{3t + 3} = e^{3t} \cdot e^{3}</mrow>
-									<mrow>\text{Note:}\ e^3\ \amp \text{is constant}</mrow>
-								</md>
-							</p>
-						</sidebyside>
-					</p>
+					<sidebyside widths="58% 42%">
+						<p>
+							<md>
+								<mrow>
+									\lap{{\DLO e^{3t}} \cdot u_1(t)}
+									\amp = e^{-s} \lap{{\DLO f(t + 1)}}
+								</mrow>
+								<mrow>
+									\amp = e^{-s} \lap{{\DLO e^{3t} \cdot e^{3}}}
+								</mrow>
+								<mrow>
+									\amp = e^{-s} \cdot e^{3} \lap{e^{3t}}
+								</mrow>
+								<mrow>
+									\amp = e^{-s + 3} \left(\dfrac{1}{s - 3}\right)
+								</mrow>
+							</md>
+						</p>
+						<p>
+							<md>
+								<mrow>\DLO f(t)\ 	\amp\DLO = e^{3t}</mrow>
+								<mrow>\DLO f(t + 1)\ 	\amp\DLO = e^{3(t + 1)} </mrow>
+								<mrow>				\amp\DLO = e^{3t + 3} = e^{3t} \cdot e^{3}</mrow>
+								<mrow>\text{Note:}\ e^3\ \amp \text{is constant}</mrow>
+							</md>
+						</p>
+					</sidebyside>
 
 					<p>
 						Putting it all together, we arrive at the desired transformation:
@@ -869,7 +833,7 @@
 		<exercisegroup cols="2">
 			<introduction>
 				<p>
-					Express each function below in terms of unit step functions and then compute its Laplace transform.
+					Express each function below as a sum of unit step functions, then compute its Laplace transform.
 				</p>
 			</introduction>
 
@@ -1062,16 +1026,6 @@
 						\right.
 					</m>
 				</statement>
-				<solution>
-					<p>
-						
-					</p>
-				</solution>
-				<answer>
-					<p>
-						
-					</p>
-				</answer>
 			</exercise>
 		</exercisegroup>
 
@@ -1089,7 +1043,7 @@
 
 			<exercise>
 				<statement><p><m>Y(s) = e^{-3s} \cdot \dfrac{2}{s^2 + 9}</m></p></statement>
-				<answer>
+				<solution>
 					<p>
 						This is already in the form <m>e^{-cs}F(s)</m> with <m>c = 3</m> and <m>F(s) = \dfrac{2}{s^2 + 9}</m>.
 					</p>
@@ -1105,12 +1059,12 @@
 							y(t) = u_3(t) \cdot \sin(3(t - 3)) = u_3(t)\cdot \sin(3t - 9)
 						</me>
 					</p>
-				</answer>
+				</solution>
 			</exercise>
 
 			<exercise>
 				<statement><p><m>F(s) = e^{-2s} \cdot \dfrac{s}{s^2 + 4}</m></p></statement>
-				<answer>
+				<solution>
 					<p>
 						We identify this as <m>e^{-2s} \cdot F(s)</m>, where
 						<me>
@@ -1127,62 +1081,34 @@
 							f(t) = u_2(t) \cdot \cos(2(t - 2)) = u_2(t)\cdot \cos(2t - 4)
 						</me>
 					</p>
-				</answer>
+				</solution>
 			</exercise>
 
 			<exercise>
 				<statement><p><m>Y(s) = \dfrac{e^{-2s}}{s-1}</m></p></statement>
-				<solution>
-					<p>
-						<m> \ds Y(s) = \dfrac{e^{-2s}}{s-1} </m>
-					</p>
-				</solution>
 				<answer>
-					<p>
-						
-					</p>
+					<p><m>Y(s) = \dfrac{e^{-2s}}{s-1} </m></p>
 				</answer>
 			</exercise>
 		
 			<exercise>
 				<statement><p><m>H(s) = \dfrac{e^{-2s} - 3e^{-4s}}{s+2}</m></p></statement>
-				<solution>
-					<p>
-						<m> \ds H(s) = \dfrac{e^{-2s} - 3e^{-4s}}{s+2} </m>
-					</p>
-				</solution>
 				<answer>
-					<p>
-						
-					</p>
+					<p><m>H(s) = \dfrac{e^{-2s} - 3e^{-4s}}{s+2}</m></p>
 				</answer>
 			</exercise>
 		
 			<exercise>
 				<statement><p><m>M(s) = \dfrac{e^{-3s}}{s^2+9}</m></p></statement>
-				<solution>
-					<p>
-						<m> \ds M(s) = \dfrac{e^{-3s}}{s^2+9} </m>
-					</p>
-				</solution>
 				<answer>
-					<p>
-						
-					</p>
+					<p><m>M(s) = \dfrac{e^{-3s}}{s^2+9}</m></p>
 				</answer>
 			</exercise>
 		
 			<exercise>
 				<statement><p><m>X(s) = \dfrac{e^{-s}(s-5)}{(s+1)(s+2)}</m></p></statement>
-				<solution>
-					<p>
-						<m> \ds X(s) = \dfrac{e^{-s}(s-5)}{(s+1)(s+2)} </m>
-					</p>
-				</solution>
 				<answer>
-					<p>
-						
-					</p>
+					<p><m>X(s) = \dfrac{e^{-s}(s-5)}{(s+1)(s+2)}</m></p>
 				</answer>
 			</exercise>
 		</exercisegroup>
@@ -1683,7 +1609,7 @@
 						</p>
 
 						<p>
-							These exponentials come directly from transforming unit step expressions. To move back to the <m>t</m>-domain, we need a new tool: a rule that undoes the exponential shift.
+							These exponentials arise directly from transforming unit-step expressions. To move back to the <m>t</m>-domain, we need a new tool: a rule that undoes the exponential shift.
 						</p>
 
 					</paragraphs>

--- a/source/c12-ltp/exercises-ltp.ptx
+++ b/source/c12-ltp/exercises-ltp.ptx
@@ -708,7 +708,7 @@
 			<title>Sketch &amp; Transform the Step Functions</title>
 			<introduction>
 				<p>
-					Sketch the graph of the given function and determine its Laplacetransform.
+					Sketch the graph of the given function and determine its Laplace transform.
 				</p>
 			</introduction>
 			
@@ -1036,7 +1036,7 @@
 					<p>
 						<sidebyside width="80%" margins="10%">
 							<figure xml:id="e-to-neg-tsqrd-plot">
-								<caption> Graph of <m>2e^{-\sfrac{t^2}{2}} \cdot u_{1}(t)</m> </caption>
+								<caption> Graph of <m>2e^{-\sfrac{t^2}{2}} \cdot (1 - u_{1}(t))</m> </caption>
 								<image>
 									<latex-image>
 										<xi:include href="tikz-figs/e-to-neg-tsqrd-plot.tex" parse="text" />
@@ -1176,7 +1176,7 @@
 				<statement><p><m>X(s) = \dfrac{e^{-s}(s-5)}{(s+1)(s+2)}</m></p></statement>
 				<solution>
 					<p>
-						<m> \ds X(s) = \dfrac{e^{-s}(s-5)}{(s+1)(s+2)} </m> vspace{1cm}
+						<m> \ds X(s) = \dfrac{e^{-s}(s-5)}{(s+1)(s+2)} </m>
 					</p>
 				</solution>
 				<answer>


### PR DESCRIPTION
# exercises-ltp — Repair Cycle Notes (MC-edit)

VR: XML is well-formed after edits (parses cleanly).
VR: All <choices> blocks in this file already include at least one correct="yes" (no grading-key attributes needed).

C: Corrected the figure caption for `xml:id="e-to-neg-tsqrd-plot"` to match the actual function in the exercise (from `u_1(t)` to `(1 - u_1(t))`), aligning the caption with the piecewise definition and step-function form.

M: Replaced “Laplacetransform” with “Laplace transform” in the “Sketch & Transform the Step Functions” introduction.

M: Removed a stray literal `vspace{1cm}` text fragment that followed an inline math element in the `X(s)` exercise solution (would otherwise render as raw text).

References:
- https://pretextbook.org