### PR TITLE
H5: Finish the chapter 13 eigenvalue story

### DIFF
--- a/processing-tools/validate-source/placeholder-baseline.json
+++ b/processing-tools/validate-source/placeholder-baseline.json
@@ -8,7 +8,6 @@
  "source/aa-bookends/back-matter.ptx": 4,
  "source/c12-ltp/sec-unit-step-variants.ptx": 3,
  "source/c13-linsys/sec-qualitative-methods-systems.ptx": 2,
- "source/c13-linsys/sec-solving-linear-systems.ptx": 2,
  "source/c14-nlinsys/sec-nonlinear-systems.ptx": 3,
  "source/c5-if/sec-finding-the-integrating-factor.ptx": 3,
  "source/c6-qm/sec-logistical-models.ptx": 1,

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -28,6 +28,7 @@ from typing import Callable
 
 from sympy import (
     E,
+    Matrix,
     FiniteSet,
     Heaviside,
     I,
@@ -475,6 +476,48 @@ REGISTRY += [
             and w4.subs(t, 4) == 0 and diff(w4, t).subs(t, 4) == 0
             and w0.subs(t, 0) == 1 and diff(w0, t).subs(t, 0) == 0
         )(cos(t), 1 - cos(t - 2), -(1 - cos(t - 4))),
+    ),
+]
+
+
+# ----------------------------------------------------------------------
+# H5 — chapter 13 eigenvalue exercise group
+# ----------------------------------------------------------------------
+REGISTRY += [
+    Check(
+        "c13 eig drill: A=[[4,2],[1,3]] has eigenpairs (2,(1,-1)) and (5,(2,1))",
+        "source/c13-linsys/exercises-linsys.ptx",
+        lambda: (
+            lambda A: A * Matrix([1, -1]) == 2 * Matrix([1, -1])
+            and A * Matrix([2, 1]) == 5 * Matrix([2, 1])
+        )(Matrix([[4, 2], [1, 3]])),
+    ),
+    Check(
+        "c13 eig: general solution of x'=x+2y, y'=3x satisfies the system",
+        "source/c13-linsys/exercises-linsys.ptx",
+        lambda: (
+            lambda X, Y: is_zero(diff(X, t) - (X + 2 * Y))
+            and is_zero(diff(Y, t) - 3 * X)
+        )(C1 * exp(3 * t) + 2 * C2 * exp(-2 * t),
+          C1 * exp(3 * t) - 3 * C2 * exp(-2 * t)),
+    ),
+    Check(
+        "c13 eig IVP: x=2e^3t+e^-t, y=4e^3t-2e^-t solves x'=x+y, y'=4x+y with (3,2)",
+        "source/c13-linsys/exercises-linsys.ptx",
+        lambda: (
+            lambda X, Y: is_zero(diff(X, t) - (X + Y))
+            and is_zero(diff(Y, t) - (4 * X + Y))
+            and X.subs(t, 0) == 3 and Y.subs(t, 0) == 2
+        )(2 * exp(3 * t) + exp(-t), 4 * exp(3 * t) - 2 * exp(-t)),
+    ),
+    Check(
+        "c13 eig complex: spiral-sink general solution satisfies x'=-x-2y, y'=2x-y",
+        "source/c13-linsys/exercises-linsys.ptx",
+        lambda: (
+            lambda X, Y: is_zero(diff(X, t) - (-X - 2 * Y))
+            and is_zero(diff(Y, t) - (2 * X - Y))
+        )(exp(-t) * (C1 * cos(2 * t) + C2 * sin(2 * t)),
+          exp(-t) * (C1 * sin(2 * t) - C2 * cos(2 * t))),
     ),
 ]
 

--- a/source/c13-linsys/exercises-linsys.ptx
+++ b/source/c13-linsys/exercises-linsys.ptx
@@ -224,12 +224,184 @@
 
 	<exercises label="linsys-problems-main">
 		<title><e component="emoji">✍🏻</e> Problems </title>
