### PR TITLE
Update exercises-solns.ptx

### DIFF
--- a/source/c2-solns/exercises-solns.ptx
+++ b/source/c2-solns/exercises-solns.ptx
@@ -94,7 +94,7 @@
 						</p>
 					</statement>
 					<choices>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									True
@@ -142,7 +142,7 @@
 						</p>
 					</statement>
 					<choices>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									True
@@ -248,7 +248,7 @@
 						</p>
 					</statement>
 					<choices randomize="yes">
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									A function of the dependent variable.
@@ -272,7 +272,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									A numerical value. 
@@ -284,7 +284,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									A derivative of the dependent variable.
@@ -310,7 +310,7 @@
 					</statement>
 
 					<choices randomize="yes">
-						<choice>
+						<choice correct="no">
 							<statement><p><m>2x^3 + 4x^2</m></p></statement>
 							<feedback>
 								<p>
@@ -318,7 +318,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement><p><m>0</m></p></statement>
 							<feedback>
 								<p>
@@ -362,7 +362,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									The general solution to a differential equation.
@@ -374,7 +374,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									A single specific solution to a differential equation.
@@ -386,7 +386,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									A solution without any constants.
@@ -421,7 +421,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									To find the derivative of a function.
@@ -433,7 +433,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									To identify the constants in an equation.
@@ -445,7 +445,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									To determine the independent variable.
@@ -468,7 +468,7 @@
 						</p>
 					</statement>
 					<choices randomize="yes">
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									Solving a differential equation.
@@ -480,7 +480,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									Finding the general solution to a differential equation.
@@ -492,7 +492,7 @@
 								</p>
 							</feedback>
 						</choice>
-						<choice>
+						<choice correct="no">
 							<statement>
 								<p>
 									Finding a family of solutions to a differential equation.


### PR DESCRIPTION
# exercises-solns — Repair Cycle Notes (v1.9)

VR-001 | solns-cq-mc / solns-cq-tf | Added explicit correct="no" to all unmarked <choice> elements (kept existing correct="yes"/"no") | conf(H) | verify:build/preview grading ok

M-001  | <choice> (unattributed) | <choice> → <choice correct="no"> for 16 instances inside 7 tasks to remove ambiguous grading defaults