### PR TITLE
H6: Add existence and uniqueness treatment

### DIFF
--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -530,9 +530,10 @@ REGISTRY += [
         "c2 E&U example: y=x^3 and y=0 both solve y'=3y^(2/3), y(0)=0",
         "source/c2-solns/sec-initial-valued-problems.ptx",
         lambda: (
-            # (x^3)^(2/3) = x^2 for all real x, so y' = 3x^2 = 3 y^(2/3)
+            # y = x^3: (x^3)^(2/3) = x^2 for all real x, so y' = 3x^2 = 3 y^(2/3)
             all(3 * v**2 == 3 * ((v**3) ** 2) ** R(1, 3) for v in (-2, R(-1, 2), R(1, 2), 2))
-            and 0 == 3 * 0
+            # y = 0: y' = 0 and 3*(0^2)^(1/3) = 0
+            and 3 * (0**2) ** R(1, 3) == 0
         ),
     ),
 ]

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -522,6 +522,22 @@ REGISTRY += [
 ]
 
 
+# ----------------------------------------------------------------------
+# H6 — existence & uniqueness example (chapter 2)
+# ----------------------------------------------------------------------
+REGISTRY += [
+    Check(
+        "c2 E&U example: y=x^3 and y=0 both solve y'=3y^(2/3), y(0)=0",
+        "source/c2-solns/sec-initial-valued-problems.ptx",
+        lambda: (
+            # (x^3)^(2/3) = x^2 for all real x, so y' = 3x^2 = 3 y^(2/3)
+            all(3 * v**2 == 3 * ((v**3) ** 2) ** R(1, 3) for v in (-2, R(-1, 2), R(1, 2), 2))
+            and 0 == 3 * 0
+        ),
+    ),
+]
+
+
 def main() -> int:
     failures = 0
     for check in REGISTRY:

--- a/source/c2-solns/sec-initial-valued-problems.ptx
+++ b/source/c2-solns/sec-initial-valued-problems.ptx
@@ -346,6 +346,57 @@
 		</task>
 	</exercise>
 
+	<p>
+		<idx><h>existence and uniqueness</h></idx>
+		Before moving on, it's worth pausing on two questions we've been quietly taking for granted: does an initial value problem always <em>have</em> a solution, and if it does, is that solution the <em>only</em> one? For most of the equations in this book the answer to both is yes, and there is a classical result that says exactly when:
+	</p>
 
+	<assemblage xml:id="existence-uniqueness">
+		<title>✳️ Existence &amp; Uniqueness (Informal)</title>
+		<p>
+			Consider the first-order initial value problem
+			<me>
+				\frac{dy}{dx} = f(x, y), \qquad y(x_0) = y_0.
+			</me>
+			If <m>f</m> is continuous and changes smoothly with respect to <m>y</m> near the starting point <m>(x_0, y_0)</m><fn>The precise condition is that <m>f</m> and its partial derivative <m>\frac{\partial f}{\partial y}</m> (the derivative treating <m>x</m> as constant) are both continuous on a rectangle containing <m>(x_0, y_0)</m>. This result is known as the Picard–Lindelöf theorem.</fn>, then the initial value problem has <em>exactly one</em> solution on some interval around <m>x_0</m>.
+		</p>
+	</assemblage>
+
+	<p>
+		Both conclusions matter. <em>Existence</em> says the problem is not asking for the impossible — some solution curve really does pass through the initial point. <em>Uniqueness</em> says the initial condition pins down the entire future (and past) of the solution: two solutions that agree at one point must agree everywhere they are both defined. Uniqueness is also why an order-<m>n</m> equation needs <m>n</m> initial conditions: its general solution carries <m>n</m> arbitrary constants, and each condition determines one of them, just as we saw with <m>y(0)</m> and <m>y'(0)</m> above.
+	</p>
+
+	<p>
+		When the smoothness hypothesis fails, uniqueness really can break. Here is the classic cautionary example.
+	</p>
+
+	<example xml:id="example-non-unique-ivp">
+		<title>An IVP with More Than One Solution</title>
+		<statement>
+			<p>
+				Show that the initial value problem
+				<me>
+					\frac{dy}{dx} = 3y^{2/3}, \qquad y(0) = 0
+				</me>
+				has at least two different solutions.
+			</p>
+		</statement>
+		<solution>
+			<p>
+				The constant function <m>y_1(x) = 0</m> works: both sides are <m>0</m>, and <m>y_1(0) = 0</m>. But so does <m>y_2(x) = x^3</m>: substituting gives
+				<me>
+					y_2' = 3x^2 \qquad \text{and} \qquad 3y_2^{2/3} = 3\left(x^3\right)^{2/3} = 3x^2,
+				</me>
+				and <m>y_2(0) = 0</m>. Two genuinely different solutions pass through the same initial point (in fact, infinitely many do — a solution can follow <m>y = 0</m> for a while and then peel off onto a shifted cubic).
+			</p>
+			<p>
+				The culprit is the hypothesis: <m>f(x,y) = 3y^{2/3}</m> is continuous, but it does not change smoothly with respect to <m>y</m> at <m>y = 0</m> — its <m>y</m>-derivative <m>2y^{-1/3}</m> blows up there. Right where the guarantee fails, uniqueness fails with it.
+			</p>
+		</solution>
+	</example>
+
+	<p>
+		The takeaway: when you solve an IVP built from reasonably smooth functions — which describes nearly every model in this book — you can trust that the particular solution you found is <em>the</em> solution. But the guarantee has hypotheses, and the example above shows they are not just legal fine print.
+	</p>
 
 </section>

