### PR TITLE
H2: Rebuild partial-fractions appendix with verified solutions

### DIFF
--- a/source/aa-bookends/a1-algebra/L-pfd.ptx
+++ b/source/aa-bookends/a1-algebra/L-pfd.ptx
@@ -13,7 +13,6 @@
 <section xml:id="review-pfd">
 	<title>Partial Fraction Decomposition</title>
 
-	<xref provisional="WORK-IN-PROGRESS"/>
 	<p>
 		Partial fraction decomposition is a method used to express a rational function as a sum of simpler fractions. This process is especially useful when solving integrals and applying inverse Laplace transforms. The following steps outline the process to find the partial fraction decomposition of a rational function.
 	</p>
@@ -118,7 +117,11 @@
 				<m>\ds\frac{8x^2 - 51x + 41}{x^2 - 6x + 5}</m>
 				<solution>
 					<p>
-						First, factor the denominator:
+						First, check the degrees: the numerator and denominator both have degree <m>2</m>, so this rational function is <em>improper</em> and we must divide before decomposing. Polynomial long division gives
+						<me>
+							\frac{8x^2 - 51x + 41}{x^2 - 6x + 5} = 8 + \frac{-3x + 1}{x^2 - 6x + 5}.
+						</me>
+						Next, factor the denominator:
 						<me>
 							x^2 - 6x + 5 = (x - 5)(x - 1).
 						</me>
@@ -129,7 +132,7 @@
 						</ul>
 						Hence, the FORM of the partial fraction decomposition is:
 						<me>
-							u(x) = \frac{A}{x-5} + \frac{B}{x-1}.
+							u(x) = 8 + \frac{A}{x-5} + \frac{B}{x-1}.
 						</me>
 					</p>
 				</solution>
@@ -181,34 +184,36 @@
 
 	<example>
 		<p>
-			 Find the partial fraction decomposition of <me>\frac{5s + 3}{(s - 1)(s^2 + s + 1)}</me>.
+			 Find the partial fraction decomposition of <me>\frac{5s + 4}{(s - 1)(s^2 + s + 1)}</me>.
 		</p>
 		<solution>
 			<p>
-				Factor the denominator as <me>(s - 1)(s^2 + s + 1)</me>. The partial fraction decomposition is:
+				The numerator has smaller degree than the denominator, and the denominator is already factored into a linear factor <m>(s - 1)</m> and an irreducible quadratic factor <m>(s^2 + s + 1)</m> (its discriminant is <m>1 - 4 = -3 \lt 0</m>). So the partial fraction decomposition has the form:
 				<me>
-					\frac{5s + 3}{(s - 1)(s^2 + s + 1)} = \frac{A}{s - 1} + \frac{Bs + C}{s^2 + s + 1}.
+					\frac{5s + 4}{(s - 1)(s^2 + s + 1)} = \frac{A}{s - 1} + \frac{Bs + C}{s^2 + s + 1}.
 				</me>
 			</p>
 
 			<p>
-				Multiply through by <m>(s - 1)(s^2 + s + 1)</m> and solve for <m>A</m>, <m>B</m>, and <m>C</m>.
-				<me>
-					5s + 3 = A(s^2 + s + 1) + (Bs + C)(s - 1).
-				</me>
+				Multiply through by <m>(s - 1)(s^2 + s + 1)</m> and expand:
+				<md>
+					<mrow> 5s + 4 \amp = A(s^2 + s + 1) + (Bs + C)(s - 1) </mrow>
+					<mrow> \amp = (A + B)s^2 + (A - B + C)s + (A - C). </mrow>
+				</md>
 			</p>
 
 			<p>
-				Expanding and comparing coefficients, we find:
+				Comparing coefficients of <m>s^2</m>, <m>s</m>, and the free terms gives the system:
 				<me>
-					A = 5, \quad B - A = 0, \quad C - B = 3.
+					A + B = 0, \quad A - B + C = 5, \quad A - C = 4,
 				</me>
