### PR TITLE
H7: Add Lost Solutions warning to the SOV method section

### DIFF
--- a/source/c4-sov/sec-sov-method.ptx
+++ b/source/c4-sov/sec-sov-method.ptx
@@ -88,17 +88,17 @@
 		<warning xml:id="sov-lost-solutions">
 			<title>Lost Solutions: check <m>g(y) = 0</m> before you divide</title>
 			<p>
-				Separating variables starts by dividing both sides by <m>g(y)</m> — and division is only allowed when <m>g(y) \neq 0</m>. Every value <m>y = c</m> with <m>g(c) = 0</m> makes both sides of <m>\frac{dy}{dx} = f(x)\cdot g(y)</m> equal to zero, so the constant function <m>y(x) = c</m> is a perfectly good solution that the division step silently throws away.
+				Separating variables starts by dividing both sides by <m>g(y)</m> — and division is only allowed when <m>g(y) \neq 0</m>. Every value <m>y = a</m> with <m>g(a) = 0</m> makes both sides of <m>\frac{dy}{dx} = f(x)\cdot g(y)</m> equal to zero, so the constant function <m>y(x) = a</m> is a perfectly good solution that the division step silently throws away.
 			</p>
 			<p>
 				For example, separating <m>\frac{dy}{dx} = y^2</m> gives
 				<me>
-					\int \frac{1}{y^2}\, dy = \int dx \quad\implies\quad y = \frac{-1}{x + c},
+					\int \frac{1}{y^2}\, dy = \int dx \quad\implies\quad y = -\frac{1}{x + c},
 				</me>
-				but dividing by <m>y^2</m> assumed <m>y \neq 0</m> — and the constant function <m>y(x) = 0</m> also satisfies <m>y' = y^2</m>. It is a solution the algebra lost, and no choice of <m>c</m> in <m>\frac{-1}{x+c}</m> recovers it.
+				but dividing by <m>y^2</m> assumed <m>y \neq 0</m> — and the constant function <m>y(x) = 0</m> also satisfies <m>y' = y^2</m>. It is a solution the algebra lost, and no choice of the integration constant <m>c</m> in <m>-\frac{1}{x+c}</m> recovers it.
 			</p>
 			<p>
-				<alert>Habit to build:</alert> before dividing by <m>g(y)</m>, solve <m>g(y) = 0</m>. Each root gives a constant solution to report alongside the general solution from separation. (These constant solutions are exactly the <em>equilibrium solutions</em> you will meet again in the qualitative methods chapter.)
+				<alert>Habit to build:</alert> before dividing by <m>g(y)</m>, solve <m>g(y) = 0</m>. Each root gives a constant solution to report alongside the general solution from separation. (These constant solutions are exactly the <xref ref="equilibrium-solns" text="custom">equilibrium solutions</xref> you will meet again in the qualitative methods chapter.)
 			</p>
 		</warning>
 

--- a/source/c4-sov/sec-sov-method.ptx
+++ b/source/c4-sov/sec-sov-method.ptx
@@ -85,6 +85,23 @@
 
 		</proof>
 
+		<warning xml:id="sov-lost-solutions">
+			<title>Lost Solutions: check <m>g(y) = 0</m> before you divide</title>
+			<p>
+				Separating variables starts by dividing both sides by <m>g(y)</m> — and division is only allowed when <m>g(y) \neq 0</m>. Every value <m>y = c</m> with <m>g(c) = 0</m> makes both sides of <m>\frac{dy}{dx} = f(x)\cdot g(y)</m> equal to zero, so the constant function <m>y(x) = c</m> is a perfectly good solution that the division step silently throws away.
+			</p>
+			<p>
+				For example, separating <m>\frac{dy}{dx} = y^2</m> gives
+				<me>
+					\int \frac{1}{y^2}\, dy = \int dx \quad\implies\quad y = \frac{-1}{x + c},
+				</me>
+				but dividing by <m>y^2</m> assumed <m>y \neq 0</m> — and the constant function <m>y(x) = 0</m> also satisfies <m>y' = y^2</m>. It is a solution the algebra lost, and no choice of <m>c</m> in <m>\frac{-1}{x+c}</m> recovers it.
+			</p>
+			<p>
+				<alert>Habit to build:</alert> before dividing by <m>g(y)</m>, solve <m>g(y) = 0</m>. Each root gives a constant solution to report alongside the general solution from separation. (These constant solutions are exactly the <em>equilibrium solutions</em> you will meet again in the qualitative methods chapter.)
+			</p>
+		</warning>
+
 		<exercise label="sov-method-cyu-1">
 			<title><e component="emoji">📖❓</e> Reorder the Strategy</title>
 


### PR DESCRIPTION
## Summary

Implements audit item **H7** from `reports/2026-07-textbook-audit.md`: the separation-of-variables chapter never warned that dividing by `g(y)` silently discards the constant solutions `y = c` where `g(c) = 0` — the classic SOV pitfall — even though the chapter's own drills use equations (like `y′ = y²`) that lose a solution this way.

Adds a `<warning>` box (the book's ⚠️ style, matching the existing warnings in chapters 2 and 7) to `source/c4-sov/sec-sov-method.ptx`, placed after the method's justification proof:

- why the division step loses solutions,
- a worked micro-example: separating `y′ = y²` yields `y = −1/(x+c)`, but `y(x) = 0` is also a solution no choice of `c` recovers,
- the habit to build: solve `g(y) = 0` before dividing and report each root as a constant solution,
- a forward pointer connecting these to equilibrium solutions in the qualitative-methods chapter.

Example verified with SymPy (both the general solution and the lost `y = 0`); file passes `xmllint --noout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_