--- a/source/c6-qm/sec-slope-fields.ptx
+++ b/source/c6-qm/sec-slope-fields.ptx
@@ -26,6 +26,10 @@
 		<p>
 			The pattern created by a slope field provides a visual representation of the <em><xref ref="gi-family-of-solutions" text="custom">family of solutions</xref></em> to the differential equation. A slope field doesn't show just one solution—it shows them all. From any starting point, a solution curve threads through, always guided by the tiny arrows.
 		</p>
+
+		<p>
+			How many curves thread through each point? Under the mild smoothness conditions of the <xref ref="existence-uniqueness" text="custom">existence and uniqueness result</xref> from the solutions chapter, <em>exactly one</em> — which is why the solution curves in a slope field never cross each other. Where those conditions fail, curves really can merge or split (as in <xref ref="example-non-unique-ivp" text="type-global"/>), so the never-crossing rule is a theorem, not a coincidence.
+		</p>
 	</introduction>
 
 	<subsection label="slope-fields-eqn-to-slope">


### PR DESCRIPTION
## Summary

Implements audit item **H6** from `reports/2026-07-textbook-audit.md`: existence &amp; uniqueness was absent from the entire book. Two additions, at the audit's suggested homes:

**Chapter 2 (IVP section):**
- An **informal Picard–Lindelöf statement** in the book's ✳️ assemblage style — "if f is continuous and changes smoothly with respect to y near the starting point, the IVP has exactly one solution nearby" — with the precise ∂f/∂y hypothesis and the theorem's name in a footnote (the audience has only single-variable calculus).
- Prose connecting **uniqueness to why an order-n equation needs n initial conditions** — closing the gap the audit flagged where the two-constants case was only ever shown by example.
- The classic **non-uniqueness example**: `y′ = 3y^{2/3}, y(0) = 0` admits both `y = 0` and `y = x³` (and infinitely many hybrids), worked in full with the failed hypothesis identified — the y-derivative `2y^{−1/3}` blows up exactly at the initial point.

**Chapter 6 (slope fields):** a tie-in paragraph answering "how many curves thread through each point?" — exactly one under the E&amp;U conditions, which is why solution curves in a slope field never cross ("a theorem, not a coincidence"), with cross-references back to the chapter 2 box and example. This completes the repair of the section's original unconditional uniqueness claim (softened in #187).

## Verification

The example verified numerically over positive and negative sample points (`(x³)^{2/3} = x²` for all real x) and added to the regression suite (59/59 on this branch). Validator green; both files pass `xmllint`.

**Merge note:** this PR and #197 both append checks at the same anchor in `verify_worked_math.py` — whichever merges second will need a trivial conflict resolution, which I'll handle when the first merge lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_