+				which has solution <m>A = 3</m>, <m>B = -3</m>, <m>C = -1</m>.
 			</p>
 
 			<p>
 				Therefore, the partial fraction decomposition is:
 				<me>
-					\frac{5s + 3}{(s - 1)(s^2 + s + 1)} = \frac{5}{s - 1} + \frac{5s - 2}{s^2 + s + 1}.
+					\frac{5s + 4}{(s - 1)(s^2 + s + 1)} = \frac{3}{s - 1} - \frac{3s + 1}{s^2 + s + 1}.
 				</me>
 			</p>
 		</solution>
@@ -380,13 +385,13 @@
 			<exercise>
 				<statement>
 					<p>
-						<m>\ds v(x) = \frac{4x^2 - 5x + 2}{(x^2 - 2x + 1)^2}</m>
+						<m>\ds v(x) = \frac{4x^2 - 5x + 2}{x^4 - 2x^2 + 1}</m>
 					</p>
 				</statement>
 				<solution>
 					<p>
 				Here we need to finish factoring the denominator:
-					<me> v(x) = \frac{4x^2 - 5x + 2}{(x^2 - 2x + 1)(x^2 + 2x + 1)} = \frac{4x^2 - 5x + 2}{(x-1)^2(x+1)^2} </me>
+					<me> v(x) = \frac{4x^2 - 5x + 2}{(x^2 - 1)^2} = \frac{4x^2 - 5x + 2}{[(x-1)(x+1)]^2} = \frac{4x^2 - 5x + 2}{(x-1)^2(x+1)^2} </me>
 					Now we see that the denominator has the following factors:
 					<ul marker="square">
 						<li> <m>(x-1)</m> (linear, double) </li>
@@ -433,12 +438,16 @@
 			<exercise>
 				<statement>
 					<p>
-						<m>\ds v(x) = \frac{x^5 - 3x - 27}{x^3 - 2x^2 - 3x}</m>
+						<m>\ds p(x) = \frac{x^5 - 3x - 27}{x^3 - 2x^2 - 3x}</m>
 					</p>
 				</statement>
 				<solution>
 					<p>
-				First, factor the denominator:
+				First, check the degrees: the numerator has degree <m>5</m> and the denominator has degree <m>3</m>, so this rational function is improper and we must divide first. Polynomial long division gives
+					<me>
+						\frac{x^5 - 3x - 27}{x^3 - 2x^2 - 3x} = x^2 + 2x + 7 + \frac{20x^2 + 18x - 27}{x^3 - 2x^2 - 3x}.
+					</me>
+					Next, factor the denominator:
 					<me>
 						x^3 - 2x^2 - 3x = x(x^2 - 2x - 3) = x(x - 3)(x + 1).
 					</me>
@@ -450,17 +459,15 @@
 					</ul>
 					Hence, the FORM of the partial fraction decomposition is:
 					<me>
-						v(x) = \frac{A}{x} + \frac{B}{x-3} + \frac{C}{x+1}.
+						p(x) = x^2 + 2x + 7 + \frac{A}{x} + \frac{B}{x-3} + \frac{C}{x+1}.
 					</me>
 					</p>
 				</solution>
 				<answer>
 					<p>
-						<p>
 						<me>
-							v(x) = \frac{A}{x} + \frac{B}{x-3} + \frac{C}{x+1}
+							p(x) = x^2 + 2x + 7 + \frac{A}{x} + \frac{B}{x-3} + \frac{C}{x+1}
 						</me>
-					</p>
 					</p>
 				</answer>
 			</exercise>
@@ -468,12 +475,16 @@
 			<exercise>
 				<statement>
 					<p>
-						<m>\ds u(x) = \frac{8x^2 - 51x + 41}{x^2 - 6x + 5}</m>
+						<m>\ds q(x) = \frac{8x^2 - 51x + 41}{x^2 - 6x + 5}</m>
 					</p>
 				</statement>
 				<solution>
 					<p>
