### PR TITLE
Update exercises-qm.ptx

### DIFF
--- a/source/c6-qm/exercises-qm.ptx
+++ b/source/c6-qm/exercises-qm.ptx
@@ -183,12 +183,14 @@
 				<title>Review Questions</title>
 
 				<statement>
-					<p><ol>
-						<li>What is an autonomous differential equation?</li>
-						<li>How do you find equilibrium solutions for an autonomous equation?</li>
-						<li>What does the phase line represent, and how is it useful?</li>
-						<li>How can you determine the stability of an equilibrium solution using the phase line?</li>
-					</ol></p>
+					<p>
+						<ol>
+							<li>What is an autonomous differential equation?</li>
+							<li>How do you find equilibrium solutions for an autonomous equation?</li>
+							<li>What does the phase line represent, and how is it useful?</li>
+							<li>How can you determine the stability of an equilibrium solution using the phase line?</li>
+						</ol>
+					</p>
 					<p>Answer each question briefly:</p>
 				</statement>
 				<response />
@@ -201,13 +203,14 @@
 
 		<exercise label="qm-problem-01">
 			<title>Practice Problems</title>
+
 			<p>
 				Try these problems to reinforce your understanding:
 				<ol marker="a.">
-				<li>Sketch the slope field for <me>\dfrac{dy}{dt} = y^2 - 4y</me>.</li>
+					<li>Sketch the slope field for <me>\dfrac{dy}{dt} = y^2 - 4y</me>.</li>
 					<li>Identify the equilibrium solutions and their stability.</li>
 					<li>Draw the phase line for the equation and describe the long-term behavior of solutions.</li>
-			</ol>
+				</ol>
 			</p>
 
 		</exercise>

--- a/source/c6-qm/exercises-qm.ptx
+++ b/source/c6-qm/exercises-qm.ptx
@@ -183,12 +183,12 @@
 				<title>Review Questions</title>
 
 				<statement>
-					<ol>
+					<p><ol>
 						<li>What is an autonomous differential equation?</li>
 						<li>How do you find equilibrium solutions for an autonomous equation?</li>
 						<li>What does the phase line represent, and how is it useful?</li>
 						<li>How can you determine the stability of an equilibrium solution using the phase line?</li>
-					</ol>
+					</ol></p>
 					<p>Answer each question briefly:</p>
 				</statement>
 				<response />
@@ -203,12 +203,13 @@
 			<title>Practice Problems</title>
 			<p>
 				Try these problems to reinforce your understanding:
-			</p>
-			<ol marker="a.">
+				<ol marker="a.">
 				<li>Sketch the slope field for <me>\dfrac{dy}{dt} = y^2 - 4y</me>.</li>
 					<li>Identify the equilibrium solutions and their stability.</li>
 					<li>Draw the phase line for the equation and describe the long-term behavior of solutions.</li>
 			</ol>
+			</p>
+
 		</exercise>
 
 		<exercise label="qm-problems-02">


### PR DESCRIPTION
# exercises-qm — Repair Cycle Notes (MC-edit)

VR: None (V0). No external references required.

## Changes Made

M1. **PreTeXt list containment fix (qm-cq-sa-2):** Wrapped the `<ol>` in a `<p>` inside the `<statement>` to satisfy PreTeXt’s list-in-paragraph requirement.

M2. **PreTeXt list containment fix (qm-problem-01):** Moved the `<ol marker="a.">` into the preceding `<p>` so the list occurs within a paragraph.

## Grading / keying check
- All `<choices>` blocks already had explicit `correct="yes"/"no"` attributes and each has at least one correct choice.
- No label-uniqueness problems detected in this file.

C: None.