### PR TITLE
H11: Standardize notation book-wide

### DIFF
--- a/.github/instructions/pretext-source.instructions.md
+++ b/.github/instructions/pretext-source.instructions.md
@@ -16,3 +16,16 @@ Apply these instructions when editing textbook source files under `source/`.
 - When revising explanations, improve motivation, transitions, conceptual clarity, and mathematical precision.
 - When editing assessments, use concise titles, plausible distractors, and feedback that teaches the concept.
 - When editing narration-related text, keep the visible source aligned with any generated TTS narration.
+
+## Notation conventions
+
+Use these conventions in all new or revised content; align outliers when a task touches them.
+
+- **Integration constants**: uppercase `C` (and `C_1, C_2, …` for multiple constants). Within a single exercise, the statement, solution(s), and answer must all use the same letter and case.
+- **Standard linear form (ch. 5)**: `y' + P(x)y = Q(x)` with uppercase `P` and `Q` (matching function-of-`t` forms use `P(t)`, `Q(t)`).
+- **Particular/homogeneous solutions (chs. 8–9)**: `y_p` is the particular solution, `y_h` the homogeneous solution; the general solution is `y = y_h + y_p`.
+- **State vectors and matrices (ch. 13)**: write systems as `\vec{X}' = A\vec{X}` (or `\frac{d\vec{X}}{dt} = A\vec{X}`) with `\vec{X} = \begin{bmatrix} x \\ y \end{bmatrix}`; use `bmatrix` (square brackets) for all matrices and vectors, never `pmatrix`. Reserve capital `Y(s)`, `X(s)` for Laplace transforms.
+- **Equilibrium classification (ch. 6)**: `stable (sink)`, `unstable (source)`, and `semi-stable` — do not call a semi-stable equilibrium a "node"; that word is reserved for two-dimensional phase portraits (ch. 13) and the saddle-node bifurcation.
+- **Phase lines**: equilibria are solid (filled) dots; regions get up/down arrows.
+- **Slope fields**: the marks are "segments" (they have no arrowheads); direction fields for systems (ch. 13) have arrows.
+- **Variable names**: variable letters deliberately vary by application (`P` for population, `T` for temperature, etc.); see the "Different Letters, Same Roles" box in ch. 0. Within any one example or exercise, keep dependent/independent variable names internally consistent.

--- a/source/aa-bookends/glossary.ptx
+++ b/source/aa-bookends/glossary.ptx
@@ -1427,7 +1427,7 @@
     <p>
       The number of dependent variables in a system, equal to the number of entries in its <xref ref="gi-state-vector" text="title"/>.
       <md>
-        <mrow>Y=\begin{bmatrix} y_1 \\ y_2 \\ y_3 \end{bmatrix}\qquad\text{dimension } 3</mrow>
+        <mrow>\vec{X}=\begin{bmatrix} x_1 \\ x_2 \\ x_3 \end{bmatrix}\qquad\text{dimension } 3</mrow>
       </md>
     </p>
   </gi>

--- a/source/aa-bookends/glossary.ptx
+++ b/source/aa-bookends/glossary.ptx
@@ -640,7 +640,7 @@
   </gi>
 
   <gi xml:id="gi-semi-stable-equilibrium">
-    <title>semi-stable equilibrium (node)</title>
+    <title>semi-stable equilibrium</title>
     <p>
       An <xref ref="gi-equilibrium-solution" text="title"/> that attracts nearby solutions on one side and repels them on the other.
     </p>
@@ -1398,9 +1398,9 @@
   <gi xml:id="gi-coefficient-matrix">
     <title>coefficient matrix</title>
     <p>
-      For a <xref ref="gi-linear-system" text="title"/>, the matrix that collects the coefficients of the dependent variables in the equation <m>\frac{dY}{dt}=AY</m>, where <m>Y</m> is the <xref ref="gi-state-vector" text="title"/>.
+      For a <xref ref="gi-linear-system" text="title"/>, the matrix that collects the coefficients of the dependent variables in the equation <m>\frac{d\vec{X}}{dt}=A\vec{X}</m>, where <m>\vec{X}</m> is the <xref ref="gi-state-vector" text="title"/>.
       <md>