-				First, factor the denominator:
+				First, check the degrees: the numerator and denominator both have degree <m>2</m>, so this rational function is improper and we must divide first. Polynomial long division gives
+					<me>
+						\frac{8x^2 - 51x + 41}{x^2 - 6x + 5} = 8 + \frac{-3x + 1}{x^2 - 6x + 5}.
+					</me>
+					Next, factor the denominator:
 					<me>
 						x^2 - 6x + 5 = (x - 5)(x - 1).
 					</me>
@@ -484,17 +495,15 @@
 					</ul>
 					Hence, the FORM of the partial fraction decomposition is:
 					<me>
-						u(x) = \frac{A}{x-5} + \frac{B}{x-1}.
+						q(x) = 8 + \frac{A}{x-5} + \frac{B}{x-1}.
 					</me>
 					</p>
 				</solution>
 				<answer>
 					<p>
-						<p>
 						<me>
-							u(x) = \frac{A}{x-5} + \frac{B}{x-1}
+							q(x) = 8 + \frac{A}{x-5} + \frac{B}{x-1}
 						</me>
-					</p>
 					</p>
 				</answer>
 			</exercise>
@@ -536,11 +545,9 @@
 				</solution>
 				<answer>
 					<p>
-						<p>
 						<me>
-							f(x) = \frac{1}{x} + \frac{1}{x-3} + \frac{1}{x+1}
+							f(x) = -\frac{1}{3x} + \frac{11}{6(x-3)} + \frac{3}{2(x+1)}
 						</me>
-					</p>
 					</p>
 				</answer>
 			</exercise>
@@ -565,7 +572,7 @@
 				</solution>
 				<answer>
 					<p>
-						<me> g(x) = \frac{1}{x} + \frac{1}{x^2} + \frac{1}{x-3} </me>
+						<me> g(x) = -\frac{40}{9x} + \frac{11}{3x^2} + \frac{40}{9(x-3)} </me>
 					</p>
 				</answer>
 			</exercise>
@@ -592,7 +599,7 @@
 				</solution>
 				<answer>
 					<p>
-						<me> h(x) = \frac{1}{x-2} + \frac{1}{(x-2)^2} + \frac{1}{x+2} + \frac{1}{(x+2)^2} </me>
+						<me> h(x) = -\frac{3}{8(x-2)} + \frac{7}{8(x-2)^2} + \frac{3}{8(x+2)} + \frac{5}{8(x+2)^2} </me>
 					</p>
 				</answer>
 			</exercise>
@@ -615,7 +622,7 @@
 				</solution>
 				<answer>
 					<p>
-						<me> r(x) = \frac{1}{x+1} + \frac{1}{(x+1)^2} + \frac{1}{(x+1)^3} </me>
+						<me> r(x) = \frac{3}{(x+1)^2} - \frac{17}{(x+1)^3} \quad (\text{here } A = 0) </me>
 					</p>
 				</answer>
 			</exercise>
@@ -643,7 +650,7 @@
 				</solution>
 				<answer>
 					<p>
-						<me> s(x) = \frac{1}{x-3} + \frac{1}{x+3} + \frac{1}{x^2 + 9} </me>
+						<me> s(x) = \frac{37}{36(x-3)} - \frac{37}{36(x+3)} - \frac{37}{6(x^2 + 9)} </me>
 					</p>
 				</answer>
 			</exercise>
@@ -671,7 +678,7 @@
 				</solution>
 				<answer>
 					<p>
-						<me> t(x) = \frac{1}{x-2} + \frac{1}{x+2} + \frac{1}{x^2 + 4} </me>
+						<me> t(x) = \frac{3}{32(x-2)} - \frac{15}{32(x+2)} + \frac{3x + 7}{8(x^2 + 4)} </me>
 					</p>
 				</answer>
 
@@ -700,7 +707,7 @@
 				</solution>
 				<answer>
 					<p>
-						<me> u(x) = \frac{1}{x-1} + \frac{1}{x+1} + \frac{1}{x^2 + 1} </me>
+						<me> u(x) = \frac{1}{2(x-1)} - \frac{3}{2(x+1)} + \frac{x + 1}{x^2 + 1} </me>
 					</p>
 				</answer>
 			</exercise>