-		
+
+		<exercisegroup>
+			<title>The Eigenvalue Method</title>
+
+			<introduction>
+				<p>
+					Practice the eigenvalue method from <xref ref="solving-linear-systems" text="title"/>: find eigenvalues and eigenvectors, build general solutions, and classify the phase portrait using <xref ref="eigenvalues-and-phase-portraits" text="title"/>.
+				</p>
+			</introduction>
+
+			<exercise>
+				<statement>
+					<p>
+						Find the eigenvalues and eigenvectors of
+						<m>A = \begin{bmatrix} 4 \amp 2 \\ 1 \amp 3 \end{bmatrix}</m>.
+					</p>
+				</statement>
+				<solution>
+					<p>
+						Solve <m>\det(A - rI) = 0</m>:
+						<me>
+							\det\begin{bmatrix} 4-r \amp 2 \\ 1 \amp 3-r \end{bmatrix} = (4-r)(3-r) - 2 = r^2 - 7r + 10 = (r-2)(r-5)
+						</me>
+						so <m>r_1 = 2</m> and <m>r_2 = 5</m>.
+					</p>
+					<p>
+						For <m>r_1 = 2</m>: <m>(A - 2I)\vec{v} = 0</m> gives <m>2v_1 + 2v_2 = 0</m>, so <m>v_2 = -v_1</m> and <m>\vec{v}_1 = \begin{bmatrix} 1 \\ -1 \end{bmatrix}</m>.
+					</p>
+					<p>
+						For <m>r_2 = 5</m>: <m>(A - 5I)\vec{v} = 0</m> gives <m>-v_1 + 2v_2 = 0</m>, so <m>v_1 = 2v_2</m> and <m>\vec{v}_2 = \begin{bmatrix} 2 \\ 1 \end{bmatrix}</m>.
+					</p>
+				</solution>
+				<answer>
+					<p>
+						<m>r_1 = 2</m> with <m>\vec{v}_1 = \begin{bmatrix} 1 \\ -1 \end{bmatrix}</m>; <m>r_2 = 5</m> with <m>\vec{v}_2 = \begin{bmatrix} 2 \\ 1 \end{bmatrix}</m>
+					</p>
+				</answer>
+			</exercise>
+
+			<exercise>
+				<statement>
+					<p>
+						Find the general solution of the system and classify its phase portrait:
+						<md>
+							<mrow> \frac{dx}{dt} \amp = x + 2y </mrow>
+							<mrow> \frac{dy}{dt} \amp = 3x </mrow>
+						</md>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						With <m>A = \begin{bmatrix} 1 \amp 2 \\ 3 \amp 0 \end{bmatrix}</m>, the characteristic equation is
+						<me>
+							(1-r)(-r) - 6 = r^2 - r - 6 = (r-3)(r+2) = 0
+						</me>
+						so <m>r_1 = 3</m> and <m>r_2 = -2</m>.
+					</p>
+					<p>
+						For <m>r_1 = 3</m>: <m>(A - 3I)\vec{v} = 0</m> gives <m>-2v_1 + 2v_2 = 0</m>, so <m>\vec{v}_1 = \begin{bmatrix} 1 \\ 1 \end{bmatrix}</m>.
+						For <m>r_2 = -2</m>: <m>(A + 2I)\vec{v} = 0</m> gives <m>3v_1 + 2v_2 = 0</m>, so <m>\vec{v}_2 = \begin{bmatrix} 2 \\ -3 \end{bmatrix}</m>.
+					</p>
+					<p>
+						The general solution is
+						<me>
+							\vec{X}(t) = C_1 \begin{bmatrix} 1 \\ 1 \end{bmatrix} e^{3t} + C_2 \begin{bmatrix} 2 \\ -3 \end{bmatrix} e^{-2t}.
+						</me>
+						The eigenvalues are real with opposite signs, so the phase portrait is a <em>saddle</em>.
+					</p>
+				</solution>
+				<answer>
+					<p>
+						<m>\vec{X}(t) = C_1 \begin{bmatrix} 1 \\ 1 \end{bmatrix} e^{3t} + C_2 \begin{bmatrix} 2 \\ -3 \end{bmatrix} e^{-2t}</m>; saddle
+					</p>
+				</answer>
+			</exercise>
+
+			<exercise>
+				<statement>
+					<p>
+						Solve the initial value problem
+						<md>
+							<mrow> \frac{dx}{dt} \amp = x + y, \amp x(0) \amp = 3, </mrow>
+							<mrow> \frac{dy}{dt} \amp = 4x + y, \amp y(0) \amp = 2. </mrow>
+						</md>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						This is the system solved in <xref ref="ex-worked-linear-system" text="type-global"/>, whose general solution is
+						<me>
+							x(t) = C_1 e^{3t} + C_2 e^{-t}, \qquad y(t) = 2C_1 e^{3t} - 2C_2 e^{-t}.
+						</me>
+						Applying the initial conditions:
+						<md>
+							<mrow> C_1 + C_2 \amp = 3 </mrow>
+							<mrow> 2C_1 - 2C_2 \amp = 2 </mrow>
+						</md>
+						The second equation gives <m>C_1 - C_2 = 1</m>; adding this to the first gives <m>2C_1 = 4</m>, so <m>C_1 = 2</m> and <m>C_2 = 1</m>. Hence
+						<me>
+							x(t) = 2e^{3t} + e^{-t}, \qquad y(t) = 4e^{3t} - 2e^{-t}.
+						</me>
+					</p>
+				</solution>
+				<answer>
+					<p><m>x(t) = 2e^{3t} + e^{-t},\quad y(t) = 4e^{3t} - 2e^{-t}</m></p>
+				</answer>
+			</exercise>
+
+			<exercise>
+				<statement>
+					<p>
+						Find the general solution of the system and classify its phase portrait:
+						<md>
+							<mrow> \frac{dx}{dt} \amp = -x - 2y </mrow>
+							<mrow> \frac{dy}{dt} \amp = 2x - y </mrow>
+						</md>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						With <m>A = \begin{bmatrix} -1 \amp -2 \\ 2 \amp -1 \end{bmatrix}</m>, the characteristic equation is
+						<me>
+							(-1-r)^2 + 4 = 0 \quad\Rightarrow\quad r = -1 \pm 2i.
+						</me>
+					</p>
+					<p>
+						For <m>r = -1 + 2i</m>, <m>(A - rI)\vec{v} = 0</m> gives <m>-2i\,v_1 - 2v_2 = 0</m>, so <m>v_2 = -i\,v_1</m> and <m>\vec{v} = \begin{bmatrix} 1 \\ -i \end{bmatrix}</m>. Taking real and imaginary parts of <m>\vec{v}e^{(-1+2i)t}</m> gives the real general solution:
+						<md>
+							<mrow> x(t) \amp = e^{-t}\left( C_1 \cos(2t) + C_2 \sin(2t) \right) </mrow>
+							<mrow> y(t) \amp = e^{-t}\left( C_1 \sin(2t) - C_2 \cos(2t) \right) </mrow>
+						</md>
+					</p>
+					<p>
+						The eigenvalues are complex with negative real part, so the phase portrait is a <em>spiral sink</em>: trajectories loop inward as the factor <m>e^{-t}</m> decays.
+					</p>
+				</solution>
+				<answer>
+					<p>
+						<m>x(t) = e^{-t}(C_1\cos 2t + C_2\sin 2t),\quad y(t) = e^{-t}(C_1\sin 2t - C_2\cos 2t)</m>; spiral sink
+					</p>
+				</answer>
+			</exercise>
+
+			<exercise>
+				<statement>
+					<p>
+						Without solving, classify the phase portrait of a linear system whose coefficient matrix has the given eigenvalues:
+						<ol marker="(a)">
+							<li><m>r = -3,\ -1</m></li>
+							<li><m>r = -2,\ 5</m></li>
+							<li><m>r = \pm 3i</m></li>
+							<li><m>r = 1 \pm 2i</m></li>
+						</ol>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						Using the classification table in <xref ref="eigenvalues-and-phase-portraits" text="title"/>:
+						<ol marker="(a)">
+							<li>real, both negative → node (sink): all trajectories decay to the origin.</li>
+							<li>real, opposite signs → saddle.</li>
+							<li>purely imaginary → center: closed orbits around the origin.</li>
+							<li>complex with positive real part → spiral source: trajectories loop outward.</li>
+						</ol>
+					</p>
+				</solution>
+				<answer>
+					<p>(a) node (sink); (b) saddle; (c) center; (d) spiral source</p>
+				</answer>
+			</exercise>
+
+		</exercisegroup>
+
 		<exercisegroup>
 
 			<introduction>
 				<p>