-        <mrow>\frac{dY}{dt} = AY,\qquad A=\begin{bmatrix} a \amp b \\ c \amp d \end{bmatrix}</mrow>
+        <mrow>\frac{d\vec{X}}{dt} = A\vec{X},\qquad A=\begin{bmatrix} a \amp b \\ c \amp d \end{bmatrix}</mrow>
       </md>
     </p>
   </gi>
@@ -1410,7 +1410,7 @@
     <p>
       A column vector listing the dependent variables in a system.
       <md>
-        <mrow>Y=\begin{bmatrix} x \\ y \end{bmatrix}</mrow>
+        <mrow>\vec{X}=\begin{bmatrix} x \\ y \end{bmatrix}</mrow>
       </md>
     </p>
   </gi>
@@ -1471,11 +1471,11 @@
     <p>
       The step used by <xref ref="gi-eulers-method" text="title"/> when approximating a system. If
       <md>
-        <mrow>\frac{dY}{dt}=F(t,Y)</mrow>
+        <mrow>\frac{d\vec{X}}{dt}=F(t,\vec{X})</mrow>
       </md>
       then the next approximation is
       <md>
-        <mrow>Y_{k+1}=Y_k+h\,F(t_k,Y_k)</mrow>
+        <mrow>\vec{X}_{k+1}=\vec{X}_k+h\,F(t_k,\vec{X}_k)</mrow>
       </md>
       where <m>h</m> is the <xref ref="gi-step-size" text="title"/>.
     </p>

--- a/source/c0-whats-a-de/sec-variables.ptx
+++ b/source/c0-whats-a-de/sec-variables.ptx
@@ -73,6 +73,13 @@
 		</solution>
 	</example>
 
+	<assemblage xml:id="variables-different-letters">
+		<title><e component="emoji">✳️</e> Different Letters, Same Roles</title>
+		<p>
+			Throughout this book, the letters change with the context: we might solve for <m>y(x)</m>, <m>P(s)</m>, <m>u(t)</m>, or <m>Q(t)</m>. This variety is deliberate. Applications name variables after the quantities they measure—<m>P</m> for population, <m>V</m> for voltage, <m>T</m> for temperature, and <m>t</m> for time—so reading an equation in any letters is part of the skill you are building. What never changes are the <em>roles</em>: the dependent variable is the unknown function and carries the derivative, and the independent variable is what it depends on. When an equation looks unfamiliar, ask <q>which variable has the derivative applied to it?</q>—that is the dependent variable, whatever letter it wears.
+		</p>
+	</assemblage>
+
 	<exercise label="components-cyu-1">
 
 		<task label="components-cyu-1-task-1">

--- a/source/c13-linsys/sec-linear-systems.ptx
+++ b/source/c13-linsys/sec-linear-systems.ptx
@@ -83,15 +83,15 @@
 			<me>
 				A = \begin{bmatrix} a \amp b \\ c \amp d \end{bmatrix},
 				\qquad
-				Y = \begin{bmatrix} x \\ y \end{bmatrix},
+				\vec{X} = \begin{bmatrix} x \\ y \end{bmatrix},
 				\qquad
-				\frac{dY}{dt} = \begin{bmatrix} \dfrac{dx}{dt} \\ \dfrac{dy}{dt} \end{bmatrix}
+				\frac{d\vec{X}}{dt} = \begin{bmatrix} \dfrac{dx}{dt} \\ \dfrac{dy}{dt} \end{bmatrix}
 			</me>
 		</p>
 
 		<p>
 			Matrix multiplication then packages both equations into a single vector equation
-			<me>\frac{dY}{dt} = AY.</me>
+			<me>\frac{d\vec{X}}{dt} = A\vec{X}.</me>
 		</p>
 
 		<p>