@@ -708,13 +715,13 @@
 			<exercise>
 				<statement>
 					<p>
-						<m>\ds v(x) = \frac{4x^2 - 5x + 2}{(x^2 - 2x + 1)^2}</m>
+						<m>\ds v(x) = \frac{4x^2 - 5x + 2}{x^4 - 2x^2 + 1}</m>
 					</p>
 				</statement>
 				<solution>
 					<p>
 				Here we need to finish factoring the denominator:
-					<me> v(x) = \frac{4x^2 - 5x + 2}{(x^2 - 2x + 1)(x^2 + 2x + 1)} = \frac{4x^2 - 5x + 2}{(x-1)^2(x+1)^2} </me>
+					<me> v(x) = \frac{4x^2 - 5x + 2}{(x^2 - 1)^2} = \frac{4x^2 - 5x + 2}{[(x-1)(x+1)]^2} = \frac{4x^2 - 5x + 2}{(x-1)^2(x+1)^2} </me>
 					Now we see that the denominator has the following factors:
 					<ul marker="square">
 						<li> <m>(x-1)</m> (linear, double) </li>
@@ -727,7 +734,7 @@
 				</solution>
 				<answer>
 					<p>
-						<me> v(x) = \frac{1}{x-1} + \frac{1}{(x-1)^2} + \frac{1}{x+1} + \frac{1}{(x+1)^2} </me>
+						<me> v(x) = \frac{1}{2(x-1)} + \frac{1}{4(x-1)^2} - \frac{1}{2(x+1)} + \frac{11}{4(x+1)^2} </me>
 					</p>
 				</answer>
 			</exercise>
@@ -755,7 +762,7 @@
 				</solution>
 				<answer>
 					<p>
-						<me> w(x) = \frac{1}{x-2} + \frac{1}{x+2} + \frac{1}{x^2 + 4} </me>
+						<me> w(x) = \frac{15}{32(x-2)} - \frac{27}{32(x+2)} + \frac{3x + 19}{8(x^2 + 4)} </me>
 					</p>
 				</answer>
 			</exercise>
@@ -787,7 +794,7 @@
 						<p>
 							<md>
 								<mrow>-2A - 3B = 1</mrow>
-								<mrow>2A - 3(-A) = 1</mrow>
+								<mrow>-2A - 3(-A) = 1</mrow>
 								<mrow>A = 1</mrow>
 							</md>
 						</p>
@@ -845,30 +852,31 @@
 				<solution>
 					<p>
 				<md>
-						<mrow>r(x) = \frac{20x^2+65x+115}{(x^2+9)(x+11)} = \frac{20x^2+65x+115}{(x^2+9)(x+11)}</mrow>
 						<mrow>\frac{20x^2+65x+115}{(x^2+9)(x+11)} = \frac{A}{x+11} + \frac{Bx+C}{x^2+9}</mrow>
 						<mrow>\frac{20x^2+65x+115}{(x^2+9)(x+11)}\cdot (x^2+9)(x+11) = \left[\frac{A}{x+11} + \frac{Bx+C}{x^2+9}\right] \cdot (x^2+9)(x+11)</mrow>
 						<mrow>20x^2+65x+115 = A(x^2+9) + (Bx+C)(x+11)</mrow>
 						<mrow>20x^2+65x+115 = Ax^2+9A + Bx^2+11Bx + Cx+11C</mrow>
 						<mrow>20x^2+65x+115 = (A+B)x^2 + (11B+C)x + 9A+11C</mrow>
 					</md>
+					Matching coefficients gives the system
 					<md>
-						<mrow>\Rightarrow A+B = 20 \amp\text{and }	</mrow>
-						<mrow>11B+C = 65</mrow>
-						<mrow>9A+11C = 115</mrow>
-						<mrow> \amp	\amp A = 5</mrow>
-						<mrow>5+B = 20 \amp		\amp	</mrow>
-						<mrow>B = 15 \amp		\amp	</mrow>
-						<mrow>11(15)+C = 65 \amp		\amp	</mrow>
-						<mrow>165+C = 65 \amp		\amp	</mrow>
-						<mrow>C = -100 \amp		\amp	</mrow>
+						<mrow>A+B \amp = 20</mrow>
+						<mrow>11B+C \amp = 65</mrow>
+						<mrow>9A+11C \amp = 115</mrow>
 					</md>
