### PR TITLE
H8 (part 1): Backfill missing answers and solutions in chapters 3, 4, and 13

### DIFF
--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -35,11 +35,13 @@ from sympy import (
     diff,
     exp,
     laplace_transform,
+    log,
     simplify,
     sin,
     solveset,
     sqrt,
     symbols,
+    tan,
 )
 
 x, t, s, y, b, c = symbols("x t s y b c")
@@ -315,6 +317,75 @@ for _name, _lhs, _rhs in _PFD:
             (lambda L=_lhs, Rr=_rhs: is_zero(L - Rr)),
         )
     )
+
+
+# ----------------------------------------------------------------------
+# H8 answer backfill (chapters 3, 4, 13)
+# ----------------------------------------------------------------------
+C = symbols("C")
+
+REGISTRY += [
+    Check(
+        "c3 rewrite-and-solve: y=(c-1/x)sec x satisfies [y cos x]'=1/x^2",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff((c - 1 / x) / cos(x) * cos(x), x) - 1 / x**2),
+    ),
+    Check(
+        "c3 rewrite-and-solve: y=1/(2x^3)+c/x^5 satisfies [y x^5]'=x",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff((1 / (2 * x**3) + c / x**5) * x**5, x) - x),
+    ),
+    Check(
+        "c3 rewrite-and-solve: y=(x/2)e^(2x)+cx satisfies [y/x]'=e^(2x)",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff(((x / 2) * exp(2 * x) + c * x) / x, x) - exp(2 * x)),
+    ),
+    Check(
+        "c4 Level 1: y=Ce^(x^3/3) solves y'=x^2 y",
+        "source/c4-sov/exercises-sov.ptx",
+        lambda: (lambda Y: is_zero(diff(Y, x) - x**2 * Y))(C * exp(x**3 / 3)),
+    ),
+    Check(
+        "c4 Level 1: y=-ln(C-e^x) solves y'=e^(x+y)",
+        "source/c4-sov/exercises-sov.ptx",
+        lambda: (lambda Y: is_zero(diff(Y, x) - exp(x + Y)))(-log(C - exp(x))),
+    ),
+    Check(
+        "c4 Level 1: y=2-Ce^(-x) solves y'=2-y",
+        "source/c4-sov/exercises-sov.ptx",
+        lambda: (lambda Y: is_zero(diff(Y, x) - (2 - Y)))(2 - C * exp(-x)),
+    ),
+    Check(
+        "c4 Level 1: y=-1/(tan x + c) solves y'=y^2 sec^2 x",
+        "source/c4-sov/exercises-sov.ptx",
+        lambda: (lambda Y: is_zero(diff(Y, x) - Y**2 / cos(x) ** 2))(
+            -1 / (tan(x) + c)
+        ),
+    ),
+    Check(
+        "c13 sugar tank: S=120-118e^(-t/40) solves S'=3-S/40, S(0)=2",
+        "source/c13-linsys/exercises-linsys.ptx",
+        lambda: (
+            lambda S: is_zero(diff(S, t) - (3 - S / 40)) and S.subs(t, 0) == 2
+        )(120 - 118 * exp(-t / 40)),
+    ),
+    Check(
+        "c13 brine tank: S=0.2(100+t)-2e7/(100+t)^3 solves S'=0.8-3S/(100+t), S(0)=0",
+        "source/c13-linsys/exercises-linsys.ptx",
+        lambda: (
+            lambda S: is_zero(diff(S, t) - (R(4, 5) - 3 * S / (100 + t)))
+            and S.subs(t, 0) == 0
+        )(R(1, 5) * (100 + t) - 2 * 10**7 / (100 + t) ** 3),
+    ),
+    Check(
+        "c13 Euler: y'=3z, z'=y+z^2 from (2,3,-4), h=0.1, 2 steps -> (1.17, -1.479)",
+        "source/c13-linsys/exercises-linsys.ptx",
+        lambda: euler_system(
+            [lambda tk, yk, zk: 3 * zk, lambda tk, yk, zk: yk + zk**2],
+            2, [R(3), R(-4)], R(1, 10), 2,
+        ) == [R(117, 100), R(-1479, 1000)],
+    ),
+]
 
 
 def main() -> int:

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -322,8 +322,6 @@ for _name, _lhs, _rhs in _PFD:
 # ----------------------------------------------------------------------
 # H8 answer backfill (chapters 3, 4, 13)
 # ----------------------------------------------------------------------