@@ -103,11 +103,11 @@
 		<title>From Two to <m>n</m> Dimensions</title>
 
 		<p>
-			For <m>n</m> variables <m>y_1,\dots,y_n</m>, a constant-coefficient linear system reads
+			For <m>n</m> variables <m>x_1,\dots,x_n</m>, a constant-coefficient linear system reads
 			<me>
-				\frac{dY}{dt} = AY,
+				\frac{d\vec{X}}{dt} = A\vec{X},
 				\qquad
-				Y = \begin{bmatrix} y_1 \\ \vdots \\ y_n \end{bmatrix},
+				\vec{X} = \begin{bmatrix} x_1 \\ \vdots \\ x_n \end{bmatrix},
 				\quad
 				A = \begin{bmatrix}
 					a_{11} \amp a_{12} \amp \dots \amp a_{1n} \\
@@ -118,7 +118,7 @@
 		</p>
 
 		<p>
-			The dimension of the system equals the length of <m>Y</m>.  
+			The dimension of the system equals the length of <m>\vec{X}</m>.  
 			Our focus in this chapter remains on the planar case (<m>n=2</m>) where geometry and
 			algebra meet most clearly.
 		</p>
@@ -233,7 +233,7 @@
 			<task label="linear-systems-basics-cyu-3">
 				<title><e component="emoji">📖❓</e>  Benefits</title>
 				<statement>
-					<p>Choose all advantages of writing <m>\frac{dY}{dt} = AY</m>.</p>
+					<p>Choose all advantages of writing <m>\frac{d\vec{X}}{dt} = A\vec{X}</m>.</p>
 				</statement>
 				<choices randomize="yes">
 					<choice correct="yes">

--- a/source/c13-linsys/sec-solving-linear-systems.ptx
+++ b/source/c13-linsys/sec-solving-linear-systems.ptx
@@ -132,12 +132,12 @@
 			</statement>
 			<solution>
 				<p>
-					Write in matrix form <m>\frac{dY}{dt} = AY</m> with 
+					Write in matrix form <m>\frac{d\vec{X}}{dt} = A\vec{X}</m> with 
 					<m>A = \begin{bmatrix}1 \amp 1 \\ 4 \amp 1\end{bmatrix}</m>.
 				</p>
 
 				<p>
-					Guess <m>Y(t) = \vec{v}e^{rt}</m>.  
+					Guess <m>\vec{X}(t) = \vec{v}e^{rt}</m>.  
 					Substituting gives <m>A\vec{v} = r\vec{v}</m>.
 				</p>
 
@@ -182,7 +182,7 @@
 				<p>
 					Write the general solution:
 					<me>
-						Y(t) = C_1 \vec{v}_1 e^{3t} + C_2 \vec{v}_2 e^{-t}.
+						\vec{X}(t) = C_1 \vec{v}_1 e^{3t} + C_2 \vec{v}_2 e^{-t}.
 					</me>
 				</p>
 

--- a/source/c5-if/exercises-if.ptx
+++ b/source/c5-if/exercises-if.ptx
@@ -334,8 +334,8 @@
 
 					<statement>
 						<p>
-							Rewrite the differential equation below in the standard form <m>y' + p(x)y = q(x)</m>. 
-							Identify <m>p(x)</m> and <m>q(x)</m>, state its order, and determine whether it is linear.
+							Rewrite the differential equation below in the standard form <m>y' + P(x)y = Q(x)</m>. 
+							Identify <m>P(x)</m> and <m>Q(x)</m>, state its order, and determine whether it is linear.
 							<me>-4xy' + 5y = \cos (x)\,y - 1</me>
 						</p>
 					</statement>
@@ -344,8 +344,8 @@
 						<p>
 							<ul marker="square">
 								<li><m>y' + \left(\frac{\cos x - 5}{4x}\right) y = \frac{1}{4x}</m></li>