-					<me> \Rightarrow r(x) = \frac{5}{x+11} + \frac{15x+C}{x^2+9} </me>
+					From the first equation, <m>B = 20 - A</m>. Substituting into the second, <m>C = 65 - 11(20-A) = 11A - 155</m>. Substituting both into the third:
+					<md>
+						<mrow>9A + 11(11A - 155) \amp = 115</mrow>
+						<mrow>130A \amp = 1820</mrow>
+						<mrow>A \amp = 14</mrow>
+					</md>
+					so <m>B = 20 - 14 = 6</m> and <m>C = 11(14) - 155 = -1</m>.
+					<me> \Rightarrow r(x) = \frac{14}{x+11} + \frac{6x-1}{x^2+9} </me>
 					</p>
 				</solution>
 				<answer>
 					<p>
-						<me> r(x) = \frac{5}{x+11} + \frac{15x+C}{x^2+9} </me>
+						<me> r(x) = \frac{14}{x+11} + \frac{6x-1}{x^2+9} </me>
 					</p>
 				</answer>
 			</exercise>
@@ -881,31 +889,26 @@
 				</statement>
 				<solution>
 					<p>
+				Both factors are irreducible quadratics, so each contributes a term with a <em>linear</em> numerator:
 				<md>
-						<mrow>s(x) = \frac{3x^2+5x+7}{(x^2+4)(x^2+16)} = \frac{3x^2+5x+7}{(x^2+4)(x^2+16)}</mrow>
-						<mrow>\frac{3x^2+5x+7}{(x^2+4)(x^2+16)} = \frac{A}{x^2+4} + \frac{B}{x^2+16}</mrow>
-						<mrow>\frac{3x^2+5x+7}{(x^2+4)(x^2+16)}\cdot (x^2+4)(x^2+16) = \left[\frac{A}{x^2+4} + \frac{B}{x^2+16}\right] \cdot (x^2+4)(x^2+16)</mrow>
-						<mrow>3x^2+5x+7 = A(x^2+16) + B(x^2+4)</mrow>
-						<mrow>3x^2+5x+7 = Ax^2+16A + Bx^2+4B</mrow>
-						<mrow>3x^2+5x+7 = (A+B)x^2 + 16A+4B</mrow>
+						<mrow>\frac{3x^2+5x+7}{(x^2+4)(x^2+16)} = \frac{Ax+B}{x^2+4} + \frac{Cx+D}{x^2+16}</mrow>
+						<mrow>3x^2+5x+7 = (Ax+B)(x^2+16) + (Cx+D)(x^2+4)</mrow>
+						<mrow>3x^2+5x+7 = (A+C)x^3 + (B+D)x^2 + (16A+4C)x + (16B+4D)</mrow>
 					</md>
+					Matching coefficients gives the system
 					<md>
-						<mrow>\Rightarrow A+B = 3 \amp\text{and }	</mrow>
-						<mrow>16A+4B = 5</mrow>
-						<mrow> \amp	\amp A = 1</mrow>
-						<mrow>1+B = 3 \amp		\amp	</mrow>
-						<mrow>B = 2 \amp		\amp	</mrow>
-						<mrow>16(1)+4(2) =
-						\amp	\amp	</mrow>
-						<mrow>16+8 = 5 \amp		\amp	</mrow>
-						<mrow>24 = 5 \amp		\amp	</mrow>
+						<mrow>A+C \amp = 0</mrow>
+						<mrow>B+D \amp = 3</mrow>
+						<mrow>16A+4C \amp = 5</mrow>
+						<mrow>16B+4D \amp = 7</mrow>
 					</md>
