### PR TITLE
Temporarily disable automatic per-PR builds

### DIFF
--- a/.github/workflows/pretext-cli.yml
+++ b/.github/workflows/pretext-cli.yml
@@ -9,9 +9,12 @@
 # the `push` event to have it run on pushes to the main branch as well.
 name: PreTeXt-CLI Actions
 on:
-    # Runs on pull requests
-    pull_request:
-        branches: ["*"]
+    # TEMPORARILY DISABLED (July 2026): automatic per-PR builds are paused
+    # because the build is slow. Restore by uncommenting the two lines
+    # below. Manual runs still work via the Actions tab (workflow_dispatch).
+    ## Runs on pull requests
+    #pull_request:
+    #    branches: ["*"]
     ## Runs on pushes to main
     #push:
     #    branches: ["main"]


### PR DESCRIPTION
## Summary

Pauses the automatic build/deploy pipeline per request: the `pull_request` trigger on the **PreTeXt-CLI Actions** workflow is commented out (clearly marked as temporary, with restore instructions in the comment). After this merges, opening or updating a PR will no longer kick off the slow PreTeXt build.

What still works:
- **Manual runs**: both workflows keep `workflow_dispatch`, so a build or deploy can be run on demand from the Actions tab whenever wanted.
- **`pretext-deploy.yml`** was already manual-only — no change needed there.

To restore automatic per-PR builds later, uncomment the two `pull_request:` lines at the top of `.github/workflows/pretext-cli.yml`.

Side note: this also silences the red ✗ that has appeared on every PR since May from the pre-existing LaTeX-image generation failures (41 figures) — worth keeping in mind that PRs will show *no* build signal at all until the trigger is restored, so the audit's CI recommendation (a fast `pretext validate` gate, item L1) may be worth adding as a lightweight replacement when you're ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_