-					Solve the following systems of differential equations.
+					Solve the following systems of differential equations. The worked solutions below take a different road than the eigenvalue method: they apply the <em>Laplace transform</em> from the previous chapters to each equation, turning the system into simultaneous algebraic equations. Both methods produce the same solutions — as you work through these, notice how the exponential rates that appear are exactly the eigenvalues of each system's coefficient matrix.
 				</p>
 			</introduction>
 

--- a/source/c13-linsys/sec-eulers-method-systems.ptx
+++ b/source/c13-linsys/sec-eulers-method-systems.ptx
@@ -15,8 +15,8 @@
 
 	<introduction>
 		<p>
-			We've explored what linear systems are, how to visualize their behavior, and even how to write them neatly in vector form.  
-			When an exact solution is hard—or when we only need an approximation—we can compute solutions numerically.  
+			We've explored what linear systems are, how to write them neatly in vector form, and how to solve them with eigenvalues.
+			When an exact solution is hard—or when we only need an approximation—we can compute solutions numerically.
 		</p>
 
 		<p>

--- a/source/c13-linsys/sec-qualitative-methods-systems.ptx
+++ b/source/c13-linsys/sec-qualitative-methods-systems.ptx
@@ -283,11 +283,11 @@
 
 		<p>
 			<idx><h>phase portrait</h><h>classification by eigenvalues</h></idx>