-C = symbols("C")
-
 REGISTRY += [
     Check(
         "c3 rewrite-and-solve: y=(c-1/x)sec x satisfies [y cos x]'=1/x^2",
@@ -343,17 +341,17 @@ REGISTRY += [
     Check(
         "c4 Level 1: y=Ce^(x^3/3) solves y'=x^2 y",
         "source/c4-sov/exercises-sov.ptx",
-        lambda: (lambda Y: is_zero(diff(Y, x) - x**2 * Y))(C * exp(x**3 / 3)),
+        lambda: (lambda Y: is_zero(diff(Y, x) - x**2 * Y))(c * exp(x**3 / 3)),
     ),
     Check(
         "c4 Level 1: y=-ln(C-e^x) solves y'=e^(x+y)",
         "source/c4-sov/exercises-sov.ptx",
-        lambda: (lambda Y: is_zero(diff(Y, x) - exp(x + Y)))(-log(C - exp(x))),
+        lambda: (lambda Y: is_zero(diff(Y, x) - exp(x + Y)))(-log(c - exp(x))),
     ),
     Check(
         "c4 Level 1: y=2-Ce^(-x) solves y'=2-y",
         "source/c4-sov/exercises-sov.ptx",
-        lambda: (lambda Y: is_zero(diff(Y, x) - (2 - Y)))(2 - C * exp(-x)),
+        lambda: (lambda Y: is_zero(diff(Y, x) - (2 - Y)))(2 - c * exp(-x)),
     ),
     Check(
         "c4 Level 1: y=-1/(tan x + c) solves y'=y^2 sec^2 x",

--- a/source/c13-linsys/exercises-linsys.ptx
+++ b/source/c13-linsys/exercises-linsys.ptx
@@ -660,11 +660,35 @@
 					</ol>
 				</p>
 			</statement>
+			<solution>
+				<p>
+					(a) Let <m>S(t)</m> be the mass of sugar (kg) in the tank. The volume stays at 400 L since inflow and outflow rates match. Then
+					<md>
+						<mrow> \frac{dS}{dt} \amp = \underbrace{(0.3)(10)}_{\text{rate in}} - \underbrace{\frac{S}{400}(10)}_{\text{rate out}} = 3 - \frac{S}{40} </mrow>
+					</md>
+					with <m>S(0) = 2</m>. This first-order linear (and separable) equation has equilibrium <m>S = 120</m>, so
+					<me>
+						S(t) = 120 - 118e^{-t/40}.
+					</me>
+					(Check: <m>S(0) = 120 - 118 = 2</m> ✓.)
+				</p>
+				<p>
+					(b) <m>S(10) = 120 - 118e^{-1/4} \approx 28.10</m> kg, so the concentration is <m>\dfrac{S(10)}{400} \approx 0.070</m> kg/L.
+				</p>
+				<p>
+					(c) As <m>t \to \infty</m>, <m>S \to 120</m> kg, so the concentration approaches <m>\dfrac{120}{400} = 0.3</m> kg/L — exactly the concentration of the incoming mixture. This makes sense: after a long time the original contents have essentially washed out, and the tank matches what is being pumped in.
+				</p>
+			</solution>
+			<answer>
+				<p>
+					(a) <m>S(t) = 120 - 118e^{-t/40}</m> kg; (b) <m>\approx 0.070</m> kg/L; (c) <m>0.3</m> kg/L, the inflow concentration.
+				</p>
+			</answer>
 		</exercise>
 
 		<exercise>
 			<statement>
-				A brine solution of salt flows at a constant rate of 4 L/min into a large tank that initially is pure water.  The solution inside the tank is kept well-stirred and flows out of the tank at a rate of 3 L/min. Suppose the concentration of salt in the brine entering the tank is <m>0.2</m> kg/L. Then
+				A brine solution of salt flows at a constant rate of 4 L/min into a large tank that initially holds 100 L of pure water.  The solution inside the tank is kept well-stirred and flows out of the tank at a rate of 3 L/min. Suppose the concentration of salt in the brine entering the tank is <m>0.2</m> kg/L. Then
 				<p>
 				<ol marker="(a)">
 					<li>Determine the mass of the salt in the tank after <m>t </m> minutes.</li>
@@ -674,12 +698,36 @@
 			</statement>
 			<solution>
 				<p>
-					
+					(a) Let <m>S(t)</m> be the mass of salt (kg). The volume is <em>not</em> constant here: 4 L/min enters but only 3 L/min leaves, so <m>V(t) = 100 + t</m>. Then
+					<md>
+						<mrow> \frac{dS}{dt} \amp = \underbrace{(0.2)(4)}_{\text{rate in}} - \underbrace{\frac{S}{100+t}(3)}_{\text{rate out}} = 0.8 - \frac{3S}{100+t} </mrow>
+					</md>
+					with <m>S(0) = 0</m>. In standard form, <m>S' + \frac{3}{100+t}S = 0.8</m>, with integrating factor
+					<me>
+						\mu(t) = e^{\int \frac{3}{100+t}\,dt} = (100+t)^3.
+					</me>
+					Then
+					<md>
+						<mrow> \left[(100+t)^3 S\right]' \amp = 0.8(100+t)^3 </mrow>
+						<mrow> (100+t)^3 S \amp = 0.2(100+t)^4 + c </mrow>
+						<mrow> S(t) \amp = 0.2(100+t) + \frac{c}{(100+t)^3} </mrow>
+					</md>
+					and <m>S(0) = 0</m> gives <m>c = -0.2(100)^4 = -2\times 10^7</m>. Hence
+					<me>
+						S(t) = 0.2(100+t) - \frac{2\times 10^7}{(100+t)^3}.
+					</me>
+				</p>
+				<p>
+					(b) After one hour, <m>t = 60</m> and <m>V = 160</m> L:
+					<me>
+						S(60) = 0.2(160) - \frac{2\times 10^7}{160^3} \approx 32 - 4.88 = 27.12 \text{ kg}
+					</me>
+					so the concentration is <m>\dfrac{S(60)}{160} \approx 0.17</m> kg/L.
 				</p>
 			</solution>
 			<answer>
 				<p>
-					
+					(a) <m>\ds S(t) = 0.2(100+t) - \frac{2\times 10^7}{(100+t)^3}</m> kg; (b) <m>\approx 0.17</m> kg/L.
 				</p>
 			</answer>
 		</exercise>
@@ -832,7 +880,7 @@
 					<li>
 						Rewrite the system of differential equations in matrix form by using the vector
 						<m>\vec{X} = \begin{bmatrix} x\\y \end{bmatrix}.</m>
-						Notice that for this system, the right hand side should be of the for <m>A\vec{X} + \vec{B}.</m>
+						Notice that for this system, the right hand side should be of the form <m>A\vec{X} + \vec{B}.</m>
 					</li>
 					<li>
 						Write the initial conditions as a vector as well. That is, complete the following.
@@ -841,6 +889,31 @@
 				</ol>
 				</p>
 			</statement>
+			<solution>
+				<p>
+					(a) Since <m>x</m> and <m>y</m> are defense expenditures over time, natural units are currency per year (say, billions of dollars per year), with <m>t</m> in years.
+				</p>
+				<p>
+					(b) The positive coefficient on <m>y</m> means country X <em>increases</em> its spending in response to country Y's spending — an escalation driven by distrust, which is the essence of an arms race. A negative coefficient would model a country that responds to a rival's buildup by <em>reducing</em> its own spending (appeasement or forced disarmament) — possible, but it describes a different political situation.
+				</p>
+				<p>
+					(c) The negative coefficient on <m>y</m> in its own equation is self-restraint: the larger Y's current budget, the harder it is to grow it further (economic burden). A positive coefficient would mean Y's spending feeds on itself, growing without any brake — a runaway model that is harder to justify.
+				</p>
+				<p>
+					(d) The constants shift each country's baseline spending. If X trusts Y, then <m>a \lt 0</m> (X reduces spending independent of Y's behavior); if Y distrusts X, then <m>b \gt 0</m>.
+				</p>
+				<p>
+					(e) <m>\ds \frac{d\vec{X}}{dt} = \begin{bmatrix} -1 \amp 2 \\ 4 \amp -3 \end{bmatrix}\vec{X} + \begin{bmatrix} a \\ b \end{bmatrix}</m>
+				</p>
+				<p>
+					(f) <m>\ds \vec{X}(0) = \begin{bmatrix} 1 \\ 4 \end{bmatrix}</m>
+				</p>
+			</solution>
+			<answer>
+				<p>
+					(e) <m>\ds \frac{d\vec{X}}{dt} = \begin{bmatrix} -1 \amp 2 \\ 4 \amp -3 \end{bmatrix}\vec{X} + \begin{bmatrix} a \\ b \end{bmatrix}</m>; (f) <m>\ds \vec{X}(0) = \begin{bmatrix} 1 \\ 4 \end{bmatrix}</m>
+				</p>
+			</answer>
 		</exercise>
 
 		<exercisegroup>
@@ -853,12 +926,12 @@
 							<caption></caption>
 							<image width="50%" source="./figures/concentration.png"/>
 						</figure>
-						A model for the concentration <m>x(t)</m> and <m>y(t)</m> of the nutrient in compartments A and B, respectively, at time <m>t</m> is given by the linear system of differential equations:
+						A model for the amounts <m>x(t)</m> and <m>y(t)</m> of the nutrient in compartments A and B, respectively, at time <m>t</m> is given by the linear system of differential equations:
 						<md>
-							<mrow>\frac{dx}{dt}	=\amp \frac{\kappa}{V_A}(y-x), </mrow>
-							<mrow>\frac{dy}{dt}	=\amp \frac{\kappa}{V_B}(x-y). </mrow>
+							<mrow>\frac{dx}{dt}	=\amp \kappa\left(\frac{y}{V_B}-\frac{x}{V_A}\right), </mrow>
+							<mrow>\frac{dy}{dt}	=\amp \kappa\left(\frac{x}{V_A}-\frac{y}{V_B}\right). </mrow>
 						</md>
-						where <m>V_A</m> and <m>V_B</m> are the volumes of the compartments, and <m>\kappa &gt; 0 </m> is a	permeability factor.
+						where <m>V_A</m> and <m>V_B</m> are the volumes of the compartments (so <m>\sfrac{x}{V_A}</m> and <m>\sfrac{y}{V_B}</m> are the concentrations), and <m>\kappa &gt; 0 </m> is a	permeability factor.
 						Let <m>x(0) = x_0</m> and <m>y(0) = y_0</m>.
 						<ol>
 							<li>
@@ -877,12 +950,31 @@
 								<m>\vec{X} = \begin{bmatrix} x\\y \end{bmatrix}.</m>
 							</li>
 							<li>
-								Write the initial conditions as a vector as well. That is, complete the following. 
+								Write the initial conditions as a vector as well. That is, complete the following.
 								<m>\vec{X}(0) = \begin{bmatrix} ?\\? \end{bmatrix}</m>
 							</li>
 						</ol>
 					</p>
 				</statement>
+				<solution>
+					<p>
+						(a) The nutrient diffuses across the membrane from higher concentration to lower concentration. The concentration in B is <m>\sfrac{y}{V_B}</m>, and the higher it is, the faster nutrient flows <em>into</em> A — so <m>y</m> appears with a positive coefficient. The concentration in A, <m>\sfrac{x}{V_A}</m>, pushes nutrient <em>out</em> of A, so <m>x</m> appears with a negative coefficient.
+					</p>
+					<p>
+						(b) <m>\frac{d}{dt}[x+y] = 0</m> says the total amount of nutrient <m>x + y</m> never changes — the membrane only moves nutrient between the compartments; none is created or destroyed. So <m>x(t) + y(t) = x_0 + y_0</m> for all time.
+					</p>
+					<p>
+						(c) <m>\ds \frac{d\vec{X}}{dt} = \kappa\begin{bmatrix} -\sfrac{1}{V_A} \amp \sfrac{1}{V_B} \\ \sfrac{1}{V_A} \amp -\sfrac{1}{V_B} \end{bmatrix}\vec{X}</m>
+					</p>
+					<p>
+						(d) <m>\ds \vec{X}(0) = \begin{bmatrix} x_0 \\ y_0 \end{bmatrix}</m>
+					</p>
+				</solution>
+				<answer>
+					<p>
+						(c) <m>\ds \frac{d\vec{X}}{dt} = \kappa\begin{bmatrix} -\sfrac{1}{V_A} \amp \sfrac{1}{V_B} \\ \sfrac{1}{V_A} \amp -\sfrac{1}{V_B} \end{bmatrix}\vec{X}</m>; (d) <m>\ds \vec{X}(0) = \begin{bmatrix} x_0 \\ y_0 \end{bmatrix}</m>
+					</p>
+				</answer>
 			</exercise>
 
 			<exercise>
@@ -919,6 +1011,21 @@
 						approximate <m>y(2.2)</m> and <m>z(2.2)</m> using two iterations of Euler's method with a step size <m>h = 0.1</m>.
 					</p>
 				</statement>
+				<solution>
+					<p>
+						With <m>f_1(t,y,z) = 3z</m> and <m>f_2(t,y,z) = y + z^2</m>:
+						<md>
+							<mrow> \mbox{Iteration 1: } \amp \amp y_1 \amp = 3 + 0.1\cdot 3(-4) = 1.8 </mrow>
+							<mrow> \amp \amp z_1 \amp = -4 + 0.1\cdot\big(3 + (-4)^2\big) = -2.1 </mrow>
+							<mrow> \mbox{Iteration 2: } \amp \amp y_2 \amp = 1.8 + 0.1\cdot 3(-2.1) = 1.17 </mrow>
+							<mrow> \amp \amp z_2 \amp = -2.1 + 0.1\cdot\big(1.8 + (-2.1)^2\big) = -1.479 </mrow>
+						</md>
+						Therefore <m>y(2.2) \approx 1.17</m> and <m>z(2.2) \approx -1.479</m>.
+					</p>
+				</solution>
+				<answer>
+					<p><m>y(2.2) \approx 1.17</m>, <m>z(2.2) \approx -1.479</m></p>
+				</answer>
 		</exercise>
 
 		<exercise>
@@ -989,12 +1096,37 @@
 				<statement>
 					<m>y'' - 4y' + 4y = 0 </m>
 				</statement>
+				<solution>
+					<p>
+						Let <m>u = y</m> and <m>v = y'</m>. Then <m>u' = v</m>, and substituting into the equation gives <m>v' - 4v + 4u = 0</m>, so:
+						<md>
+							<mrow> u' \amp = v </mrow>
+							<mrow> v' \amp = 4v - 4u </mrow>
+						</md>
+					</p>
+				</solution>
+				<answer>
+					<p><m>u' = v,\quad v' = 4v - 4u</m> where <m>u = y</m> and <m>v = y'</m></p>
+				</answer>
 			</exercise>
 
 			<exercise>
 				<statement>
 					<m>x^2 y''' = 2y' </m>
 				</statement>
+				<solution>
+					<p>
+						This is third-order, so we need three variables. Let <m>u = y</m>, <m>v = y'</m>, and <m>w = y''</m>. Then <m>u' = v</m>, <m>v' = w</m>, and substituting into the equation gives <m>x^2 w' = 2v</m>, so:
+						<md>
+							<mrow> u' \amp = v </mrow>
+							<mrow> v' \amp = w </mrow>
+							<mrow> w' \amp = \frac{2v}{x^2} </mrow>
+						</md>
+					</p>
+				</solution>
+				<answer>
+					<p><m>u' = v,\quad v' = w,\quad w' = \dfrac{2v}{x^2}</m> where <m>u = y</m>, <m>v = y'</m>, and <m>w = y''</m></p>
+				</answer>
 			</exercise>
 
 			<exercise>

--- a/source/c3-di/exercises-di.ptx
+++ b/source/c3-di/exercises-di.ptx
@@ -1119,14 +1119,74 @@
 			
 				<exercise>
 					<statement><p><m>\left[y \cos x \right]^{\prime} = \dfrac{1}{x^2}</m></p></statement>
+					<solution>
+						<p>
+							(a) Expanding the left side with the product rule gives
+							<md>
+								<mrow> y'\cos x - y\sin x \amp = \frac{1}{x^2} </mrow>
+								<mrow> y' - (\tan x)\, y \amp = \frac{\sec x}{x^2} </mrow>
+							</md>
+							after dividing both sides by <m>\cos x</m>. Here <m>P(x) = -\tan x</m> and <m>Q(x) = \dfrac{\sec x}{x^2}</m>.
+						</p>
+						<p>
+							(b) The original form is ready for direct integration:
+							<md>
+								<mrow> y \cos x \amp = \int \frac{1}{x^2}\, dx = -\frac{1}{x} + c </mrow>
+								<mrow> y \amp = \left(c - \frac{1}{x}\right)\sec x </mrow>
+							</md>
+						</p>
+					</solution>
+					<answer>
+						<p><m>\ds y = \left(c - \frac{1}{x}\right)\sec x</m></p>
+					</answer>
 				</exercise>
 
 				<exercise>
 					<statement><p><m>\left[y x^5 \right]^{\prime} = x</m></p></statement>
+					<solution>
+						<p>
+							(a) Expanding the left side with the product rule gives
+							<md>
+								<mrow> y' x^5 + 5x^4 y \amp = x </mrow>
+								<mrow> y' + \frac{5}{x}\, y \amp = \frac{1}{x^4} </mrow>
+							</md>
+							after dividing both sides by <m>x^5</m>. Here <m>P(x) = \dfrac{5}{x}</m> and <m>Q(x) = \dfrac{1}{x^4}</m>.
+						</p>
+						<p>
+							(b) The original form is ready for direct integration:
+							<md>
+								<mrow> y x^5 \amp = \int x\, dx = \frac{x^2}{2} + c </mrow>
+								<mrow> y \amp = \frac{1}{2x^3} + \frac{c}{x^5} </mrow>
+							</md>
+						</p>
+					</solution>
+					<answer>
+						<p><m>\ds y = \frac{1}{2x^3} + \frac{c}{x^5}</m></p>
+					</answer>
 				</exercise>
 
 				<exercise>
 					<statement><p><m>\left[x^{-1}y\right]^{\prime} = e^{2x}</m></p></statement>
+					<solution>
+						<p>
+							(a) Expanding the left side with the product rule gives
+							<md>
+								<mrow> x^{-1} y' - x^{-2} y \amp = e^{2x} </mrow>
+								<mrow> y' - \frac{1}{x}\, y \amp = x e^{2x} </mrow>
+							</md>
+							after multiplying both sides by <m>x</m>. Here <m>P(x) = -\dfrac{1}{x}</m> and <m>Q(x) = x e^{2x}</m>.
+						</p>
+						<p>
+							(b) The original form is ready for direct integration:
+							<md>
+								<mrow> x^{-1} y \amp = \int e^{2x}\, dx = \frac{1}{2}e^{2x} + c </mrow>
+								<mrow> y \amp = \frac{x}{2}e^{2x} + cx </mrow>
+							</md>
+						</p>
+					</solution>
+					<answer>
+						<p><m>\ds y = \frac{x}{2}e^{2x} + cx</m></p>
+					</answer>
 				</exercise>
 
 			</exercisegroup>

--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -1856,10 +1856,10 @@
 								<mrow> \int e^{-y}\, dy \amp = \int e^x\, dx </mrow>
 								<mrow> -e^{-y} \amp = e^x + c </mrow>
 							</md>
-							Solving for <m>y</m> (renaming the constant so <m>e^{-y} = C - e^x</m>) gives <m>y = -\ln\left(C - e^x\right)</m>.
+							Solving for <m>y</m> (renaming the constant so <m>e^{-y} = C - e^x</m>) gives <m>y = -\ln\left(C - e^x\right)</m>. Since <m>e^{-y}</m> is always positive, this solution is only valid where <m>C - e^x \gt 0</m>, i.e. for <m>x \lt \ln C</m>.
 						</p>
 					</solution>
-					<answer><p><m>\ds y = -\ln\left(C - e^x\right)</m></p></answer>
+					<answer><p><m>\ds y = -\ln\left(C - e^x\right)</m> for <m>x \lt \ln C</m></p></answer>
 				</exercise>
 
 				<exercise>

--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -1834,38 +1834,132 @@
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = x^2y</m></statement>
+					<solution>
+						<p>
+							Separating (<m>y \neq 0</m>) and integrating:
+							<md>
+								<mrow> \int \frac{1}{y}\, dy \amp = \int x^2\, dx </mrow>
+								<mrow> \ln|y| \amp = \frac{x^3}{3} + c </mrow>
+							</md>
+							Exponentiating and absorbing signs into the constant gives <m>y = Ce^{x^3/3}</m>. The constant solution <m>y = 0</m> is included (take <m>C = 0</m>).
+						</p>
+					</solution>
+					<answer><p><m>\ds y = Ce^{x^3/3}</m></p></answer>
 				</exercise>
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = e^{x+y}</m></statement>
+					<solution>
+						<p>
+							Since <m>e^{x+y} = e^x \cdot e^y</m>, the equation is separable:
+							<md>
+								<mrow> \int e^{-y}\, dy \amp = \int e^x\, dx </mrow>
+								<mrow> -e^{-y} \amp = e^x + c </mrow>
+							</md>
+							Solving for <m>y</m> (renaming the constant so <m>e^{-y} = C - e^x</m>) gives <m>y = -\ln\left(C - e^x\right)</m>.
+						</p>
+					</solution>
+					<answer><p><m>\ds y = -\ln\left(C - e^x\right)</m></p></answer>
 				</exercise>
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = \frac{x}{y}</m></statement>
+					<solution>
+						<p>
+							Separating and integrating:
+							<md>
+								<mrow> \int y\, dy \amp = \int x\, dx </mrow>
+								<mrow> \frac{y^2}{2} \amp = \frac{x^2}{2} + c </mrow>
+							</md>
+							so <m>y^2 = x^2 + C</m>, or <m>y = \pm\sqrt{x^2 + C}</m> (an initial condition selects the sign).
+						</p>
+					</solution>
+					<answer><p><m>\ds y = \pm\sqrt{x^2 + C}</m></p></answer>
 				</exercise>
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = \cos(x) \sec(y)</m></statement>
+					<solution>
+						<p>
+							Since <m>\sec(y) = \frac{1}{\cos(y)}</m>, separating gives:
+							<md>
+								<mrow> \int \cos(y)\, dy \amp = \int \cos(x)\, dx </mrow>
+								<mrow> \sin(y) \amp = \sin(x) + c </mrow>
+							</md>
+							which we leave as an implicit solution (or <m>y = \arcsin\big(\sin(x) + c\big)</m> where the inverse applies).
+						</p>
+					</solution>
+					<answer><p><m>\sin(y) = \sin(x) + c</m></p></answer>
 				</exercise>
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = \frac{2x}{1+y^2}</m></statement>
+					<solution>
+						<p>
+							Separating and integrating:
+							<md>
+								<mrow> \int (1 + y^2)\, dy \amp = \int 2x\, dx </mrow>
+								<mrow> y + \frac{y^3}{3} \amp = x^2 + c </mrow>
+							</md>
+							The cubic in <m>y</m> is not worth solving explicitly, so we leave the solution implicit.
+						</p>
+					</solution>
+					<answer><p><m>\ds y + \frac{y^3}{3} = x^2 + c</m></p></answer>
 				</exercise>
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = 2-y</m></statement>
+					<solution>
+						<p>
+							Separating (<m>y \neq 2</m>) and integrating:
+							<md>
+								<mrow> \int \frac{1}{2-y}\, dy \amp = \int dx </mrow>
+								<mrow> -\ln|2-y| \amp = x + c </mrow>
+							</md>
+							Exponentiating and absorbing signs into the constant gives <m>2 - y = Ce^{-x}</m>, so <m>y = 2 - Ce^{-x}</m>. The constant solution <m>y = 2</m> is included (take <m>C = 0</m>).
+						</p>
+					</solution>
+					<answer><p><m>\ds y = 2 - Ce^{-x}</m></p></answer>
 				</exercise>
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = \frac{y-x}{y+x}</m></statement>
+					<solution>
+						<p>
+							This one is <em>not possible</em> with separation of variables: no algebra turns <m>\frac{y-x}{y+x}</m> into a product <m>f(x)\cdot g(y)</m> — the sum <m>y+x</m> in the denominator inseparably mixes the variables. (Equations like this can be solved with a substitution method not covered in this book.)
+						</p>
+					</solution>
+					<answer><p>Not separable — no algebra puts <m>\frac{y-x}{y+x}</m> into the form <m>f(x)\cdot g(y)</m>.</p></answer>
 				</exercise>
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = y^2 \sec^2(x)</m></statement>
+					<solution>
+						<p>
+							Separating (<m>y \neq 0</m>) and integrating:
+							<md>
+								<mrow> \int y^{-2}\, dy \amp = \int \sec^2(x)\, dx </mrow>
+								<mrow> -\frac{1}{y} \amp = \tan(x) + c </mrow>
+							</md>
+							so <m>y = -\dfrac{1}{\tan(x) + c}</m>. Dividing by <m>y^2</m> lost the constant solution <m>y = 0</m>, which we report alongside the general solution.
+						</p>
+					</solution>
+					<answer><p><m>\ds y = -\frac{1}{\tan(x) + c}</m>, plus the constant solution <m>y = 0</m></p></answer>
 				</exercise>
 
 				<exercise>
 					<statement><m>\dfrac{dy}{dx} = \frac{1}{xy}</m></statement>
+					<solution>
+						<p>
+							Separating and integrating:
+							<md>
+								<mrow> \int y\, dy \amp = \int \frac{1}{x}\, dx </mrow>
+								<mrow> \frac{y^2}{2} \amp = \ln|x| + c </mrow>
+							</md>
+							so <m>y^2 = 2\ln|x| + C</m>, or <m>y = \pm\sqrt{2\ln|x| + C}</m> (an initial condition selects the sign).
+						</p>
+					</solution>
+					<answer><p><m>\ds y = \pm\sqrt{2\ln|x| + C}</m></p></answer>
 				</exercise>
 
 			</exercisegroup>


### PR DESCRIPTION
## Summary

First installment of audit item **H8** from `reports/2026-07-textbook-audit.md`: every enumerated answer/solution gap in chapters 3, 4, and 13 is now filled, with all quantitative results SymPy-verified.

**Chapter 3 — "Rewrite and Solve"**: full (a)/(b) worked solutions and answers for all three product-rule exercises (previously statements only).

**Chapter 4 — "Level 1"**: worked solutions and answers for the nine unsupported exercises, matching the style of the two that already had them. Two notes:
- `(y−x)/(y+x)` is the group's deliberate "if possible" trap — its solution now explains *why* no algebra produces the `f(x)·g(y)` form.
- `y′ = y² sec²x` reports the lost constant solution `y = 0` alongside the general solution, reinforcing the new Lost Solutions warning (#191).

**Chapter 13**:
- **Sugar tank**: solved (`S(t) = 120 − 118e^{−t/40}`, limiting concentration 0.3 kg/L = the inflow concentration).
- **Brine tank**: the statement never specified the initial volume, which the problem requires since inflow (4 L/min) ≠ outflow (3 L/min); it now starts with 100 L of pure water, and the previously empty `<solution>`/`<answer>` blocks contain the full integrating-factor solution.
- **Membrane**: statement repair — the printed equations `κ/V_A(y−x)`, `κ/V_B(x−y)` contradict the exercise's own part (b) claim that `d/dt[x+y] = 0` (their sum is nonzero unless `V_A = V_B`). Restated with the standard amount-based model `κ(y/V_B − x/V_A)`, which conserves `x+y` identically; all four parts solved.
- **Arms race**: all six parts answered, including the matrix form `X′ = AX + B` ("of the for" → "of the form" fixed in passing).
- **Euler for systems** (`y′ = 3z`): worked two-step solution → `y(2.2) = 1.17`, `z(2.2) = −1.479`.
- **Reduction to systems**: both exercises (`y″−4y′+4y=0` and `x²y‴=2y′`) solved.

## Verification

All ODE solutions verified by substitution and all numeric values recomputed in exact arithmetic with SymPy. Ten regression checks covering the new solutions added to `processing-tools/verify-worked-math` — **48/48 pass**. All three touched `.ptx` files pass `xmllint --noout`.

**Remaining H8 scope** (follow-up PR): chapter 12's Laplace solution coverage (~33%) and the conceptual sub-parts in chapters 6–7.

Note: the `build` CI check fails on every PR due to the pre-existing repo-wide LaTeX-image generation issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_