-					<me> \Rightarrow s(x) = \frac{1}{x^2+4} + \frac{2}{x^2+16} </me>
+					From the first equation, <m>C = -A</m>, so <m>16A - 4A = 5</m> gives <m>A = \frac{5}{12}</m> and <m>C = -\frac{5}{12}</m>. From the second, <m>D = 3 - B</m>, so <m>16B + 4(3-B) = 7</m> gives <m>B = -\frac{5}{12}</m> and <m>D = \frac{41}{12}</m>.
+					<me> \Rightarrow s(x) = \frac{5x-5}{12(x^2+4)} + \frac{-5x+41}{12(x^2+16)} </me>
 					</p>
 				</solution>
 				<answer>
 					<p>
-						<me> s(x) = \frac{1}{x^2+4} + \frac{2}{x^2+16} </me>
+						<me> s(x) = \frac{5x-5}{12(x^2+4)} + \frac{-5x+41}{12(x^2+16)} </me>
 					</p>
 				</answer>
 			</exercise>
@@ -918,31 +921,26 @@
 				</statement>
 				<solution>
 					<p>
+				Both factors are irreducible quadratics, so each contributes a term with a <em>linear</em> numerator:
 				<md>
-						<mrow>t(x) = \frac{2x^2+3x+5}{(x^2+1)(x^2+4)} = \frac{2x^2+3x+5}{(x^2+1)(x^2+4)}</mrow>
-						<mrow>\frac{2x^2+3x+5}{(x^2+1)(x^2+4)} = \frac{A}{x^2+1} + \frac{B}{x^2+4}</mrow>
-						<mrow>\frac{2x^2+3x+5}{(x^2+1)(x^2+4)}\cdot (x^2+1)(x^2+4) = \left[\frac{A}{x^2+1} + \frac{B}{x^2+4}\right] \cdot (x^2+1)(x^2+4)</mrow>
-						<mrow>2x^2+3x+5 = A(x^2+4) + B(x^2+1)</mrow>
-						<mrow>2x^2+3x+5 = Ax^2+4A + Bx^2+B</mrow>
-						<mrow>2x^2+3x+5 = (A+B)x^2 + 4A+B</mrow>
+						<mrow>\frac{2x^2+3x+5}{(x^2+1)(x^2+4)} = \frac{Ax+B}{x^2+1} + \frac{Cx+D}{x^2+4}</mrow>
+						<mrow>2x^2+3x+5 = (Ax+B)(x^2+4) + (Cx+D)(x^2+1)</mrow>
+						<mrow>2x^2+3x+5 = (A+C)x^3 + (B+D)x^2 + (4A+C)x + (4B+D)</mrow>
 					</md>
+					Matching coefficients gives the system
 					<md>
-						<mrow>\Rightarrow A+B = 2 \amp\text{and }	</mrow>
-						<mrow>4A+B = 3</mrow>
-						<mrow> \amp	\amp A = 1</mrow>
-						<mrow>1+B = 2 \amp		\amp	</mrow>
-						<mrow>B = 1 \amp		\amp	</mrow>
-						<mrow>4(1)+1 =
-						\amp	\amp	</mrow>
-						<mrow>4+1 = 3 \amp		\amp	</mrow>
-						<mrow>5 = 3 \amp		\amp	</mrow>
+						<mrow>A+C \amp = 0</mrow>
+						<mrow>B+D \amp = 2</mrow>
+						<mrow>4A+C \amp = 3</mrow>
+						<mrow>4B+D \amp = 5</mrow>
 					</md>
-					<me> \Rightarrow t(x) = \frac{1}{x^2+1} + \frac{1}{x^2+4} </me>
+					Subtracting the first equation from the third gives <m>3A = 3</m>, so <m>A = 1</m> and <m>C = -1</m>. Subtracting the second from the fourth gives <m>3B = 3</m>, so <m>B = 1</m> and <m>D = 1</m>.
+					<me> \Rightarrow t(x) = \frac{x+1}{x^2+1} + \frac{-x+1}{x^2+4} </me>
 					</p>
 				</solution>
 				<answer>
 					<p>
