### PR TITLE
Update sec-unit-step-variants.ptx

### DIFF
--- a/source/c12-ltp/sec-unit-step-variants.ptx
+++ b/source/c12-ltp/sec-unit-step-variants.ptx
@@ -1,15 +1,3 @@
-<!-- LICENSING
-  This file is part of the textbook "Exploring Differential Equations, An Interactive, Student-Centered Approach" by Geoffrey Cox.
-  License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
-  You are free to:
-    • Share — copy and redistribute the material in any medium or format.
-    • Adapt — remix, transform, and build upon the material for any purpose, even commercially.
-  Under the following terms:
-    • Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.
-    • ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license.
-  Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
-  Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
--->
 <section label="unit-step-functions">
 	<title>Unit Step Function Variants</title>
 
@@ -17,12 +5,12 @@
 			<p>
 					The basic unit step <m>u(t)</m> switches a function on at <m>t=0</m>. But what if you need the switch to flip later, flip off, or even turn on for just a short while?  
 					This paragraphs introduces three key variants:
-			</p>
 			<ul marker="disc">
 					<li><m>u_c(t)</m> — switches ON at a chosen time <m>c</m>.</li>
 					<li><m>1 - u_c(t)</m> — switches OFF at time <m>c</m>.</li>
 					<li><m>u_c(t) - u_d(t)</m> — switches ON for a window from <m>c</m> to <m>d</m>.</li>
 			</ul>
+			</p>
 			<p>
 					Together, these act like a complete toolkit for modeling stepwise ON/OFF behavior in real systems.
 			</p>
@@ -51,11 +39,11 @@
 			<statement>
 				<p>
 					The unit step function <m>u(t - 6)</m> jumps from <m>0</m> (OFF) to <m>1</m> (ON) at 
-					<m>t =</m> <fillin width="2" mode="string" answer="6" />.		
+					<m>t =</m> <fillin width="2" mode="string" answer="6"/>.		
 				</p>
 			</statement>
 			<evaluation>
-				<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
+				<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
 			</evaluation>
 		</task>
 	</exercise>
@@ -171,16 +159,8 @@
 		</p>
 
 		<sidebyside width="85%" margins="5% 10%">
-			<interactive xml:id="unit-step-2"
-				platform="jsxgraph"
-				aspect="5:2"
-				dark-mode-enabled="yes"
-				source="
-					code/jsxgraph/jsx-core/board.js
-					code/jsxgraph/jsx-core/piecewise.js
-					code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-2.js"
-			>
-				<slate xml:id="unit-step-2-plot1" surface="jsxboard" aspect="5:2" />
+			<interactive xml:id="unit-step-2" platform="jsxgraph" aspect="5:2" dark-mode-enabled="yes" source="      code/jsxgraph/jsx-core/board.js      code/jsxgraph/jsx-core/piecewise.js      code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-2.js">
+				<slate xml:id="unit-step-2-plot1" surface="jsxboard" aspect="5:2"/>
 				<static>
 					<image source="code/jsxgraph/img-labels/t.png" width="70%"> Need to Add </image>
 				</static>
@@ -199,15 +179,15 @@
 					<statement>It forces <m>f(t)</m> OFF before <m>t = 5</m>, then switches it ON at <m>t = 5</m>.</statement>
 					<feedback>Exactly! Multiplying by <m>u_5(t)</m> means the function is 0 before <m>t = 5</m> and normal after.</feedback>
 				</choice>
-				<choice>
+				<choice correct="no">
 					<statement>It multiplies <m>f(t)</m> by <m>5</m>.</statement>
 					<feedback>Not quite. <m>u_5(t)</m> is not a scaling factor, it's a switching function.</feedback>
 				</choice>
-				<choice>
+				<choice correct="no">
 					<statement>It adds <m>5</m> to <m>f(t)</m>.</statement>
 					<feedback>Nope, <m>u_5(t)</m> does not alter the function's output directly. It controls when it turns on.</feedback>
 				</choice>