-								<li><m>p(x) = \frac{\cos x - 5}{4x}</m></li>
-								<li><m>q(x) = \frac{1}{4x}</m></li>
+								<li><m>P(x) = \frac{\cos x - 5}{4x}</m></li>
+								<li><m>Q(x) = \frac{1}{4x}</m></li>
 								<li>Order: first</li>
 								<li>Classification: linear</li>
 							</ul>
@@ -646,8 +646,8 @@
 															\amp = \int \frac{e^{1/x}}{x^2} dx \qquad \rightarrow
 										</mrow>
 										<mrow>	e^{1/x} y	\amp = \int -e^u du </mrow>
-										<mrow>	e^{1/x} y	\amp = -e^u + c		</mrow>
-										<mrow>	e^{1/x} y	\amp = -e^{1/x} + c	</mrow>
+										<mrow>	e^{1/x} y	\amp = -e^u + C		</mrow>
+										<mrow>	e^{1/x} y	\amp = -e^{1/x} + C	</mrow>
 									</md>
 								</p>
 								<p>
@@ -662,7 +662,7 @@
 							
 							Finally, solve for <m>y</m>:
 							<md>
-								<mrow> y = -1 + ce^{-1/x}	</mrow>
+								<mrow> y = -1 + Ce^{-1/x}	</mrow>
 							</md>
 						</p>
 					</solution>
@@ -797,7 +797,7 @@
 							<p>
 								<md>
 									<mrow>
-										\frac{1}{t^4} M = \frac{1}{3}t^{3} - \frac{1}{2}t^{-2} + c
+										\frac{1}{t^4} M = \frac{1}{3}t^{3} - \frac{1}{2}t^{-2} + C
 									</mrow>
 								</md>
 							</p>
@@ -807,7 +807,7 @@
 							<p>General Solution</p>
 							<p>
 								<me>
-									M = \frac{1}{3}t^{7} - \frac{1}{2}t^2 + ct^4
+									M = \frac{1}{3}t^{7} - \frac{1}{2}t^2 + Ct^4
 								</me>.
 							</p>
 						</sidebyside>

--- a/source/c5-if/if-model.ptx
+++ b/source/c5-if/if-model.ptx
@@ -72,7 +72,7 @@
 		</p>
 
 		<p>
-			This is a first-order linear differential equation with <m>p(t) = \frac{1}{RC}</m> and <m>q(t) = \frac{1}{RC}V_s(t)</m>.
+			This is a first-order linear differential equation with <m>P(t) = \frac{1}{RC}</m> and <m>Q(t) = \frac{1}{RC}V_s(t)</m>.
 		</p>
 
 		<p>

--- a/source/c6-qm/exercises-qm.ptx
+++ b/source/c6-qm/exercises-qm.ptx
@@ -159,7 +159,7 @@
 				<choices randomize="yes">
 					<choice correct="yes"><statement>Stable (sink)</statement></choice>
 					<choice correct="no"><statement>Unstable (source)</statement></choice>
-					<choice correct="no"><statement>Semi-stable (node)</statement></choice>
+					<choice correct="no"><statement>Semi-stable</statement></choice>
 					<choice correct="no"><statement>Not an equilibrium point</statement></choice>
 				</choices>
 			</task>
@@ -174,7 +174,7 @@
 						<me>
 							\dfrac{dy}{dt} = y(3 - y^2).
 						</me>
-						Then classify each equilibrium solution as a sink, source, or node.
+						Then classify each equilibrium solution as a sink, source, or semi-stable.
 					</p>
 				</statement>
 			</task>
