### PR TITLE
H8 (part 2): Complete the answer/solution backfill in chapters 7 and 12

### DIFF
--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -386,6 +386,100 @@ REGISTRY += [
 ]
 
 
+# ----------------------------------------------------------------------
+# H8 part 2 — chapter 12 backfill (step transforms, inverses, IVPs)
+# ----------------------------------------------------------------------
+from sympy import Heaviside as _U
+
+_tp, _sp = symbols("tp sp", positive=True)
+
+
+def _lap_p(f_t, F_s):
+    """laplace_matches with positive-symbol assumptions (Heaviside-safe)."""
+    got = laplace_transform(f_t, _tp, _sp, noconds=True)
+    return is_zero(got - F_s)
+
+
+REGISTRY += [
+    Check(
+        "c12 window: L{u(t-1)-u(t-4)} = (e^-s - e^-4s)/s",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: _lap_p(_U(_tp - 1) - _U(_tp - 4), (exp(-_sp) - exp(-4 * _sp)) / _sp),
+    ),
+    Check(
+        "c12: L{(t-1)^2 u(t-3)} = e^-3s (2/s^3 + 4/s^2 + 4/s)",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: _lap_p((_tp - 1) ** 2 * _U(_tp - 3),
+                       exp(-3 * _sp) * (2 / _sp**3 + 4 / _sp**2 + 4 / _sp)),
+    ),
+    Check(
+        "c12: L{t e^3t u(t+pi/4)} = 1/(s-3)^2 (step already on)",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: _lap_p(_tp * exp(3 * _tp), 1 / (_sp - 3) ** 2),
+    ),
+    Check(
+        "c12 piecewise g: 2u1 - u2 + 2u3 takes values 0,2,1,3",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: [
+            (2 * _U(v - 1) - _U(v - 2) + 2 * _U(v - 3))
+            for v in (R(1, 2), R(3, 2), R(5, 2), 4)
+        ] == [0, 2, 1, 3],
+    ),
+    Check(
+        "c12 inverse: L{u2 e^(t-2)} = e^-2s/(s-1)",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: _lap_p(_U(_tp - 2) * exp(_tp - 2), exp(-2 * _sp) / (_sp - 1)),
+    ),
+    Check(
+        "c12 inverse: h(t) matches (e^-2s - 3e^-4s)/(s+2)",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: _lap_p(
+            _U(_tp - 2) * exp(-2 * (_tp - 2)) - 3 * _U(_tp - 4) * exp(-2 * (_tp - 4)),
+            (exp(-2 * _sp) - 3 * exp(-4 * _sp)) / (_sp + 2)),
+    ),
+    Check(
+        "c12 inverse: (1/3)u3 sin(3(t-3)) matches e^-3s/(s^2+9)",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: _lap_p(R(1, 3) * _U(_tp - 3) * sin(3 * (_tp - 3)),
+                       exp(-3 * _sp) / (_sp**2 + 9)),
+    ),
+    Check(
+        "c12 inverse: u1(-6e^-(t-1) + 7e^-2(t-1)) matches e^-s(s-5)/((s+1)(s+2))",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: _lap_p(
+            _U(_tp - 1) * (-6 * exp(-(_tp - 1)) + 7 * exp(-2 * (_tp - 1))),
+            exp(-_sp) * (_sp - 5) / ((_sp + 1) * (_sp + 2))),
+    ),
+    Check(
+        "c12 IVP: z(t) solves z''+3z'+2z=e^-3t U(t-2), z(0)=2, z'(0)=-3 (regionwise)",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: (
+            lambda zh, zp: is_zero(diff(zh, t, 2) + 3 * diff(zh, t) + 2 * zh)
+            and is_zero(diff(zh + zp, t, 2) + 3 * diff(zh + zp, t) + 2 * (zh + zp)
+                        - exp(-3 * t))
+            and zp.subs(t, 2) == 0 and simplify(diff(zp, t).subs(t, 2)) == 0
+            and zh.subs(t, 0) == 2 and diff(zh, t).subs(t, 0) == -3
+        )(
+            exp(-t) + exp(-2 * t),
+            exp(-6) * (R(1, 2) * exp(-(t - 2)) - exp(-2 * (t - 2))
+                       + R(1, 2) * exp(-3 * (t - 2))),
+        ),
+    ),
+    Check(
+        "c12 IVP: w(t) solves w''+w=U(t-2)-U(t-4), w(0)=1, w'(0)=0 (regionwise)",
+        "source/c12-ltp/exercises-ltp.ptx",
+        lambda: (
+            lambda w0, w2, w4: is_zero(diff(w0, t, 2) + w0)
+            and is_zero(diff(w0 + w2, t, 2) + (w0 + w2) - 1)
+            and is_zero(diff(w0 + w2 + w4, t, 2) + (w0 + w2 + w4))
+            and w2.subs(t, 2) == 0 and diff(w2, t).subs(t, 2) == 0
+            and w4.subs(t, 4) == 0 and diff(w4, t).subs(t, 4) == 0
+            and w0.subs(t, 0) == 1 and diff(w0, t).subs(t, 0) == 0
+        )(cos(t), 1 - cos(t - 2), -(1 - cos(t - 4))),
+    ),
+]
+
+
 def main() -> int:
     failures = 0
     for check in REGISTRY:

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -29,6 +29,7 @@ from typing import Callable
 from sympy import (
     E,
     FiniteSet,
+    Heaviside,
     I,
     Rational as R,
     cos,
@@ -389,8 +390,6 @@ REGISTRY += [
 # ----------------------------------------------------------------------
 # H8 part 2 — chapter 12 backfill (step transforms, inverses, IVPs)
 # ----------------------------------------------------------------------
-from sympy import Heaviside as _U
-
 _tp, _sp = symbols("tp sp", positive=True)
 
 
@@ -404,12 +403,12 @@ REGISTRY += [
     Check(
         "c12 window: L{u(t-1)-u(t-4)} = (e^-s - e^-4s)/s",
         "source/c12-ltp/exercises-ltp.ptx",
-        lambda: _lap_p(_U(_tp - 1) - _U(_tp - 4), (exp(-_sp) - exp(-4 * _sp)) / _sp),
+        lambda: _lap_p(Heaviside(_tp - 1) - Heaviside(_tp - 4), (exp(-_sp) - exp(-4 * _sp)) / _sp),
     ),
     Check(
         "c12: L{(t-1)^2 u(t-3)} = e^-3s (2/s^3 + 4/s^2 + 4/s)",
         "source/c12-ltp/exercises-ltp.ptx",
-        lambda: _lap_p((_tp - 1) ** 2 * _U(_tp - 3),
+        lambda: _lap_p((_tp - 1) ** 2 * Heaviside(_tp - 3),
                        exp(-3 * _sp) * (2 / _sp**3 + 4 / _sp**2 + 4 / _sp)),
     ),
     Check(
@@ -421,33 +420,33 @@ REGISTRY += [
         "c12 piecewise g: 2u1 - u2 + 2u3 takes values 0,2,1,3",
         "source/c12-ltp/exercises-ltp.ptx",
         lambda: [
-            (2 * _U(v - 1) - _U(v - 2) + 2 * _U(v - 3))
+            (2 * Heaviside(v - 1) - Heaviside(v - 2) + 2 * Heaviside(v - 3))
             for v in (R(1, 2), R(3, 2), R(5, 2), 4)
         ] == [0, 2, 1, 3],
     ),
     Check(
         "c12 inverse: L{u2 e^(t-2)} = e^-2s/(s-1)",
         "source/c12-ltp/exercises-ltp.ptx",
-        lambda: _lap_p(_U(_tp - 2) * exp(_tp - 2), exp(-2 * _sp) / (_sp - 1)),
+        lambda: _lap_p(Heaviside(_tp - 2) * exp(_tp - 2), exp(-2 * _sp) / (_sp - 1)),
     ),
     Check(
         "c12 inverse: h(t) matches (e^-2s - 3e^-4s)/(s+2)",
         "source/c12-ltp/exercises-ltp.ptx",
         lambda: _lap_p(
-            _U(_tp - 2) * exp(-2 * (_tp - 2)) - 3 * _U(_tp - 4) * exp(-2 * (_tp - 4)),
+            Heaviside(_tp - 2) * exp(-2 * (_tp - 2)) - 3 * Heaviside(_tp - 4) * exp(-2 * (_tp - 4)),
             (exp(-2 * _sp) - 3 * exp(-4 * _sp)) / (_sp + 2)),
     ),
     Check(
         "c12 inverse: (1/3)u3 sin(3(t-3)) matches e^-3s/(s^2+9)",
         "source/c12-ltp/exercises-ltp.ptx",
-        lambda: _lap_p(R(1, 3) * _U(_tp - 3) * sin(3 * (_tp - 3)),
+        lambda: _lap_p(R(1, 3) * Heaviside(_tp - 3) * sin(3 * (_tp - 3)),
                        exp(-3 * _sp) / (_sp**2 + 9)),
     ),
     Check(
         "c12 inverse: u1(-6e^-(t-1) + 7e^-2(t-1)) matches e^-s(s-5)/((s+1)(s+2))",
         "source/c12-ltp/exercises-ltp.ptx",
         lambda: _lap_p(
-            _U(_tp - 1) * (-6 * exp(-(_tp - 1)) + 7 * exp(-2 * (_tp - 1))),
+            Heaviside(_tp - 1) * (-6 * exp(-(_tp - 1)) + 7 * exp(-2 * (_tp - 1))),
             exp(-_sp) * (_sp - 5) / ((_sp + 1) * (_sp + 2))),
     ),
     Check(

--- a/source/c12-ltp/exercises-ltp.ptx
+++ b/source/c12-ltp/exercises-ltp.ptx
@@ -746,17 +746,38 @@
 
 			<exercise>
 				<statement><p><m>w(t) = u(t-1) - u(t-4)</m></p></statement>
-				<answer></answer>
+				<answer>
+					<p>
+						The graph is a window: it jumps from <m>0</m> up to <m>1</m> at <m>t = 1</m> and back down to <m>0</m> at <m>t = 4</m>. Transforming each step separately:
+						<me>
+							\lap{u(t-1) - u(t-4)} = \frac{e^{-s}}{s} - \frac{e^{-4s}}{s}
+						</me>
+					</p>
+				</answer>
 			</exercise>
-		
+
 			<exercise>
 				<statement><p><m>y(t) = (t-1)^2u(t-3)</m></p></statement>
-				<answer></answer>
+				<answer>
+					<p>
+						The graph is <m>0</m> until <m>t = 3</m>, where the parabola <m>(t-1)^2</m> switches on (starting at height <m>4</m>). Since the function multiplying <m>u(t-3)</m> is not shifted by <m>3</m>, we use <m>\lap{f(t)\,u_c(t)} = e^{-cs}\lap{f(t+c)}</m> with <m>f(t+3) = (t+2)^2 = t^2 + 4t + 4</m>:
+						<me>
+							\lap{(t-1)^2 u(t-3)} = e^{-3s}\left(\frac{2}{s^3} + \frac{4}{s^2} + \frac{4}{s}\right)
+						</me>
+					</p>
+				</answer>
 			</exercise>
-		
+
 			<exercise>
 				<statement><p><m>x(t) = te^{3t}u(t+\pi/4)</m></p></statement>
-				<answer></answer>
+				<answer>
+					<p>
+						Careful: <m>u(t+\pi/4)</m> activates at <m>t = -\pi/4</m>, which is <em>before</em> <m>t = 0</m>. Since the Laplace transform only sees <m>t \ge 0</m>, the step is always on and the graph is simply <m>te^{3t}</m>:
+						<me>
+							\lap{te^{3t}u(t+\pi/4)} = \lap{te^{3t}} = \frac{1}{(s-3)^2}
+						</me>
+					</p>
+				</answer>
 			</exercise>
 
 			<exercise>
@@ -1053,8 +1074,8 @@
 			<exercise>
 				<statement>
 					<m>
-						\ds g(t) = 
-						\left\{ 
+						\ds g(t) =
+						\left\{
 							\begin{array}{ll}
 								0,	\amp t \le 1\\
 								2,	\amp 1 \le t \le 2\\
@@ -1064,6 +1085,19 @@
 						\right.
 					</m>
 				</statement>
+				<solution>
+					<p>
+						Build the function window by window: the value <m>2</m> is active on <m>[1,2)</m>, the value <m>1</m> on <m>[2,3)</m>, and the value <m>3</m> from <m>t = 3</m> on:
+						<md>
+							<mrow> g(t) \amp = 2\big(u_1(t) - u_2(t)\big) + 1\big(u_2(t) - u_3(t)\big) + 3u_3(t) </mrow>
+							<mrow> \amp = 2u_1(t) - u_2(t) + 2u_3(t) </mrow>
+						</md>
+						Check: for <m>1 \lt t \lt 2</m> this gives <m>2</m>; for <m>2 \lt t \lt 3</m> it gives <m>2 - 1 = 1</m>; for <m>t \gt 3</m> it gives <m>2 - 1 + 2 = 3</m>. ✓
+					</p>
+				</solution>
+				<answer>
+					<p><m>g(t) = 2u_1(t) - u_2(t) + 2u_3(t)</m></p>
+				</answer>
 			</exercise>
 		</exercisegroup>
 
@@ -1124,30 +1158,62 @@
 
 			<exercise>
 				<statement><p><m>Y(s) = \dfrac{e^{-2s}}{s-1}</m></p></statement>
-				<answer>
-					<p><m>Y(s) = \dfrac{e^{-2s}}{s-1} </m></p>
-				</answer>
+				<solution>
+					<p>
+						This is <m>e^{-2s}F(s)</m> with <m>c = 2</m> and <m>F(s) = \dfrac{1}{s-1}</m>, whose inverse is <m>f(t) = e^{t}</m>. Applying the shift rule:
+						<me>
+							y(t) = u_2(t)\, e^{t-2}
+						</me>
+					</p>
+				</solution>
+				<answer><p><m>y(t) = u_2(t)\, e^{t-2}</m></p></answer>
 			</exercise>
-		
+
 			<exercise>
 				<statement><p><m>H(s) = \dfrac{e^{-2s} - 3e^{-4s}}{s+2}</m></p></statement>
-				<answer>
-					<p><m>H(s) = \dfrac{e^{-2s} - 3e^{-4s}}{s+2}</m></p>
-				</answer>
+				<solution>
+					<p>
+						Split into two shifted terms sharing <m>F(s) = \dfrac{1}{s+2}</m>, whose inverse is <m>f(t) = e^{-2t}</m>:
+						<me>
+							H(s) = e^{-2s}\cdot\frac{1}{s+2} - 3e^{-4s}\cdot\frac{1}{s+2}
+						</me>
+						Applying the shift rule to each term (<m>c = 2</m> and <m>c = 4</m>):
+						<me>
+							h(t) = u_2(t)\, e^{-2(t-2)} - 3u_4(t)\, e^{-2(t-4)}
+						</me>
+					</p>
+				</solution>
+				<answer><p><m>h(t) = u_2(t)\, e^{-2(t-2)} - 3u_4(t)\, e^{-2(t-4)}</m></p></answer>
 			</exercise>
-		
+
 			<exercise>
 				<statement><p><m>M(s) = \dfrac{e^{-3s}}{s^2+9}</m></p></statement>
-				<answer>
-					<p><m>M(s) = \dfrac{e^{-3s}}{s^2+9}</m></p>
-				</answer>
+				<solution>
+					<p>
+						This is <m>e^{-3s}F(s)</m> with <m>F(s) = \dfrac{1}{s^2+9}</m>. To match the sine form we need <m>b = 3</m> in the numerator, so write <m>F(s) = \dfrac13\cdot\dfrac{3}{s^2+9}</m>, giving <m>f(t) = \dfrac13\sin(3t)</m>. Applying the shift rule:
+						<me>
+							m(t) = \frac13\, u_3(t)\, \sin\big(3(t-3)\big)
+						</me>
+					</p>
+				</solution>
+				<answer><p><m>m(t) = \dfrac13\, u_3(t)\, \sin\big(3(t-3)\big)</m></p></answer>
 			</exercise>
-		
+
 			<exercise>
 				<statement><p><m>X(s) = \dfrac{e^{-s}(s-5)}{(s+1)(s+2)}</m></p></statement>
-				<answer>
-					<p><m>X(s) = \dfrac{e^{-s}(s-5)}{(s+1)(s+2)}</m></p>
-				</answer>
+				<solution>
+					<p>
+						This is <m>e^{-s}F(s)</m> with <m>F(s) = \dfrac{s-5}{(s+1)(s+2)}</m>, which needs a partial fraction decomposition first:
+						<me>
+							\frac{s-5}{(s+1)(s+2)} = \frac{A}{s+1} + \frac{B}{s+2}
+						</me>
+						Multiplying through by <m>(s+1)(s+2)</m> gives <m>s - 5 = A(s+2) + B(s+1)</m>. Setting <m>s = -1</m> gives <m>A = -6</m>; setting <m>s = -2</m> gives <m>B = 7</m>. So <m>f(t) = -6e^{-t} + 7e^{-2t}</m>, and the shift rule gives:
+						<me>
+							x(t) = u_1(t)\left(-6e^{-(t-1)} + 7e^{-2(t-1)}\right)
+						</me>
+					</p>
+				</solution>
+				<answer><p><m>x(t) = u_1(t)\left(-6e^{-(t-1)} + 7e^{-2(t-1)}\right)</m></p></answer>
 			</exercise>
 		</exercisegroup>
 
@@ -1301,10 +1367,76 @@
 
 			<exercise>
 				<statement><p><m>z'' + 3z' + 2z = e^{-3t}U(t-2),\ \ z(0) = 2,\ \ z'(0) = -3</m></p></statement>
+				<solution>
+					<p>
+						<term>Step 1: Apply the Laplace Transform.</term> The forcing term is not yet in shifted form, so first rewrite it using <m>\lap{f(t)\,u_c(t)} = e^{-cs}\lap{f(t+c)}</m> with <m>f(t+2) = e^{-3(t+2)} = e^{-6}e^{-3t}</m>:
+						<me>
+							\lap{e^{-3t}U(t-2)} = e^{-6}\,\frac{e^{-2s}}{s+3}
+						</me>
+						Transforming the equation and inserting the initial conditions:
+						<md>
+							<mrow> \big[s^2Z - 2s + 3\big] + 3\big[sZ - 2\big] + 2Z \amp = e^{-6}\,\frac{e^{-2s}}{s+3} </mrow>
+							<mrow> (s^2 + 3s + 2)Z \amp = 2s + 3 + e^{-6}\,\frac{e^{-2s}}{s+3} </mrow>
+						</md>
+					</p>
+					<p>
+						<term>Step 2: Solve for <m>Z(s)</m>.</term>
+						<me>
+							Z(s) = \frac{2s+3}{(s+1)(s+2)} + e^{-6}\,\frac{e^{-2s}}{(s+1)(s+2)(s+3)}
+						</me>
+					</p>
+					<p>
+						<term>Step 3: Prepare for the Inverse.</term> Partial fractions give
+						<me>
+							\frac{2s+3}{(s+1)(s+2)} = \frac{1}{s+1} + \frac{1}{s+2}, \qquad
+							F(s) = \frac{1}{(s+1)(s+2)(s+3)} = \frac{\sfrac12}{s+1} - \frac{1}{s+2} + \frac{\sfrac12}{s+3}
+						</me>
+						so <m>f(t) = \ilap{F(s)} = \frac12 e^{-t} - e^{-2t} + \frac12 e^{-3t}</m>.
+					</p>
+					<p>
+						<term>Step 4: Take the Inverse Transform.</term> The first part inverts directly and the shifted part uses the delay rule:
+						<me>
+							z(t) = e^{-t} + e^{-2t} + e^{-6}\, U(t-2)\left(\tfrac12 e^{-(t-2)} - e^{-2(t-2)} + \tfrac12 e^{-3(t-2)}\right)
+						</me>
+					</p>
+				</solution>
+				<answer>
+					<p><m>z(t) = e^{-t} + e^{-2t} + e^{-6}\, U(t-2)\left(\frac12 e^{-(t-2)} - e^{-2(t-2)} + \frac12 e^{-3(t-2)}\right)</m></p>
+				</answer>
 			</exercise>
-		
+
 			<exercise>
 				<statement><p><m>w'' + w = U(t-2) - U(t-4),\ \ w(0) = 1,\ \ w'(0) = 0</m></p></statement>
+				<solution>
+					<p>
+						<term>Step 1: Apply the Laplace Transform.</term> Using the initial conditions:
+						<md>
+							<mrow> \big[s^2W - s\big] + W \amp = \frac{e^{-2s}}{s} - \frac{e^{-4s}}{s} </mrow>
+						</md>
+					</p>
+					<p>
+						<term>Step 2: Solve for <m>W(s)</m>.</term>
+						<me>
+							W(s) = \frac{s}{s^2+1} + \frac{e^{-2s} - e^{-4s}}{s(s^2+1)}
+						</me>
+					</p>
+					<p>
+						<term>Step 3: Prepare for the Inverse.</term> Partial fractions give
+						<me>
+							F(s) = \frac{1}{s(s^2+1)} = \frac{1}{s} - \frac{s}{s^2+1}
+						</me>
+						so <m>f(t) = \ilap{F(s)} = 1 - \cos(t)</m>.
+					</p>
+					<p>
+						<term>Step 4: Take the Inverse Transform.</term> The first term gives <m>\cos(t)</m>, and the two shifted terms use the delay rule with <m>c = 2</m> and <m>c = 4</m>:
+						<me>
+							w(t) = \cos(t) + U(t-2)\big(1 - \cos(t-2)\big) - U(t-4)\big(1 - \cos(t-4)\big)
+						</me>
+					</p>
+				</solution>
+				<answer>
+					<p><m>w(t) = \cos(t) + U(t-2)\big(1 - \cos(t-2)\big) - U(t-4)\big(1 - \cos(t-4)\big)</m></p>
+				</answer>
 			</exercise>
 
 			<exercise>

--- a/source/c7-em/exercises-em.ptx
+++ b/source/c7-em/exercises-em.ptx
@@ -232,6 +232,11 @@
 					</li>
 					<li>
 						What is the meaning of your answer in part (a)?
+						<solution>
+							<p>
+								The values <m>y_1 = 3.8</m> and <m>y_2 = 2.98</m> are <em>approximations</em> of the true solution's values at <m>x = 1.1</m> and <m>x = 1.2</m>. Starting from the known point <m>(1, 5)</m>, Euler's method followed the slope given by the differential equation for two short straight-line steps — so <m>y(1.1) \approx 3.8</m> and <m>y(1.2) \approx 2.98</m>, with some error since the true solution curves between steps.
+							</p>
+						</solution>
 					</li>
 					<li>
 						Compute 2 iterations of Euler's method using step size <m> \ds h = 0.05</m>.
@@ -267,6 +272,11 @@
 					</li>
 					<li>
 						What is the meaning of your answer in part (c)?
+						<solution>
+							<p>
+								With the smaller step <m>h = 0.05</m>, the values <m>y_1 = 4.4</m> and <m>y_2 = 3.895</m> approximate the solution at <m>x = 1.05</m> and <m>x = 1.1</m>. Notice that parts (a) and (c) both produce an estimate of <m>y(1.1)</m> — <m>3.8</m> versus <m>3.895</m> — and the <m>h = 0.05</m> estimate is the more trustworthy of the two because each straight-line step deviates less from the curved solution.
+							</p>
+						</solution>
 					</li>
 					<li>
 						Find the analytic solution to the IVP. Use your solution to compare the exact value of <m>y(1.1)</m> with your answers from parts (a) and (c).
@@ -398,6 +408,12 @@
 					</li>
 					<li>
 						Which of the approximations above do you trust more?
+						<solution>
+							<p>
+								The <m>h = 0.25</m> approximation. Smaller steps let Euler's method correct its direction more often, so the straight-line segments hug the curved solution more closely and less error accumulates. (Part (d) confirms it: the exact value is <m>\sqrt{e} \approx 1.6487</m>, and <m>1.5625</m> is closer to it than <m>1.5</m>.)
+							</p>
+						</solution>
+						<answer><p>The <m>h = 0.25</m> approximation — smaller steps accumulate less error.</p></answer>
 					</li>
 					<li>
 						Find the analytic solution to the IVP. Use it to compute the exact value of <m>y(0.5)</m> and compare with your answers from parts (a) and (b).
@@ -526,6 +542,11 @@
 					</ol>
 				</p>
 			</solution>
+			<answer>
+				<p>
+					(a) Smaller steps keep the straight-line segments closer to the curved solution, so less error accumulates. (b) Errors compound step by step; use a smaller <m>h</m> or a more accurate method. (c) Only when the true solution is a straight line (e.g. <m>y' = c</m>) — otherwise every step introduces some error.
+				</p>
+			</answer>
 		</exercise>
 
 	</exercises>


### PR DESCRIPTION
## Summary

Completes audit item **H8** from `reports/2026-07-textbook-audit.md` (part 1 was #192).

**Chapter 12** — the static tiers previously had ~33% solution coverage; every remaining gap is now filled:
- Three **empty answers** in "Sketch &amp; Transform": the `u(t−1)−u(t−4)` window; `(t−1)²u(t−3)` via the unshifted-function rule `L{f(t)u_c(t)} = e^{−cs}L{f(t+c)}`; and `te^{3t}u(t+π/4)` — a nice teaching case, since the step activates *before* t = 0 and is therefore always on in the Laplace domain.
- The **piecewise → step-form** exercise solved: `g(t) = 2u₁ − u₂ + 2u₃`, with a value-by-value check.
- Four inverse-transform "**answers**" that merely **repeated their statements** (the same placeholder pattern as the partial-fractions appendix) replaced with worked solutions in the style of their two solved siblings, including the partial-fractions case (`A = −6, B = 7`).
- Both unsupported **IVPs** given complete four-step Laplace solutions: `z″+3z′+2z = e^{−3t}U(t−2)` (including the `e^{−6}` factor from rewriting the unshifted forcing term) and `w″+w = U(t−2)−U(t−4)`.

**Chapter 7** — the conceptual sub-parts: interpretation answers for em-problem-03 (b)/(d) (including the h = 0.1 vs h = 0.05 comparison of the two `y(1.1)` estimates), the "which do you trust more?" part of em-problem-04 tied to its exact value `√e`, and a compact answer for em-problem-06.

**Chapter 6** was checked and needs nothing — every static exercise already carries both solution and answer (the audit note was stale).

## Verification

Every quantitative result verified with SymPy — the IVP solutions region-by-region (zero residual on each interval, solution and derivative continuous at every activation time) and each transform pair symbolically. Ten regression checks added to `verify-worked-math` — **58/58 pass**. Both touched `.ptx` files pass `xmllint`; the new L1 validator (#195) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_