### PR TITLE
Update sec-laplace-piecewise-method.ptx

### DIFF
--- a/source/c12-ltp/sec-laplace-piecewise-method.ptx
+++ b/source/c12-ltp/sec-laplace-piecewise-method.ptx
@@ -159,15 +159,15 @@
 						<statement>A term with the step function switch, <m>u_4(t)</m>.</statement>
 						<feedback>Correct — <m>e^{-cs}</m> always brings in <m>u_c(t)</m> and a shift by <m>c</m>.</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement>A term with a coefficient of <m>4</m>.</statement>
 						<feedback>No — the exponential doesn't change coefficients like that.</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement>An exponential term <m>e^{4t}</m>.</statement>
 						<feedback>No — <m>e^{-4s}</m> doesn't translate to <m>e^{4t}</m>.</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement>A term containing <m>\dfrac{1}{t+4}</m>.</statement>
 						<feedback>No — perhaps you thought this looked like the forward transform <me>\lap{e^{-4t}} = \frac{1}{s+4}</me>?</feedback>
 					</choice>
@@ -179,7 +179,7 @@
 			</me>
 
 			<p>
-				To match the form in <xref ref="lt-L11" text="custom">L<m>_{11}</m></xref>, its a good habit to define the shorthand:
+				To match the form in <xref ref="lt-L11" text="custom">L<m>_{11}</m></xref>, it's a good habit to define the shorthand:
 				<me>
 					F(s) = \frac{1}{s(s^2 + 4)}
 				</me>
@@ -198,7 +198,7 @@
 				<p>
 					Decompose:
 					<me>
-						F(s) = \frac{3}{s^2(s + 2)} = \frac{A}{s} + \frac{Bs + C}{s^2 + 4}
+						F(s) = \frac{1}{s(s^2 + 4)} = \frac{A}{s} + \frac{Bs + C}{s^2 + 4}
 					</me>.
 				</p>
 				<p>
@@ -562,7 +562,7 @@
 					<p>
 						Using <xref ref="lt-L11" text="custom">L<m>_{11}</m></xref> updates our solution to:
 						<me>
-							y(t) = f_1(t) + 3f_2(t) - 2\frac{e^{-2s}}{s}f_2(t-2) + \frac{e^{-4s}}{s}f_3(t-4)
+							y(t) = f_1(t) + 3f_2(t) - 2f_2(t-2)u_2(t) + f_3(t-4)u_4(t)
 						</me>
 					</p>
 
@@ -820,7 +820,7 @@
 					<p>
 						Using <xref ref="lt-L11" text="custom">L<m>_{11}</m></xref> updates our solution to:
 						<me>
-							y(t) = f_1(t) + \frac{e^{-2s}}{s}f_2(t-2)
+							y(t) = f_1(t) + f_2(t-1)u_1(t)
 						</me>
 					</p>
 
@@ -833,7 +833,7 @@
 					</p>
 
 					<p>
-						Finally, substitute <m>f_1(t)</m> and <m>f_2(t-2)</m> to get the final solution:
+						Finally, substitute <m>f_1(t)</m> and <m>f_2(t-1)</m> to get the final solution:
 					</p>
 
 					<md>


### PR DESCRIPTION
# Repair Cycle Notes — sec-laplace-piecewise-method

VR1: Build/preview this section and confirm the checkpoint **chkpt-piecewise-laplace-2** grades as single-correct (only the intended choice marked correct).

C1: Added explicit `correct="no"` on the three non-keyed `<choice>` elements in **chkpt-piecewise-laplace-2** (prevents ambiguous grading keys).

C2: Fixed typo “its a good habit” → “it’s a good habit”.

M1: Model problem details: corrected the decomposition line inside the “🔎 Here are the Details” proof to match the defined `F(s)=1/(s(s^2+4))` (it incorrectly showed `3/(s^2(s+2))`).

M2: Example 2 (Step 3): fixed the L11 inversion line to use the correct step-function shift form: `y(t)=f1(t)+3f2(t)-2 f2(t-2) u2(t)+ f3(t-4) u4(t)` (removed the stray `e^{-2s}/s` factor and added the missing step functions).

M3: Example 3 (Step 3): corrected the L11 inversion line and the adjacent sentence so the shift matches `e^{-s}`: `y(t)=f1(t)+ f2(t-1) u1(t)`.

## References
N/A (repair-cycle edits based on internal consistency and the cited Laplace shift rule L11 already referenced in-text).