-				<choice>
+				<choice correct="no">
 					<statement>It delays <m>f(t)</m> by 5 seconds.</statement>
 					<feedback>Close, but that's what happens when you write <m>f(t - 5)</m>. Multiplying by <m>u_5(t)</m> just turns it ON at <m>t = 5</m>.</feedback>
 				</choice>
@@ -248,8 +228,8 @@
 					</p>
 
 					<p>
-						<m>u_3(t)=</m> <fillin width="2" mode="string" answer="0" /> before <m>t = 3</m>, and 
-						<m>u_3(t)=</m> <fillin width="2" mode="string" answer="1" /> after <m>t = 3</m>,
+						<m>u_3(t)=</m> <fillin width="2" mode="string" answer="0"/> before <m>t = 3</m>, and 
+						<m>u_3(t)=</m> <fillin width="2" mode="string" answer="1"/> after <m>t = 3</m>,
 					</p>
 
 					<p>
@@ -257,15 +237,15 @@
 					</p>
 
 					<p>
-						<m>1-u_3(t)=</m> <fillin width="2" mode="string" answer="1" /> before <m>t = 3</m>, and  
-						<m>1-u_3(t)=</m> <fillin width="2" mode="string" answer="0" /> after <m>t = 3</m>, 
+						<m>1-u_3(t)=</m> <fillin width="2" mode="string" answer="1"/> before <m>t = 3</m>, and  
+						<m>1-u_3(t)=</m> <fillin width="2" mode="string" answer="0"/> after <m>t = 3</m>, 
 					</p>
 				</statement>
 				<evaluation>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
 				</evaluation>
 			</task>
 
@@ -277,7 +257,7 @@
 					</p>
 				</statement>
 				<choices randomize="yes">
-					<choice>
+					<choice correct="no">
 					<statement>
 						<p>That <m>g(t)</m> becomes negative for <m>t \gt 4</m>.</p>
 					</statement>
@@ -287,7 +267,7 @@
 						</p>
 					</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 					<statement>
 						<p>That <m>g(t)</m> stops increasing after <m>t = 4</m>.</p>
 					</statement>
@@ -307,7 +287,7 @@
 						</p>
 					</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 					<statement>
 						<p>That <m>g(t)</m> is undefined for <m>t \gt 4</m>.</p>
 					</statement>
@@ -525,7 +505,7 @@
 				</p>
 			</statement>
 			<choices randomize="yes">
-				<choice>
+				<choice correct="no">
 				<statement><p><m>t \cdot u_{-2}(t)</m></p></statement>
 				<feedback>
 					<p>
@@ -541,7 +521,7 @@
 					</p>
 				</feedback>
 				</choice>
-				<choice>
+				<choice correct="no">
 				<statement><p><m>(t - 2) \cdot u_{-2}(t)</m></p></statement>
 				<feedback>
 					<p>
@@ -549,7 +529,7 @@
 					</p>
 				</feedback>
 				</choice>
-				<choice>
+				<choice correct="no">
 				<statement><p><m>t + 2</m></p></statement>
 				<feedback>
 					<p>
@@ -611,9 +591,9 @@
 
 					<tabular halign="center">
 						<col right="minor"/>
-						<col right="minor" />
-						<col right="minor" />
-						<col right="minor" />
+						<col right="minor"/>
+						<col right="minor"/>
+						<col right="minor"/>
 						<row bottom="minor">
 							<cell/>
 							<cell><m>t \lt 3</m></cell>
@@ -622,15 +602,15 @@
 						</row>
 						<row>
 							<cell><m>u_3(t)</m></cell>
