### PR TITLE
Update sec-autonomous-equations.ptx

### DIFF
--- a/source/c6-qm/sec-autonomous-equations.ptx
+++ b/source/c6-qm/sec-autonomous-equations.ptx
@@ -260,7 +260,7 @@
 					</p>
 				</statement>
 
-				<choices>
+				<choice correct="no"s>
 					<choice correct="no">
 						<statement><m>0</m></statement>
 						<feedback>This is incorrect. The slope depends only on <m>y</m>, not on <m>t</m>.</feedback>
@@ -292,20 +292,20 @@
 						Which of the following must also be a solution?
 					</p>
 				</statement>
-				<choices randomize="yes">
+				<choice correct="no"s randomize="yes">
 					<choice correct="yes">
 						<statement><m>\ y(t + 3)</m></statement>
 						<feedback>Exactly—autonomous equations ignore the clock. Shifting in time just slides the solution along the <m>t</m>-axis.</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><m>\ y(t) + 3</m></statement>
 						<feedback>Adding to <m>y</m> changes the function itself—this doesn't preserve the solution.</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><m>\ 3\ y(t)</m></statement>
 						<feedback>Scaling <m>y</m> is not guaranteed to produce another solution unless the DE is linear, which this one may not be.</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><m>\ y(-t)</m></statement>
 						<feedback>Flipping time is not generally a symmetry—it changes how <m>y</m> evolves.</feedback>
 					</choice>


### PR DESCRIPTION
# sec-autonomous-equations — Repair Cycle Notes (MC-edit)

VR: None (V0). Grading/keying repair only.

## Changes Made

M1. **Explicit correctness attributes for grading safety:** Added `correct="no"` to every `<choice>` element that lacked a `correct="..."` attribute.
- Instances updated: 5
- Remaining `<choice>` without `correct`: 0

## VERIFY-REQUIRED
None.

## References
None.