-						<me> t(x) = \frac{1}{x^2+1} + \frac{1}{x^2+4} </me>
+						<me> t(x) = \frac{x+1}{x^2+1} + \frac{-x+1}{x^2+4} </me>
 					</p>
 				</answer>
 			</exercise>

--- a/source/aa-bookends/a1-algebra/L-pfd.ptx
+++ b/source/aa-bookends/a1-algebra/L-pfd.ptx
@@ -205,7 +205,7 @@
 			<p>
 				Comparing coefficients of <m>s^2</m>, <m>s</m>, and the free terms gives the system:
 				<me>
-					A + B = 0, \quad A - B + C = 5, \quad A - C = 4,
+					A + B = 0, \quad A - B + C = 5, \quad A - C = 4
 				</me>
 				which has solution <m>A = 3</m>, <m>B = -3</m>, <m>C = -1</m>.
 			</p>
@@ -617,12 +617,12 @@
 					Now we see that <m>(x+1)</m> (which is linear), is a factor (three times) of the denominator.
 					Hence, the FORM of the partial fraction decomposition is:
 					<me> r(x) = \frac{A}{x+1} + \frac{B}{(x+1)^2} + \frac{C}{(x+1)^3}. </me>
-					Multiply both sides by the common denominator and solve for <m>A,</m> <m>B,</m> and <m>C.</m>
+					Multiply both sides by the common denominator and solve for <m>A,</m> <m>B,</m> and <m>C.</m> Note that solving gives <m>A = 0</m> here, so the <m>\frac{A}{x+1}</m> term drops out of the final decomposition.
 					</p>
 				</solution>
 				<answer>
 					<p>
-						<me> r(x) = \frac{3}{(x+1)^2} - \frac{17}{(x+1)^3} \quad (\text{here } A = 0) </me>
+						<me> r(x) = \frac{3}{(x+1)^2} - \frac{17}{(x+1)^3} </me>
 					</p>
 				</answer>
 			</exercise>


### PR DESCRIPTION
## Summary

Implements audit item **H2** from `reports/2026-07-textbook-audit.md`: a full rebuild of the broken parts of `source/aa-bookends/a1-algebra/L-pfd.ptx` (Partial Fraction Decomposition review).

**What was broken → fixed:**
- Two worked solutions decomposed over irreducible quadratics with **constant** numerators (`A/(x²+4) + B/(x²+16)`), producing visible contradictions ("24 = 5", "5 = 3") that were waved past. Both now use the correct `(Ax+B)` form with the full coefficient-matching system worked out.
- The `r(x)` solution asserted `A = 5` out of nowhere and its final answer literally contained the unsolved symbol `C`. Correct values: `A = 14, B = 6, C = −1`.
- All **nine placeholder "all-ones" answers** (`1/x + 1/(x−3) + 1/(x+1)`-style) in the decomposition exercise group replaced with computed coefficients.
- The three **improper** rational functions (numerator degree ≥ denominator degree) now perform polynomial long division first — the step the section's own method list requires.
- The second worked example's printed answer didn't equal the original function; the numerator was adjusted (`5s+3` → `5s+4`) so the correct solution has clean integer coefficients, and the coefficient-matching work is shown in full.
- The `v(x)` statement's denominator `(x²−2x+1)²` contradicted its own solution's factoring into `(x−1)²(x+1)²`; the statement now reads `x⁴−2x²+1 = (x²−1)²`, matching the intended factoring.
- Duplicated function labels in the form group (`v(x)`, `u(x)` reused) renamed to `p(x)`/`q(x)`; a sign slip in the `g(x)` elimination fixed; the `WORK-IN-PROGRESS` provisional marker removed now that the section is complete.

## Verification

Every final answer in the file (17 checks: both worked examples, both improper forms, and all 13 answer keys) was verified symbolically with SymPy: `simplify(statement − answer) == 0` for all. File passes `xmllint --noout`. Note: the repo's `build` CI check has been failing on every PR since May due to pre-existing LaTeX-image generation failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_