### PR TITLE
L1: Add fast per-PR validation gate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,33 @@
+# Fast validation gate for pull requests.
+#
+# Runs in seconds (no PreTeXt build, no LaTeX): XML well-formedness over
+# all source .ptx files, duplicate xml:id/label detection across the
+# main.ptx build set, a placeholder-marker ratchet, and the SymPy
+# verification of worked mathematics. The full PreTeXt build workflow
+# (PreTeXt-CLI Actions) remains available via manual dispatch.
+name: Validate Source
+on:
+    pull_request:
+        branches: ["*"]
+    workflow_dispatch:
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout source
+              uses: actions/checkout@v4
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+
+            - name: Validate PreTeXt source (well-formedness, ids, placeholders)
+              run: python3 processing-tools/validate-source/validate_source.py
+
+            - name: Install SymPy
+              run: pip install sympy
+
+            - name: Verify worked mathematics
+              run: python3 processing-tools/verify-worked-math/verify_worked_math.py

--- a/processing-tools/validate-source/placeholder-baseline.json
+++ b/processing-tools/validate-source/placeholder-baseline.json
@@ -1,0 +1,18 @@
+{
+ "source/aa-bookends/a1-algebra/K-rational-functions.ptx": 2,
+ "source/aa-bookends/a1-algebra/M-piecewise-functions.ptx": 2,
+ "source/aa-bookends/a1-algebra/N-recursive-functions.ptx": 2,
+ "source/aa-bookends/a1-algebra/O-interrelated-functions.ptx": 2,
+ "source/aa-bookends/a1-algebra/P-units-mass-balance.ptx": 2,
+ "source/aa-bookends/a3-quickref/c11-qref-ltp.ptx": 1,
+ "source/aa-bookends/back-matter.ptx": 4,
+ "source/c12-ltp/sec-unit-step-variants.ptx": 3,
+ "source/c13-linsys/sec-qualitative-methods-systems.ptx": 2,
+ "source/c13-linsys/sec-solving-linear-systems.ptx": 2,
+ "source/c14-nlinsys/sec-nonlinear-systems.ptx": 3,
+ "source/c5-if/sec-finding-the-integrating-factor.ptx": 3,
+ "source/c6-qm/sec-logistical-models.ptx": 1,
+ "source/c6-qm/sec-parameter-analysis.ptx": 1,
+ "source/c7-em/sec-euler-method.ptx": 1,
+ "source/main.ptx": 3
+}