@@ -217,7 +217,7 @@
 						<p>Task 6: For <m>y' = y(3 - y^2)</m>, set <m>y(3 - y^2) = 0</m> to find equilibria: <m>y = 0</m> or <m>3 - y^2 = 0</m>, giving <m>y = 0, \sqrt{3}, -\sqrt{3}</m>. Testing regions: for <m>y &lt; -\sqrt{3}</m>, try <m>y=-2</m>: <m>f(-2) = -2(3-4) = 2 &gt; 0</m> (upward arrow); for <m>-\sqrt{3} &lt; y &lt; 0</m>, try <m>y=-1</m>: <m>f(-1) = -1(3-1) = -2 &lt; 0</m> (downward arrow); for <m>0 &lt; y &lt; \sqrt{3}</m>, try <m>y=1</m>: <m>f(1) = 1(3-1) = 2 &gt; 0</m> (upward arrow); for <m>y &gt; \sqrt{3}</m>, try <m>y=2</m>: <m>f(2) = 2(3-4) = -2 &lt; 0</m> (downward arrow). Classification: <m>y = -\sqrt{3}</m> is a source (arrows away on both sides), <m>y = 0</m> is a sink (arrows toward from both sides), <m>y = \sqrt{3}</m> is a source (arrows away on both sides).</p>
 					</li>
 					<li>
-						<p>Task 7: 1) An autonomous differential equation has the form <m>\frac{dy}{dt} = f(y)</m>, where the rate of change depends only on <m>y</m>, not on <m>t</m>. 2) Set <m>f(y) = 0</m> and solve algebraically for <m>y</m>. 3) The phase line is a vertical number line showing equilibrium points and arrows indicating whether solutions increase (upward) or decrease (downward) in each region; it helps visualize long-term solution behavior. 4) Examine the arrows on the phase line: if they point toward the equilibrium from both sides, it's stable (sink); if they point away on both sides, it's unstable (source); if they point in opposite directions, it's semi-stable (node).</p>
+						<p>Task 7: 1) An autonomous differential equation has the form <m>\frac{dy}{dt} = f(y)</m>, where the rate of change depends only on <m>y</m>, not on <m>t</m>. 2) Set <m>f(y) = 0</m> and solve algebraically for <m>y</m>. 3) The phase line is a vertical number line showing equilibrium points and arrows indicating whether solutions increase (upward) or decrease (downward) in each region; it helps visualize long-term solution behavior. 4) Examine the arrows on the phase line: if they point toward the equilibrium from both sides, it's stable (sink); if they point away on both sides, it's unstable (source); if they point in opposite directions, it's semi-stable.</p>
 					</li>
 				</ol>
 			</solution>
@@ -315,12 +315,12 @@
 						<p>This system does not exhibit chaotic behavior. Chaos typically requires at least three dimensions and sensitivity to initial conditions. This is a one-dimensional autonomous ODE, which cannot exhibit chaos. The system's behavior is predictable and depends smoothly on initial conditions.</p>
 					</li>
 					<li>
-						<p>Test regions: For <m>y &lt; 1</m>, try <m>y=0</m>: <m>f(0) = 1 &gt; 0</m> (upward). For <m>y &gt; 1</m>, try <m>y=2</m>: <m>f(2) = 4 - 4 + 1 = 1 &gt; 0</m> (upward). Phase line: Place a dot at <m>y=1</m> with upward arrows on both sides. Stability: <m>y = 1</m> is a semi-stable equilibrium (node). Long-term behavior: Solutions below <m>y=1</m> increase toward <m>y=1</m> but never quite reach it (approach asymptotically); solutions above <m>y=1</m> increase away from <m>y=1</m> without bound.</p>
+						<p>Test regions: For <m>y &lt; 1</m>, try <m>y=0</m>: <m>f(0) = 1 &gt; 0</m> (upward). For <m>y &gt; 1</m>, try <m>y=2</m>: <m>f(2) = 4 - 4 + 1 = 1 &gt; 0</m> (upward). Phase line: Place a dot at <m>y=1</m> with upward arrows on both sides. Stability: <m>y = 1</m> is a semi-stable equilibrium. Long-term behavior: Solutions below <m>y=1</m> increase toward <m>y=1</m> but never quite reach it (approach asymptotically); solutions above <m>y=1</m> increase away from <m>y=1</m> without bound.</p>
 					</li>
 				</ol>
 			</solution>
 			<answer>