-			In <xref ref="solving-linear-systems" text="title"/>, we saw that the general solution of <m>\vec{X}' = A\vec{X}</m> is built from terms like <m>\vec{v}e^{rt}</m>, where <m>r</m> is an eigenvalue of <m>A</m>. Those eigenvalues are exactly what the phase portrait is showing us: each exponential rate controls whether trajectories grow, decay, or rotate. So once you know the eigenvalues, you know the shape of the picture — no plotting required.
+			In <xref ref="solving-linear-systems" text="title"/>, we saw that the general solution of <m>\vec{X}' = A\vec{X}</m> is built from terms like <m>\vec{v}e^{rt}</m>, where <m>r</m> is an eigenvalue of <m>A</m>. Those eigenvalues are exactly what the phase portrait is showing us: each exponential rate controls whether trajectories grow, decay, or rotate. So once you know the eigenvalues, you can classify the behavior — usually without any plotting.
 		</p>
 
 		<p>
-			For a <m>2\times 2</m> system with eigenvalues <m>r_1</m> and <m>r_2</m>, the standard cases are:
+			For a <m>2\times 2</m> system with <em>distinct</em> eigenvalues <m>r_1</m> and <m>r_2</m> (real or complex), the standard cases are:<fn>The borderline case of a <em>repeated</em> eigenvalue (<m>r_1 = r_2</m>) is more delicate — there the eigenvectors also matter, and the portrait can be a star or a degenerate node. We won't need that case in this book.</fn>
 		</p>
 
 		<tabular halign="center" top="minor" bottom="minor" left="minor" right="minor">