-							<cell><fillin width="6" mode="string" answer="0" /></cell>
-							<cell><fillin width="6" mode="string" answer="1" /></cell>
-							<cell><fillin width="6" mode="string" answer="1" /></cell>
+							<cell><fillin width="6" mode="string" answer="0"/></cell>
+							<cell><fillin width="6" mode="string" answer="1"/></cell>
+							<cell><fillin width="6" mode="string" answer="1"/></cell>
 						</row>
 						<row bottom="minor">
 							<cell><m>u_7(t)</m></cell>
-							<cell><fillin width="6" mode="string" answer="0" /></cell>
-							<cell><fillin width="6" mode="string" answer="0" /></cell>
-							<cell><fillin width="6" mode="string" answer="1" /></cell>
+							<cell><fillin width="6" mode="string" answer="0"/></cell>
+							<cell><fillin width="6" mode="string" answer="0"/></cell>
+							<cell><fillin width="6" mode="string" answer="1"/></cell>
 						</row>
 					</tabular>
 
@@ -640,9 +620,9 @@
 
 					<tabular halign="center">
 						<col right="minor"/>
-						<col right="minor" />
-						<col right="minor" />
-						<col right="minor" />
+						<col right="minor"/>
+						<col right="minor"/>
+						<col right="minor"/>
 						<row bottom="minor">
 							<cell/>
 							<cell><m>t \lt 3</m></cell>
@@ -651,22 +631,22 @@
 						</row>
 						<row bottom="minor">
 							<cell><m>u_3(t) - u_7(t)</m></cell>
-							<cell><fillin width="6" mode="string" answer="0" /></cell>
-							<cell><fillin width="6" mode="string" answer="1" /></cell>
-							<cell><fillin width="6" mode="string" answer="0" /></cell>
+							<cell><fillin width="6" mode="string" answer="0"/></cell>
+							<cell><fillin width="6" mode="string" answer="1"/></cell>
+							<cell><fillin width="6" mode="string" answer="0"/></cell>
 						</row>
 					</tabular>
 				</statement>
 				<evaluation>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
-					<evaluate><test><strcmp use-answer="yes" /></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
+					<evaluate><test><strcmp use-answer="yes"/></test></evaluate>
 				</evaluation>
 			</task>
 		</exercise>
@@ -777,20 +757,12 @@
 				<sidebyside widths="50% 5% 45%" margins="0% 0%" valign="middle">
 					<p>
 						<sidebyside width="50%" margins="0% 50%">
-							<interactive xml:id="unit-step-uc-ud"
-								platform="jsxgraph"
-								aspect="2.8:3"
-								dark-mode-enabled="yes"
-								source="
-									code/jsxgraph/jsx-core/board.js
-									code/jsxgraph/jsx-core/piecewise.js
-									code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-uc-ud.js"
-							>
+							<interactive xml:id="unit-step-uc-ud" platform="jsxgraph" aspect="2.8:3" dark-mode-enabled="yes" source="          code/jsxgraph/jsx-core/board.js          code/jsxgraph/jsx-core/piecewise.js          code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-uc-ud.js">
 								<sidebyside width="100%" margins="0% 0%">
 									<stack>
-										<slate xml:id="unit-step-uc-ud-plot1" surface="jsxboard" aspect="2.8:1" />
-										<slate xml:id="unit-step-uc-ud-plot2" surface="jsxboard" aspect="2.8:1" />
-										<slate xml:id="unit-step-uc-ud-plot3" surface="jsxboard" aspect="2.8:1" />
+										<slate xml:id="unit-step-uc-ud-plot1" surface="jsxboard" aspect="2.8:1"/>
+										<slate xml:id="unit-step-uc-ud-plot2" surface="jsxboard" aspect="2.8:1"/>
+										<slate xml:id="unit-step-uc-ud-plot3" surface="jsxboard" aspect="2.8:1"/>
 									</stack>
 								</sidebyside>
 								<static>