-				<p>a) <m>y = 1</m>. b) No chaos; this is a predictable 1D system. c) <m>y = 1</m> is semi-stable (node); solutions below approach it, solutions above grow unbounded.</p>
+				<p>a) <m>y = 1</m>. b) No chaos; this is a predictable 1D system. c) <m>y = 1</m> is semi-stable; solutions below approach it, solutions above grow unbounded.</p>
 			</answer>
 
 		</exercise>
@@ -432,7 +432,7 @@
 					<me>
 						\dfrac{dy}{dt} = y^2 - 4y + 3.
 					</me>
-					Then classify each equilibrium point as a sink, source, or node.
+					Then classify each equilibrium point as a sink, source, or semi-stable.
 				</p>
 			</statement>
 

--- a/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
+++ b/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
@@ -32,18 +32,17 @@
 			<idx><h>unstable equilibrium</h></idx>
 			<idx><h>source</h></idx>
 			<idx><h>semi-stable equilibrium</h></idx>
-			<idx><h>node</h></idx>
 			There are three common types:
 		</p>
 
 		<ul marker="square">
 			<li><term>Stable (sink):</term> Solutions move <em>toward</em> the equilibrium from both sides.</li>
 			<li><term>Unstable (source):</term> Solutions move <em>away</em> from the equilibrium on both sides.</li>
-			<li><term>Semi-stable (node):</term> Solutions move toward the equilibrium on one side and away from it on the other.</li>
+			<li><term>Semi-stable:</term> Solutions move toward the equilibrium on one side and away from it on the other.</li>
 		</ul>
 
 		<p>
-			In a slope field, a sink looks like arrows converging toward a horizontal line, a source shows arrows diverging away, and a node is a mix: converging on one side, diverging on the other. Next, we'll look at different ways to determine these behaviors.
+			In a slope field, a sink looks like segments converging toward a horizontal line, a source shows segments diverging away, and a semi-stable equilibrium is a mix: converging on one side, diverging on the other. Next, we'll look at different ways to determine these behaviors.
 		</p>
 	</subsection>
 
@@ -281,7 +280,7 @@
 
 									% Draw equilibrium points
 									\foreach \eqpt in \eqpts {
-										\draw[fill=white, thick] (0,\eqpt) circle (8pt);
+										\draw[fill=black, thick] (0,\eqpt) circle (8pt);
 										\draw[] (0,\eqpt) node[left, font=\scriptsize] {\eqpt};
 									}
 
@@ -356,7 +355,7 @@
 				</match>
 				<match>
 					<premise><me>C</me></premise>
-					<response>Node</response>
+					<response>Semi-stable</response>
 				</match>
 				<match>
 					<response>None of these</response>
@@ -654,8 +653,8 @@
 					<choice correct="no"><statement><m>y = -1</m> is a source, <m>y = 3</m> sink</statement></choice>
 					<choice correct="no"><statement>Both are sinks</statement></choice>
 					<choice correct="no"><statement>Both are sources</statement></choice>
-					<choice correct="no"><statement><m>y = -1</m> is a node, <m>y = 3</m> sink</statement></choice>
-					<choice correct="no"><statement><m>y = -1</m> is a source, <m>y = 3</m> node</statement></choice>
+					<choice correct="no"><statement><m>y = -1</m> is semi-stable, <m>y = 3</m> sink</statement></choice>
+					<choice correct="no"><statement><m>y = -1</m> is a source, <m>y = 3</m> semi-stable</statement></choice>
 				</choices>
 			</task>
 			

--- a/source/c6-qm/sec-slope-fields.ptx
+++ b/source/c6-qm/sec-slope-fields.ptx
@@ -20,11 +20,11 @@
 		</p>
 
 		<p>
-			A <xref ref="gi-slope-field" text="custom">slope field</xref> visually represents the slopes that a solution curve must follow at each point in the plane, shown as short arrows pointing the way a solution would travel—like a leaf carried by a stream.
+			A <xref ref="gi-slope-field" text="custom">slope field</xref> visually represents the slopes that a solution curve must follow at each point in the plane, shown as short segments tracing the way a solution would travel—like a leaf carried by a stream.
 		</p>
 
 		<p>