@@ -297,7 +297,7 @@
 				<cell>Behavior of Trajectories</cell>
 			</row>
 			<row>
-				<cell>real, both negative (<m>r_2 \lt r_1 \lt 0</m>)</cell>
+				<cell>real, both negative (<m>r_1 \lt r_2 \lt 0</m>)</cell>
 				<cell>node (sink)</cell>
 				<cell>all trajectories slide into the origin</cell>
 			</row>

--- a/source/c13-linsys/sec-qualitative-methods-systems.ptx
+++ b/source/c13-linsys/sec-qualitative-methods-systems.ptx
@@ -56,61 +56,8 @@
 		</example>
 
 		<p>
-			For more interesting systems — like ones with partial or full coupling — the direction field can show curved paths, spirals, or saddle-shaped flows. This visual approach helps us predict system behavior even before we dive into equations.
-		</p>
-	</subsection>
-
-	<subsection label="visualizing-systems">
-		<title>Visualization Tools</title>
-
-		<p>
-			So far, we've seen examples of systems in which variables evolve independently or influence one another. Now let's step back and look at how to visualize a system as a whole.
-		</p>
-
-		<p>
-			The <em>phase plane</em> is a two-dimensional space where we plot one variable on the horizontal axis and the other on the vertical axis. A solution to a system like
-			<md>
-				<mrow> \frac{dx}{dt} \amp = -x </mrow>
-				<mrow> \frac{dy}{dt} \amp = -2y </mrow>
-			</md>
-		</p>
-
-		<p>
 			<idx><h>phase portrait</h></idx>
-			Such a solution becomes a curve in the <m>(x, y)</m> plane: a path that the system traces over time. We often call this a <em>trajectory</em>.
-		</p>
-
-		<p>
-			Instead of plotting <m>x(t)</m> and <m>y(t)</m> separately, we visualize the pair <m>(x(t), y(t))</m> moving through the plane.
-		</p>
-
-		<p>
-			To understand how the system behaves without solving it, we can draw a <em>slope field</em> or <em>direction field</em>: a grid of arrows showing the direction of motion at each point.
-		</p>
-
-		<p>
-			Each arrow represents the vector <m>(dx/dt, dy/dt)</m> at a point <m>(x, y)</m>. Together, they show how the system is evolving.
-		</p>
-
-		<example xml:id="ex-slopefield-uncoupled">
-			<title>Phase Portrait of an Uncoupled System</title>
-
-			<statement>
-				<p>
-					Consider the system:
-					<md>
-						<mrow> \frac{dx}{dt} \amp = -x </mrow>
-						<mrow> \frac{dy}{dt} \amp = -2y </mrow>
-					</md>
-				</p>
-				<p>
-					The phase portrait shows trajectories curving toward the origin (the axes themselves are straight-line trajectories), because each variable decays independently at its own rate.
-				</p>
-			</statement>
-		</example>
-
-		<p>
-			In more interesting systems, such as partially coupled ones, the slope field reveals how the variables interact.
+			For more interesting systems — like ones with partial or full coupling — the direction field can show curved paths, spirals, or saddle-shaped flows. This visual approach helps us predict system behavior even before we dive into equations.
 		</p>
 
 		<example xml:id="ex-slopefield-partial">
@@ -135,7 +82,7 @@
 		</p>
 
 		<corollary>
-			<title>Euler's Method Visualized</title>
+			<title>Exploring a Direction Field</title>
 
 			<statement>
 				<p>
@@ -202,7 +149,7 @@
 		</p>
 
 		<p>
-			Later, we'll connect these patterns to the algebra of the system's coefficients. But even now, these <q>big-picture</q> behaviors help us think about what the math is saying.
+			These <q>big-picture</q> behaviors are not accidents — they are completely determined by the algebra of the system's coefficients. The next subsection makes that connection precise using the eigenvalues from <xref ref="solving-linear-systems" text="title"/>.
 		</p>
 
 		<exercise label="qualitative-methods-for-linear-systems-cyu-bundle">