@@ -825,15 +797,15 @@
 						<statement><p><m>\ f(t)\left(u_2(t) - u_5(t)\right)</m></p></statement>
 						<feedback>Correct!</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><p><m>\ 2f(t) + 5f(t)</m></p></statement>
 						<feedback>Incorrect</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><p><m>\ f(t)\left(u_5(t) - u_2(t)\right)</m></p></statement>
 						<feedback>Incorrect</feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><p><m>\ f(t)\ u_5(t) - u_2(t) </m></p></statement>
 						<feedback>Incorrect</feedback>
 					</choice>
@@ -986,17 +958,9 @@
 			</p>
 
 			<sidebyside width="90%" margins="3% 3%">
-				<interactive xml:id="unit-step-sine-plus-2-uc-ud"
-					platform="jsxgraph"
-					aspect="2.1:1"
-					dark-mode-enabled="yes"
-					source="
-						code/jsxgraph/jsx-core/board.js
-						code/jsxgraph/jsx-core/piecewise.js
-						code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-sine-plus-2-uc-ud.js"
-				>
+				<interactive xml:id="unit-step-sine-plus-2-uc-ud" platform="jsxgraph" aspect="2.1:1" dark-mode-enabled="yes" source="       code/jsxgraph/jsx-core/board.js       code/jsxgraph/jsx-core/piecewise.js       code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-sine-plus-2-uc-ud.js">
 					<sidebyside width="100%">
-						<slate xml:id="unit-step-sine-plus-2-uc-ud-plot1" surface="jsxboard" aspect="2.1:1" />
+						<slate xml:id="unit-step-sine-plus-2-uc-ud-plot1" surface="jsxboard" aspect="2.1:1"/>
 					</sidebyside>
 					<static>
 						<image source="code/jsxgraph/img-labels/t.png" width="70%"> Need to Add </image>
@@ -1025,15 +989,15 @@
 						<statement><p>It switches <m>f(t)</m> ON at <m>t=c</m> and keeps it ON forever.</p></statement>
 						<feedback><p>Correct — <m>u_c(t)</m> equals 0 before <m>t=c</m> and 1 afterward.</p></feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><p>It switches <m>f(t)</m> OFF at <m>t=c</m>.</p></statement>
 						<feedback><p>Not quite — that would be <m>1-u_c(t)</m>.</p></feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><p>It reverses the direction of <m>f(t)</m> at <m>t=c</m>.</p></statement>
 						<feedback><p>No — there's no <q>reverse</q> here, just ON/OFF switching.</p></feedback>
 					</choice>
-					<choice>
+					<choice correct="no">
 						<statement><p>It multiplies <m>f(t)</m> by <m>t</m> after <m>t=c</m>.</p></statement>
 						<feedback><p>No — <m>u_c(t)</m> is either 0 or 1; it doesn't add factors of <m>t</m>.</p></feedback>
 					</choice>


### PR DESCRIPTION
# sec-unit-step-variants — Repair Cycle Notes (MC-edit) VR: V0. Focus: grading-key safety + PreTeXt schema-safe list containment + label uniqueness. ## Changes Made
M1. **Grading safety (choices):** Added explicit `correct="no"` to `<choice>` elements missing `correct="..."`.
- Choices updated: 15 M2. **PreTeXt list containment:** Ensured any `<ol>/<ul>/<dl>` elements occur inside a `<p>` (moved into the immediately preceding `<p>` when available; otherwise wrapped in a new minimal `<p>`).
- Lists moved into preceding `<p>`: 1
- Lists wrapped in new `<p>`: 0 M3. **Label uniqueness check:** Duplicate `label="..."` values found: 0.
- Renamed for uniqueness: 0

## VERIFY-REQUIRED
VR1. Found placeholder text `Need to Add` inside `<image>` elements in `<static>` blocks for JSXGraph interactives. This is not a parse/grading break, but it is a publish-facing placeholder.
- Occurrences: 3

## Error-level status
- XML well-formed parse check: PASS

C: None.

References
- https://pretextbook.org/doc/guide/html/topic-interactive-exercises.html