-			The pattern created by a slope field provides a visual representation of the <em><xref ref="gi-family-of-solutions" text="custom">family of solutions</xref></em> to the differential equation. A slope field doesn't show just one solution—it shows them all. From any starting point, a solution curve threads through, always guided by the tiny arrows.
+			The pattern created by a slope field provides a visual representation of the <em><xref ref="gi-family-of-solutions" text="custom">family of solutions</xref></em> to the differential equation. A slope field doesn't show just one solution—it shows them all. From any starting point, a solution curve threads through, always guided by the tiny segments.
 		</p>
 
 		<p>
@@ -229,7 +229,7 @@
 		</sidebyside>
 
 		<p>
-			Sketching by hand is great for intuition, but tedious when you need more points. Computer-generated slope fields fill in the gaps, revealing a dense web of arrows that paints the full picture. In <xref ref="y-t-slope-field-16x16"/>, the solution curve through <m>(0,\frac12)</m> flows smoothly along the arrows, like an object carried by a current.
+			Sketching by hand is great for intuition, but tedious when you need more points. Computer-generated slope fields fill in the gaps, revealing a dense web of segments that paints the full picture. In <xref ref="y-t-slope-field-16x16"/>, the solution curve through <m>(0,\frac12)</m> flows smoothly along the segments, like an object carried by a current.
 		</p>
 
 		<sidebyside widths="44%" margins="28% 28%" valign="middle">
@@ -329,7 +329,7 @@
 		</sidebyside>
 
 		<p>
-			A slope field turns an equation into a navigational chart. Each arrow is an instruction every solution must obey. The entire field represents the whole family of solutions, letting you spot patterns in how solutions behave, without ever solving for <m>y</m> explicitly. Next, we'll look at <em><xref ref="gi-autonomous-differential-equation" text="custom">autonomous equations</xref></em>, whose slope fields reveal even more structure.
+			A slope field turns an equation into a navigational chart. Each segment is an instruction every solution must obey. The entire field represents the whole family of solutions, letting you spot patterns in how solutions behave, without ever solving for <m>y</m> explicitly. Next, we'll look at <em><xref ref="gi-autonomous-differential-equation" text="custom">autonomous equations</xref></em>, whose slope fields reveal even more structure.
 		</p>
 
 		<exercise label="slope-fields-cyu-1">

--- a/source/main-dev.ptx
+++ b/source/main-dev.ptx
@@ -352,7 +352,7 @@
 							<ul>
 								<li>stable (sinks) that pull solutions in,</li>
 								<li>unstable (source) that push them out, or</li>
-								<li>semi-stable (node) that do one of each.</li>
+								<li>semi-stable that do one of each.</li>
 							</ul>
 						</p>
 					</li>
@@ -785,7 +785,7 @@
 						</p>
 					</li>
 					<li><p>A system is <em>linear</em> if its unknowns appear without products, powers, or nonlinear functions. Such systems can be written in vector form:
-								<me>\dfrac{d\vec{Y}}{dt} = A\vec{Y}</me>
+								<me>\dfrac{d\vec{X}}{dt} = A\vec{X}</me>
 								where <m>A</m> is the constant coefficient matrix.
 							</p>
 					</li>

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -359,7 +359,7 @@
 							<ul>
 								<li>stable (sinks) that pull solutions in,</li>
 								<li>unstable (source) that push them out, or</li>
-								<li>semi-stable (node) that do one of each.</li>
+								<li>semi-stable that do one of each.</li>
 							</ul>
 						</p>
 					</li>
@@ -799,7 +799,7 @@
 						</p>
 					</li>
 					<li><p>A system is <em>linear</em> if its unknowns appear without products, powers, or nonlinear functions. Such systems can be written in vector form:
-								<me>\dfrac{d\vec{Y}}{dt} = A\vec{Y}</me>
+								<me>\dfrac{d\vec{X}}{dt} = A\vec{X}</me>
 								where <m>A</m> is the constant coefficient matrix.
 							</p>
 					</li>


### PR DESCRIPTION
Executes **H11 (book-wide notation standardization)** from the [July 2026 audit](reports/2026-07-textbook-audit.md).

## What changed

### "Semi-stable", not "(node)"
The 1-D classification name "node" collided with the 2-D node of ch. 13 phase portraits and the saddle-node bifurcation in the same chapter. All 1-D uses now say just **semi-stable**:
- c6 narrative list + slope-field description (`sec-classifying-equilibrium-solutions.ptx`), cardsort response, and two checkpoint choices
- c6 exercises: choice text, two "classify as sink, source, or ~node~ semi-stable" prompts, and three solution/answer strings
- ch. 6 summary bullet in `main.ptx` / `main-dev.ptx`
- glossary title `semi-stable equilibrium (node)` → `semi-stable equilibrium` (the `<gi>` id is unchanged, so no xrefs break)

### Phase-line dot convention
The classifying section states "Equilibria are marked with solid dots," but its own worked phase-line figure drew the equilibrium as an open circle (`fill=white`). The figure now uses `fill=black`.

### Slope-field marks are "segments"
The glossary already defines a slope field as "short segments"; the c6 narrative called them "arrows" in five places (`sec-slope-fields.ptx` + the classifying section). All now say **segments**. Ch. 13 direction fields legitimately use arrowheads and are untouched.

### Ch. 5 standard form: uppercase `P(x)/Q(x)`
The chapter's definition and ~25 other sites use uppercase; the two lowercase outliers (`if-cq-sa-03` exercise, RC-circuit model) now match.

### Integration constants: `C` within each item
`if-problem-gen-sol-2` and `-6` had compact solutions/answers in `C` but detailed solutions in `c` (5 sites). Detailed solutions now use `C`. (These were the only within-item mismatches found by a scripted scan of c3/c4/c5 exercise blocks.)

### Ch. 13 state vector: `\vec{X}` everywhere
`\vec{X}` was already the majority convention (15+ uses in exercises and the qualitative-methods section), but the two foundational sections still introduced the system as `dY/dt = AY`:
- `sec-linear-systems.ptx`: matrix formulation, n-dimensional form (components renamed `y_i` → `x_i` to match), dimension remark, and a checkpoint
- `sec-solving-linear-systems.ptx`: worked example (matrix form, guess, general solution)
- `main.ptx`/`main-dev.ptx` ch. 13 summary, and the glossary entries for *coefficient matrix*, *state vector*, and *Euler update (for a system)*
- `Y(s)`/`X(s)` remain reserved for Laplace transforms in the c13 Laplace exercises

### Variable-name variety is now a teaching point
New ✳️ box "Different Letters, Same Roles" in ch. 0 `sec-variables.ptx` (new id `variables-different-letters`), telling students the book deliberately varies letters by application and that the *roles* are what matter.

### Conventions documented
Appended a **Notation conventions** section to `.github/instructions/pretext-source.instructions.md` covering all of the above (plus `y_p`/`y_h` and bmatrix-only, which were already consistent in source), so future edits — human or AI — land on the same conventions.

## Out of scope
- `linsys-model.ptx` still uses `pmatrix`, but it is commented out of the build and needs its Jacobian fixed first — both are covered by M4.
- The `y_h`-as-particular mislabel flagged in the audit for the c9 quick-ref is already fixed in current `main`.

## Verification
- Well-formedness: 136/136 files parse; build set 116 files, 0 missing includes
- Unique ids: 1574 (new id `variables-different-letters` registered, no duplicates)
- Placeholder ratchet unchanged at 32
- SymPy regression suite: **63/63 checks pass** (notation-only change; no math values touched)
- `git diff --numstat` confirms minimal per-line diffs — no line-ending churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQeYLYpPZPESvq3x9M2Kxx)_