@@ -330,5 +277,80 @@
 			</task>
 		</exercise>
 	</subsection>
-	
+
+	<subsection xml:id="eigenvalues-and-phase-portraits">
+		<title>Connecting Eigenvalues to Phase Portraits</title>
+
+		<p>
+			<idx><h>phase portrait</h><h>classification by eigenvalues</h></idx>
+			In <xref ref="solving-linear-systems" text="title"/>, we saw that the general solution of <m>\vec{X}' = A\vec{X}</m> is built from terms like <m>\vec{v}e^{rt}</m>, where <m>r</m> is an eigenvalue of <m>A</m>. Those eigenvalues are exactly what the phase portrait is showing us: each exponential rate controls whether trajectories grow, decay, or rotate. So once you know the eigenvalues, you know the shape of the picture — no plotting required.
+		</p>
+
+		<p>
+			For a <m>2\times 2</m> system with eigenvalues <m>r_1</m> and <m>r_2</m>, the standard cases are:
+		</p>
+
+		<tabular halign="center" top="minor" bottom="minor" left="minor" right="minor">
+			<row header="yes" bottom="minor">
+				<cell>Eigenvalues</cell>
+				<cell>Phase Portrait</cell>
+				<cell>Behavior of Trajectories</cell>
+			</row>
+			<row>
+				<cell>real, both negative (<m>r_2 \lt r_1 \lt 0</m>)</cell>
+				<cell>node (sink)</cell>
+				<cell>all trajectories slide into the origin</cell>
+			</row>
+			<row>
+				<cell>real, both positive (<m>0 \lt r_1 \lt r_2</m>)</cell>
+				<cell>node (source)</cell>
+				<cell>all trajectories flow away from the origin</cell>
+			</row>
+			<row>
+				<cell>real, opposite signs (<m>r_1 \lt 0 \lt r_2</m>)</cell>
+				<cell>saddle</cell>
+				<cell>drawn in along one eigenvector, flung out along the other</cell>
+			</row>
+			<row>
+				<cell>complex, <m>r = a \pm bi</m> with <m>a \lt 0</m></cell>
+				<cell>spiral sink</cell>
+				<cell>trajectories loop inward as they decay</cell>
+			</row>
+			<row>
+				<cell>complex, <m>r = a \pm bi</m> with <m>a \gt 0</m></cell>
+				<cell>spiral source</cell>
+				<cell>trajectories loop outward as they grow</cell>
+			</row>
+			<row>
+				<cell>purely imaginary, <m>r = \pm bi</m></cell>
+				<cell>center</cell>
+				<cell>trajectories orbit the origin in closed loops</cell>
+			</row>
+		</tabular>
+
+		<p>
+			The reading is straightforward: the <em>real part</em> of each eigenvalue controls growth (<m>e^{at}</m> grows when <m>a \gt 0</m>, decays when <m>a \lt 0</m>), and a nonzero <em>imaginary part</em> contributes rotation (through the <m>\cos(bt)</m> and <m>\sin(bt)</m> factors in the real form of the solution).
+		</p>
+
+		<p>
+			Let's revisit the two systems we solved earlier through this lens:
+			<ul marker="square">
+				<li>
+					<p>
+						In <xref ref="ex-worked-linear-system" text="type-global"/>, the eigenvalues were <m>r_1 = 3</m> and <m>r_2 = -1</m> — real with opposite signs. The phase portrait is a <em>saddle</em>: solutions starting along the eigenvector <m>\begin{bmatrix}1\\-2\end{bmatrix}</m> decay toward the origin, while every other solution is eventually carried off in the direction of <m>\begin{bmatrix}1\\2\end{bmatrix}</m> by the dominant <m>e^{3t}</m> term.
+					</p>
+				</li>
+				<li>
+					<p>
+						In <xref ref="ex-complex-eigenvalues" text="type-global"/>, the eigenvalues were <m>r = 2 \pm 5i</m> — complex with positive real part. The phase portrait is a <em>spiral source</em>: the <m>e^{2t}</m> factor pushes trajectories outward while the <m>\cos(5t)</m> and <m>\sin(5t)</m> factors rotate them.
+					</p>
+				</li>
+			</ul>
+		</p>
+
+		<p>
+			This connection runs both ways. Eigenvalues predict the picture, and a glance at a phase portrait tells you the character of the eigenvalues — spirals mean complex eigenvalues, saddles mean real eigenvalues of opposite signs, and so on. You'll practice both directions in the exercises.
+		</p>
+	</subsection>
+
 </section>