--- a/processing-tools/validate-source/validate_source.py
+++ b/processing-tools/validate-source/validate_source.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Fast validation gate for the PreTeXt source.
+
+Three checks, all static and dependency-free (Python stdlib only):
+
+1. Well-formedness — every ``source/**/*.ptx`` file must parse as XML.
+2. Unique ids — no ``xml:id`` or ``label`` value may be defined twice
+   within the ``main.ptx`` build set (PreTeXt treats the two attributes
+   as one id namespace). Ids inside XML comments are ignored, as the
+   builder ignores them.
+3. Placeholder lint — draft markers must not increase. Counts of known
+   markers (``provisional`` xrefs, ``NEEDS-A-LABEL``, "Need to Add", …)
+   are compared per file against ``placeholder-baseline.json``. New
+   markers fail the check; removing markers prints a reminder to shrink
+   the baseline so the ratchet only ever tightens.
+
+Scope: checks 2 and 3 run on the files reachable from ``source/main.ptx``
+via ``xi:include`` (the shipping build set), so the stranded dev/parts
+variants cannot cause false duplicates. Check 1 runs on every ``.ptx``
+file under ``source/``.
+
+Usage:
+    python3 processing-tools/validate-source/validate_source.py
+
+Exits nonzero on any failure. Designed for the per-PR validate workflow
+(a fast stand-in while the full PreTeXt build is paused), and equally
+runnable locally before a commit.
+"""
+
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SOURCE = REPO / "source"
+MAIN = SOURCE / "main.ptx"
+BASELINE_FILE = Path(__file__).resolve().parent / "placeholder-baseline.json"
+
+XI_INCLUDE = re.compile(r"<xi:include\s+[^>]*href=\"([^\"]+)\"([^>]*)>")
+XML_DECL = re.compile(r"^\s*<\?xml[^?]*\?>")
+XML_ID = "{http://www.w3.org/XML/1998/namespace}id"
+
+PLACEHOLDER_TOKENS = [
+    "provisional=",
+    "NEEDS-A-LABEL",
+    "Need to Add",
+    "-COMMENTED-",
+    "WORK-IN-PROGRESS",
+    "FUTURE-WORK",
+    "PIECEWISE AND UNIT STEP STUFF",
+    "WebWorK Here For Mathquill",
+]
+
+
+def parse_ptx(path: Path):
+    """Parse a .ptx file, tolerating an undeclared xi: prefix.
+
+    Individual section files may use <xi:include> without declaring the
+    namespace (the declaration lives on the including document), so wrap
+    the content in a root that declares it before parsing.
+    """
+    text = path.read_text(encoding="utf-8")
+    body = XML_DECL.sub("", text, count=1)
+    wrapped = (
+        '<ptx-validate-wrapper xmlns:xi="http://www.w3.org/2001/XInclude">'
+        + body
+        + "</ptx-validate-wrapper>"
+    )
+    return ET.fromstring(wrapped)
+
+
+def build_set(main: Path):
+    """Files reachable from main.ptx via xi:include (XML includes only)."""
+    seen = []
+    queue = [main]
+    visited = set()
+    while queue:
+        f = queue.pop()
+        if f in visited or not f.exists():
+            continue
+        visited.add(f)
+        seen.append(f)
+        if f.suffix != ".ptx":
+            continue
+        text = f.read_text(encoding="utf-8")
+        # strip XML comments so commented-out includes are not followed
+        text = re.sub(r"<!--.*?-->", "", text, flags=re.S)
+        for href, rest in XI_INCLUDE.findall(text):
+            if 'parse="text"' in rest:
+                continue
+            queue.append((f.parent / href).resolve())
+    return seen
+
+
+def main() -> int:
+    failures = []
+
+    # 1. well-formedness, all .ptx under source/
+    all_ptx = sorted(SOURCE.rglob("*.ptx"))
+    trees = {}
+    for f in all_ptx:
+        try:
+            trees[f] = parse_ptx(f)
+        except ET.ParseError as exc:
+            failures.append(f"not well-formed: {f.relative_to(REPO)}: {exc}")
+    print(f"well-formedness: {len(all_ptx) - sum(1 for m in failures)}"
+          f"/{len(all_ptx)} files parse")
+
+    included = [f for f in build_set(MAIN) if f.suffix == ".ptx"]
+    print(f"build set: {len(included)} files reachable from main.ptx")
+
+    # 2. duplicate xml:id / label within the build set
+    where = defaultdict(list)
+    for f in included:
+        tree = trees.get(f)
+        if tree is None:
+            continue
+        for el in tree.iter():
+            # xml:id and label on the same element with the same value is
+            # one definition, not a collision (label mirrors xml:id)
+            vals = {el.get(attr) for attr in (XML_ID, "label")} - {None}
+            for val in vals:
+                where[val].append(f)
+    dups = {k: v for k, v in where.items() if len(v) > 1}
+    for ident, files in sorted(dups.items()):
+        locs = ", ".join(sorted({str(f.relative_to(REPO)) for f in files}))
+        failures.append(f"duplicate id '{ident}' defined {len(files)}x in: {locs}")
+    print(f"unique ids: {len(where) - len(dups)} unique, {len(dups)} duplicated")
+
+    # 3. placeholder ratchet
+    baseline = {}
+    if BASELINE_FILE.exists():
+        baseline = json.loads(BASELINE_FILE.read_text())
+    current = {}
+    for f in included:
+        text = f.read_text(encoding="utf-8")
+        count = sum(text.count(tok) for tok in PLACEHOLDER_TOKENS)
+        if count:
+            current[str(f.relative_to(REPO))] = count
+    for path, count in sorted(current.items()):
+        allowed = baseline.get(path, 0)
+        if count > allowed:
+            failures.append(
+                f"placeholder markers increased in {path}: {count} > baseline {allowed}"
+            )
+    shrunk = {p: c for p, c in baseline.items() if current.get(p, 0) < c}
+    if shrunk:
+        print("note: placeholder counts dropped below baseline in "
+              f"{len(shrunk)} file(s) - tighten placeholder-baseline.json:")
+        for p in sorted(shrunk):
+            print(f"  {p}: baseline {baseline[p]} -> now {current.get(p, 0)}")
+    print(f"placeholders: {sum(current.values())} markers in {len(current)} files "
+          f"(baseline total {sum(baseline.values())})")
+
+    print()
+    if failures:
+        for msg in failures:
+            print(f"FAIL {msg}")
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/processing-tools/validate-source/validate_source.py
+++ b/processing-tools/validate-source/validate_source.py
@@ -73,15 +73,23 @@ def parse_ptx(path: Path):
 
 
 def build_set(main: Path):
-    """Files reachable from main.ptx via xi:include (XML includes only)."""
+    """Files reachable from main.ptx via xi:include (XML includes only).
+
+    Returns (files, missing): missing holds include targets that do not
+    exist on disk, which the caller must treat as failures.
+    """
     seen = []
+    missing = []
     queue = [main]
     visited = set()
     while queue:
         f = queue.pop()
-        if f in visited or not f.exists():
+        if f in visited:
             continue
         visited.add(f)
+        if not f.exists():
+            missing.append(f)
+            continue
         seen.append(f)
         if f.suffix != ".ptx":
             continue
@@ -92,7 +100,7 @@ def build_set(main: Path):
             if 'parse="text"' in rest:
                 continue
             queue.append((f.parent / href).resolve())
-    return seen
+    return seen, missing
 
 
 def main() -> int:
@@ -104,13 +112,17 @@ def main() -> int:
     for f in all_ptx:
         try:
             trees[f] = parse_ptx(f)
-        except ET.ParseError as exc:
+        except (ET.ParseError, UnicodeDecodeError, ValueError) as exc:
             failures.append(f"not well-formed: {f.relative_to(REPO)}: {exc}")
     print(f"well-formedness: {len(all_ptx) - sum(1 for m in failures)}"
           f"/{len(all_ptx)} files parse")
 
-    included = [f for f in build_set(MAIN) if f.suffix == ".ptx"]
-    print(f"build set: {len(included)} files reachable from main.ptx")
+    reachable, missing = build_set(MAIN)
+    included = [f for f in reachable if f.suffix == ".ptx"]
+    for f in missing:
+        failures.append(f"missing xi:include target: {f.relative_to(REPO)}")
+    print(f"build set: {len(included)} files reachable from main.ptx, "
+          f"{len(missing)} missing include target(s)")
 
     # 2. duplicate xml:id / label within the build set
     where = defaultdict(list)
@@ -133,7 +145,11 @@ def main() -> int:
     # 3. placeholder ratchet
     baseline = {}
     if BASELINE_FILE.exists():
-        baseline = json.loads(BASELINE_FILE.read_text())
+        try:
+            baseline = json.loads(BASELINE_FILE.read_text())
+        except json.JSONDecodeError as exc:
+            failures.append(f"malformed baseline {BASELINE_FILE.name}: {exc}")
+            baseline = {}
     current = {}
     for f in included:
         text = f.read_text(encoding="utf-8")

--- a/source/c12-ltp/sec-piecewise-transform-rules.ptx
+++ b/source/c12-ltp/sec-piecewise-transform-rules.ptx
@@ -178,7 +178,7 @@
 			The next rule provides a formula for the product of a step function and a function of <m>t</m> and will be the primary tool used when forward transforming a piecewise function. 
 		</p>
 
-		<assemblage xml:id="laplace-ft-uc">
+		<assemblage xml:id="laplace-ft-uc-rule">
 			<title>📜 Laplace Transform of <m>f(t) u_c(t)</m></title>
 			<p>
 				<md>
@@ -386,7 +386,7 @@
 			Finally, we cover the last rule that will be particularly useful for inverting expressions in the Laplace domain (i.e., <xref ref="lt-step-3" text="custom">step 3</xref>) that are associated with step functions.
 		</p>
 
-		<assemblage xml:id="laplace-ftc-uc">
+		<assemblage xml:id="laplace-ftc-uc-rule">
 			<title>📜 Laplace Transform of <m>f(t-c) u_c(t)</m></title>
 			<p>
 				<md>

--- a/source/c4-sov/sec-separable-form.ptx
+++ b/source/c4-sov/sec-separable-form.ptx
@@ -30,7 +30,7 @@
 			<statement>
 				<p>
 					A first-order differential equation is <term>separable</term> if it can be written in the following <term>separable form</term>
-					<men xml:id="separable-form">
+					<men xml:id="separable-form-eqn">
 						\dfrac{dy}{dx} = f(x) \cdot g(y)
 					</men>.
 				</p>

--- a/source/c5-if/sec-if-method.ptx
+++ b/source/c5-if/sec-if-method.ptx
@@ -68,7 +68,7 @@
 			This outlines the complete process of the <xref ref="gi-integrating-factor-method" text="custom">integrating factor method</xref>.
 		</p>
 
-		<exploration xml:id="if-method">
+		<exploration xml:id="if-method-exploration">
 			<title>Integrating Factor (IF) Method</title>
 			<p>
 				Given a <xref ref="gi-first-order-linear-differential-equation" text="custom">first-order linear equation</xref> in standard form:

--- a/source/c8-lhcc/sec-higher-order-lhcc-eqns.ptx
+++ b/source/c8-lhcc/sec-higher-order-lhcc-eqns.ptx
@@ -19,7 +19,7 @@
 		</p>
 	</introduction>
 
-	<subsection label="characteristic-equation">
+	<subsection label="characteristic-equation-higher-order">
 		<title>The Characteristic Equation</title>
 
 		<exercise label="chkpt-higher-order-lhcc-1">

--- a/source/c9-uc/sec-selecting-the-particular-soln.ptx
+++ b/source/c9-uc/sec-selecting-the-particular-soln.ptx
@@ -564,7 +564,7 @@
 			Now, <m>y_p</m> has no terms in common with <m>y_h</m>, ensuring that they are independent.
 		</p>
 
-		<assemblage xml:id="modifying-yp">
+		<assemblage xml:id="modifying-yp-rule">
 			<title>Modification Rule for the Particular Solution</title>
 
 			<p>

--- a/source/c9-uc/sec-uc-method.ptx
+++ b/source/c9-uc/sec-uc-method.ptx
@@ -148,7 +148,7 @@
 			Let's summarize the entire process of using the <xref ref="gi-method-of-undetermined-coefficients" text="custom">Method of Undetermined Coefficients</xref>. Your goal is to find the full general solution <m>y = y_h + y_p</m> by first solving the homogeneous equation and then selecting, modifying, and finding <m>y_p</m>.
 		</p>
 
-		<exploration xml:id="uc-method">
+		<exploration xml:id="uc-method-exploration">
 			<title>Undetermined Coefficients</title>
 			<p>
 				The general solution for the linear nonhomogeneous constant coefficient equation,


### PR DESCRIPTION
## Summary

Implements audit item **L1** from `reports/2026-07-textbook-audit.md`, filling the gap left by pausing the full build (#193): a **Validate Source** workflow that runs on every PR in seconds, with no PreTeXt/LaTeX dependency.

**What it checks** (`processing-tools/validate-source/validate_source.py`, stdlib-only, also runnable locally):
1. **XML well-formedness** of every `source/**/*.ptx` (namespace-tolerant parsing, so section files using `xi:include` without the namespace declaration parse fine).
2. **Duplicate `xml:id`/`label`** across the `main.ptx` build set — resolved by walking the `xi:include` graph, so the stranded dev/parts variants can't cause false positives; ids inside XML comments are ignored, matching the builder.
3. **Placeholder ratchet** — counts of draft markers (`provisional=`, `NEEDS-A-LABEL`, "Need to Add", `-COMMENTED-`, …) per file, compared against `placeholder-baseline.json`. The current 34 markers are baselined; any *new* marker fails the check, and removals print a reminder to tighten the baseline, so the count only ever goes down (M1's cleanup will ratchet it toward zero).

The workflow then runs the existing SymPy worked-math verification (48/48).

**Bonus fixes**: the duplicate-id check immediately surfaced **seven live collisions** the audit's static grep missed. Six were real — a subsection/assemblage or section/equation pair sharing one id in chapters 4, 8, 9 (×2), and 12 (×2) — fixed by renaming the unreferenced twin (verified zero xrefs point at any renamed id; the two `uc-method` xrefs now resolve unambiguously to the section, parallel to the audit-flagged `if-method` fix also included here). The seventh was a single element carrying matching `xml:id` and `label`, which PreTeXt treats as one definition — the validator now does too.

Validator output on this branch: `136/136 files parse · 1572 unique ids, 0 duplicated · 34 placeholder markers (= baseline) · all checks passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_