--- a/source/c13-linsys/sec-solving-linear-systems.ptx
+++ b/source/c13-linsys/sec-solving-linear-systems.ptx
@@ -14,11 +14,9 @@
 	<title>Solving Linear Systems</title>
 
 	<introduction>
-		<p><xref provisional="WORK-IN-PROGRESS"/></p>
-
 		<p>
-			We've explored what linear systems are, how to visualize their behavior, and how to write them in compact matrix form. 
-			Now it's time to actually <em>solve</em> them.
+			We've explored what linear systems are and how to write them in compact matrix form.
+			Now it's time to actually <em>solve</em> them. (Later in the chapter, we'll also learn to <em>visualize</em> their behavior in the phase plane.)
 		</p>
 
 		<p>
@@ -275,7 +273,7 @@
 
 				<p>
 					The exponential factor <m>e^{2t}</m> causes growth; the sine and cosine produce rotation.
-					The system's phase portrait shows spirals moving outward from the origin.
+					The system's phase portrait shows spirals moving outward from the origin — a connection we make precise in <xref ref="eigenvalues-and-phase-portraits" text="title"/>.
 				</p>
 			</solution>
 		</example>


### PR DESCRIPTION
## Summary

Implements audit item **H5** from `reports/2026-07-textbook-audit.md` — the chapter that taught the eigenvalue method but never had students practice it, and promised an eigenvalue↔geometry connection it never delivered.

**New content:**
- **"Connecting Eigenvalues to Phase Portraits"** subsection in the qualitative-methods section, fulfilling the "Later, we'll connect these patterns to the algebra" promise: a six-case classification table (node sink/source, saddle, spiral sink/source, center), the real-part-controls-growth / imaginary-part-adds-rotation reading, and revisits of both worked examples through this lens (the r = 3, −1 saddle and the r = 2 ± 5i spiral source — the latter now cross-links forward from the example itself).
- **"The Eigenvalue Method" exercise group** (five problems, placed before the Laplace-solved Problems): eigenpair computation, general solution + classification (saddle), an IVP that continues the section's own worked example, the complex/spiral-sink case, and classification from eigenvalues alone.
- **Bridge** added to the Laplace Problems group's introduction: the two methods as two roads to the same solutions, with the exponential rates identified as the eigenvalues of each coefficient matrix.

**Structural repairs:**
- Merged the two near-duplicate phase-plane subsections (both defined phase plane/trajectory/direction field and presented the identical uncoupled example); kept the glossary-linked prose, the partially-coupled example, and both interactives. The direction-field interactive is no longer mistitled "Euler's Method Visualized".
- Removed the `WORK-IN-PROGRESS` provisional marker from the solving section — the placeholder ratchet tightens 34 → 32.
- Fixed the premature "how to visualize their behavior" back-references in the solving and Euler intros (visualization comes later in the chapter, and the intro now says so).

## Verification

All new exercise mathematics SymPy-verified (eigenpairs, all general solutions by substitution, IVP constants); four regression checks added — **62/62 pass**. Validator: 136/136 files parse, 1571 unique ids, 0 duplicates, placeholders at the tightened baseline. No refs pointed at any merged-away id (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_