### PR TITLE
H9: Add cumulative mixed-method reviews + which-method selector

### DIFF
--- a/.github/workflows/pretext-deploy.yml
+++ b/.github/workflows/pretext-deploy.yml
@@ -1,4 +1,4 @@
-# This file was automatically generated with PreTeXt 2.39.0.
+# This file was automatically generated with PreTeXt 2.44.0.
 # If you modify this file, PreTeXt will no longer automatically update it.
 #
 

--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,8 @@ bh_unicode_properties.cache
 GitHub.sublime-settings
 
 # Don't track common virtual environment directories
-venv/
+# venv is a symbolic link. Don't delete it, unlink it.
+.venv
 __pycache__/
 *.pyc
 

--- a/assets/code/jsxgraph/method-flowchart/method-flowchart.js
+++ b/assets/code/jsxgraph/method-flowchart/method-flowchart.js
@@ -114,26 +114,26 @@
 	// --- layout ---
 	const qX = 4.6, mX = 11.8;
 	const nodes = {
-		start: makeNode(qX, 11.3, 6.4, 1.1,
+		start: makeNode(qX, 11.3, 6.0, 1.3,
 			'<b>Start:</b> a differential equation to solve', 'question'),
-		q1: makeNode(qX, 9.3, 6.4, 1.3,
+		q1: makeNode(qX, 9.3, 6.0, 1.3,
 			'Is the equation <b>first order</b>?<br>(highest derivative is y&prime;)', 'question'),
-		mHigher: makeNode(mX, 9.3, 7.0, 1.3,
+		mHigher: makeNode(mX, 9.3, 6.0, 1.3,
 			'<b>Higher-order equation</b><br>new tools coming in later chapters', 'method'),
-		q2: makeNode(qX, 7.1, 6.4, 1.3,
+		q2: makeNode(qX, 7.1, 6.0, 1.3,
 			'Is it <b>already a derivative</b>?<br>d&frasl;dx[ &hellip; ] = f(x)', 'question'),
-		mDI: makeNode(mX, 7.1, 7.0, 1.3,
+		mDI: makeNode(mX, 7.1, 6.0, 1.3,
 			'<b>Direct Integration</b><br>integrate both sides', 'method'),
-		q3: makeNode(qX, 4.9, 6.4, 1.3,
+		q3: makeNode(qX, 4.9, 6.0, 1.3,
 			'Is it <b>separable</b>?<br>y&prime; = f(x)&middot;g(y)', 'question'),
-		mSOV: makeNode(mX, 4.9, 7.0, 1.3,
+		mSOV: makeNode(mX, 4.9, 6.0, 1.3,
 			'<b>Separation of Variables</b><br>separate, then integrate', 'method'),
-		q4: makeNode(qX, 2.7, 6.4, 1.3,
+		q4: makeNode(qX, 2.7, 6.0, 1.3,
 			'Is it <b>linear</b>?<br>y&prime; + P(x)y = Q(x)', 'question'),
-		mIF: makeNode(mX, 2.7, 7.0, 1.3,
+		mIF: makeNode(mX, 2.7, 6.0, 1.3,
 			'<b>Integrating Factor</b><br>multiply by &mu;(x) = e<sup>&int;P(x)dx</sup>', 'method'),
-		mNone: makeNode(qX, 0.7, 8.6, 1.2,
-			'<b>No formula method (yet)</b> &mdash; try qualitative or numerical tools', 'method'),
+		mNone: makeNode(qX, 0.7, 6.0, 1.3,
+			'<b>No formula method (yet)</b><br>try qualitative or numerical tools', 'method'),
 	};
 
 	const edges = {
@@ -208,12 +208,12 @@
 		return btn;
 	}
 
-	makeButton(12.2, 11.55, 1.7, 0.9, 'Yes', '#c9e7cd', () => answer('yes'));
-	makeButton(14.2, 11.55, 1.7, 0.9, 'No', '#f6cfcf', () => answer('no'));
-	makeButton(13.2, 10.35, 2.2, 0.8, 'Reset', '#e2e2e2', reset);
+	makeButton(9.7,  11.3, 1.6, 0.9, 'Yes', '#c9e7cd', () => answer('yes'));
+	makeButton(11.7, 11.3, 1.6, 0.9, 'No', '#f6cfcf', () => answer('no'));
+	makeButton(13.7, 11.3, 1.6, 0.9, 'Reset', '#e2e2e2', reset);
 
-	board.create('text', [13.2, 0.7,
-		'If an equation is <i>both</i> separable and linear,<br>either tool works &mdash; pick the faster one.'], {
+	board.create('text', [12.2, 0.7,
+		'If an equation is <i>both</i> separable and<br>linear, either method works.'], {
 		anchorX: 'middle',
 		anchorY: 'middle',
 		fixed: true,

--- a/assets/code/jsxgraph/method-flowchart/method-flowchart.js
+++ b/assets/code/jsxgraph/method-flowchart/method-flowchart.js
@@ -1,0 +1,225 @@
+// === "Which Method?" Interactive Flowchart ===
+// Clickable decision tree for choosing a first-order solution method.
+// The student answers the highlighted question with the Yes / No buttons
+// and the chart walks them to the appropriate tool:
+//   first order? -> already a derivative? -> separable? -> linear? -> which tool
+// Companion to the "Which Method Applies" drills in the Integrating Factor chapter.
+(function () {
+	const boardId = 'method-flowchart';
+
+	// Colors
+	const QUESTION_FILL = '#f7f7f7';
+	const METHOD_FILL = '#eef4fb';
+	const ACTIVE_FILL = '#fff3c4';   // question waiting on an answer
+	const DONE_FILL = '#c9e7cd';     // method the path ends on
+	const EDGE_IDLE = '#b0b0b0';
+	const EDGE_TAKEN = '#2e7d32';
+	const BORDER_IDLE = '#888888';
+	const BORDER_ACTIVE = '#b28900';
+	const BORDER_DONE = '#2e7d32';
+
+	const board = JXG.JSXGraph.initBoard(boardId + '-plot1', {
+		boundingbox: [0, 12.2, 16, 0],
+		axis: false,
+		showCopyright: false,
+		showNavigation: false,
+		pan: { enabled: false },
+		zoom: { enabled: false },
+	});
+
+	const baseText = 'font-family: sans-serif; text-align: center; line-height: 1.25;';
+
+	// --- node factory: centered box (polygon) + html text ---
+	function makeNode(cx, cy, w, h, html, kind) {
+		const half = { x: w / 2, y: h / 2 };
+		const box = board.create('polygon', [
+			[cx - half.x, cy - half.y], [cx + half.x, cy - half.y],
+			[cx + half.x, cy + half.y], [cx - half.x, cy + half.y],
+		], {
+			fillColor: kind === 'question' ? QUESTION_FILL : METHOD_FILL,
+			fillOpacity: 1,
+			highlight: false,
+			hasInnerPoints: false,
+			vertices: { visible: false, fixed: true },
+			borders: { strokeColor: BORDER_IDLE, strokeWidth: 1.5, highlight: false, fixed: true },
+			fixed: true,
+		});
+		const label = board.create('text', [cx, cy, html], {
+			anchorX: 'middle',
+			anchorY: 'middle',
+			fixed: true,
+			highlight: false,
+			cssStyle: baseText + ' font-size: 13px;',
+		});
+		return { box, label, cx, cy, w, h, kind };
+	}
+
+	function setNodeState(node, state) {
+		// state: 'idle' | 'active' | 'done'
+		const fill = state === 'active' ? ACTIVE_FILL
+			: state === 'done' ? DONE_FILL
+			: (node.kind === 'question' ? QUESTION_FILL : METHOD_FILL);
+		const stroke = state === 'active' ? BORDER_ACTIVE
+			: state === 'done' ? BORDER_DONE
+			: BORDER_IDLE;
+		node.box.setAttribute({ fillColor: fill });
+		node.box.borders.forEach(b => b.setAttribute({
+			strokeColor: stroke,
+			strokeWidth: state === 'idle' ? 1.5 : 3,
+		}));
+	}
+
+	// --- edge factory: arrow + yes/no tag ---
+	function makeEdge(from, to, answer) {
+		let p1, p2, tagPos;
+		if (Math.abs(from.cx - to.cx) < 0.01) {
+			// vertical drop
+			p1 = [from.cx, from.cy - from.h / 2];
+			p2 = [to.cx, to.cy + to.h / 2];
+			tagPos = [from.cx + 0.45, (p1[1] + p2[1]) / 2];
+		} else {
+			// horizontal hop
+			p1 = [from.cx + from.w / 2, from.cy];
+			p2 = [to.cx - to.w / 2, to.cy];
+			tagPos = [(p1[0] + p2[0]) / 2, from.cy + 0.38];
+		}
+		const arrow = board.create('arrow', [p1, p2], {
+			strokeColor: EDGE_IDLE,
+			strokeWidth: 2,
+			fixed: true,
+			highlight: false,
+		});
+		const tag = board.create('text', [tagPos[0], tagPos[1], answer], {
+			anchorX: 'middle',
+			anchorY: 'middle',
+			fixed: true,
+			highlight: false,
+			cssStyle: baseText + ' font-size: 12px; font-style: italic; color: #666;',
+		});
+		return { arrow, tag };
+	}
+
+	function setEdgeState(edge, taken) {
+		edge.arrow.setAttribute({
+			strokeColor: taken ? EDGE_TAKEN : EDGE_IDLE,
+			strokeWidth: taken ? 3.5 : 2,
+		});
+		edge.tag.setAttribute({
+			cssStyle: baseText + ' font-size: 12px; font-style: italic; color: '
+				+ (taken ? EDGE_TAKEN : '#666') + ';'
+				+ (taken ? ' font-weight: bold;' : ''),
+		});
+	}
+
+	// --- layout ---
+	const qX = 4.6, mX = 11.8;
+	const nodes = {
+		start: makeNode(qX, 11.3, 6.4, 1.1,
+			'<b>Start:</b> a differential equation to solve', 'question'),
+		q1: makeNode(qX, 9.3, 6.4, 1.3,
+			'Is the equation <b>first order</b>?<br>(highest derivative is y&prime;)', 'question'),
+		mHigher: makeNode(mX, 9.3, 7.0, 1.3,
+			'<b>Higher-order equation</b><br>new tools coming in later chapters', 'method'),
+		q2: makeNode(qX, 7.1, 6.4, 1.3,
+			'Is it <b>already a derivative</b>?<br>d&frasl;dx[ &hellip; ] = f(x)', 'question'),
+		mDI: makeNode(mX, 7.1, 7.0, 1.3,
+			'<b>Direct Integration</b><br>integrate both sides', 'method'),
+		q3: makeNode(qX, 4.9, 6.4, 1.3,
+			'Is it <b>separable</b>?<br>y&prime; = f(x)&middot;g(y)', 'question'),
+		mSOV: makeNode(mX, 4.9, 7.0, 1.3,
+			'<b>Separation of Variables</b><br>separate, then integrate', 'method'),
+		q4: makeNode(qX, 2.7, 6.4, 1.3,
+			'Is it <b>linear</b>?<br>y&prime; + P(x)y = Q(x)', 'question'),
+		mIF: makeNode(mX, 2.7, 7.0, 1.3,
+			'<b>Integrating Factor</b><br>multiply by &mu;(x) = e<sup>&int;P(x)dx</sup>', 'method'),
+		mNone: makeNode(qX, 0.7, 8.6, 1.2,
+			'<b>No formula method (yet)</b> &mdash; try qualitative or numerical tools', 'method'),
+	};
+
+	const edges = {
+		startq1: makeEdge(nodes.start, nodes.q1, ''),
+		q1no: makeEdge(nodes.q1, nodes.mHigher, 'no'),
+		q1yes: makeEdge(nodes.q1, nodes.q2, 'yes'),
+		q2yes: makeEdge(nodes.q2, nodes.mDI, 'yes'),
+		q2no: makeEdge(nodes.q2, nodes.q3, 'no'),
+		q3yes: makeEdge(nodes.q3, nodes.mSOV, 'yes'),
+		q3no: makeEdge(nodes.q3, nodes.q4, 'no'),
+		q4yes: makeEdge(nodes.q4, nodes.mIF, 'yes'),
+		q4no: makeEdge(nodes.q4, nodes.mNone, 'no'),
+	};
+
+	// --- decision logic ---
+	const flow = {
+		q1: { yes: { node: 'q2', edge: 'q1yes' }, no: { node: 'mHigher', edge: 'q1no' } },
+		q2: { yes: { node: 'mDI', edge: 'q2yes' }, no: { node: 'q3', edge: 'q2no' } },
+		q3: { yes: { node: 'mSOV', edge: 'q3yes' }, no: { node: 'q4', edge: 'q3no' } },
+		q4: { yes: { node: 'mIF', edge: 'q4yes' }, no: { node: 'mNone', edge: 'q4no' } },
+	};
+
+	let current = 'q1';
+
+	function reset() {
+		Object.values(nodes).forEach(n => setNodeState(n, 'idle'));
+		Object.values(edges).forEach(e => setEdgeState(e, false));
+		setEdgeState(edges.startq1, true);
+		current = 'q1';
+		setNodeState(nodes.q1, 'active');
+		board.update();
+	}
+
+	function answer(ans) {
+		if (!flow[current]) { return; } // already at a terminal node
+		const step = flow[current][ans];
+		const nextKey = step.node;
+		setEdgeState(edges[step.edge], true);
+		setNodeState(nodes[current], 'idle');
+		if (flow[nextKey]) {
+			setNodeState(nodes[nextKey], 'active');
+		} else {
+			setNodeState(nodes[nextKey], 'done');
+		}
+		current = nextKey;
+		board.update();
+	}
+
+	// --- buttons ---
+	function makeButton(cx, cy, w, h, textStr, fill, handler) {
+		const half = { x: w / 2, y: h / 2 };
+		const btn = board.create('polygon', [
+			[cx - half.x, cy - half.y], [cx + half.x, cy - half.y],
+			[cx + half.x, cy + half.y], [cx - half.x, cy + half.y],
+		], {
+			fillColor: fill,
+			fillOpacity: 1,
+			highlight: false,
+			vertices: { visible: false, fixed: true },
+			borders: { strokeColor: '#555555', strokeWidth: 1.5, highlight: false, fixed: true },
+			fixed: true,
+		});
+		const lbl = board.create('text', [cx, cy, '<b>' + textStr + '</b>'], {
+			anchorX: 'middle',
+			anchorY: 'middle',
+			fixed: true,
+			highlight: false,
+			cssStyle: baseText + ' font-size: 13px; cursor: pointer;',
+		});
+		btn.on('down', handler);
+		lbl.on('down', handler);
+		return btn;
+	}
+
+	makeButton(12.2, 11.55, 1.7, 0.9, 'Yes', '#c9e7cd', () => answer('yes'));
+	makeButton(14.2, 11.55, 1.7, 0.9, 'No', '#f6cfcf', () => answer('no'));
+	makeButton(13.2, 10.35, 2.2, 0.8, 'Reset', '#e2e2e2', reset);
+
+	board.create('text', [13.2, 0.7,
+		'If an equation is <i>both</i> separable and linear,<br>either tool works &mdash; pick the faster one.'], {
+		anchorX: 'middle',
+		anchorY: 'middle',
+		fixed: true,
+		highlight: false,
+		cssStyle: baseText + ' font-size: 11.5px; color: #666;',
+	});
+
+	reset();
+})();

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 from sympy import (
+    DiracDelta,
     E,
     Matrix,
     FiniteSet,
@@ -535,6 +536,211 @@ REGISTRY += [
             # y = 0: y' = 0 and 3*(0^2)^(1/3) = 0
             and 3 * (0**2) ** R(1, 3) == 0
         ),
+    ),
+]
+
+
+# ----------------------------------------------------------------------
+# H9 — cumulative mixed-method reviews (chapters 5, 9, 12)
+# ----------------------------------------------------------------------
+REGISTRY += [
+    # --- Chapter 5 review: choosing a first-order method ---
+    Check(
+        "c5 review R1: y=2x^3-2x^2+x+1 solves y'=6x^2-4x+1, y(1)=2",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x) - (6 * x**2 - 4 * x + 1)) and Y.subs(x, 1) == 2
+        )(2 * x**3 - 2 * x**2 + x + 1),
+    ),
+    Check(
+        "c5 review R2: y=sqrt(9-x^2) solves y'=-x/y, y(0)=3",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x) + x / Y) and Y.subs(x, 0) == 3
+        )(sqrt(9 - x**2)),
+    ),
+    Check(
+        "c5 review R3: y=2-e^(-2x) solves y'+2y=4, y(0)=1 (both-methods bridge)",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x) + 2 * Y - 4) and Y.subs(x, 0) == 1
+        )(2 - exp(-2 * x)),
+    ),
+    Check(
+        "c5 review R4: y=x^2/4+C1/x^2 solves xy'+2y=x^2",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (
+            lambda Y: is_zero(x * diff(Y, x) + 2 * Y - x**2)
+        )(x**2 / 4 + C1 / x**2),
+    ),
+    Check(
+        "c5 review R5: y=ln(e^x+c) solves y'=e^(x-y)",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x) - exp(x - Y))
+        )(log(exp(x) + c)),
+    ),
+    Check(
+        "c5 review R6: y=e^(-x)(sin x+C1) solves e^x y'+e^x y=cos x",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (
+            lambda Y: is_zero(exp(x) * diff(Y, x) + exp(x) * Y - cos(x))
+        )(exp(-x) * (sin(x) + C1)),
+    ),
+    Check(
+        "c5 review quiz 7 feedback: x^2 y=2x^2+C i.e. y=2+C1/x^2 solves x^2 y'+2xy=4x",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (
+            lambda Y: is_zero(x**2 * diff(Y, x) + 2 * x * Y - 4 * x)
+        )(2 + C1 / x**2),
+    ),
+    # --- Chapter 9 review: constant-coefficient equations ---
+    Check(
+        "c9 review P1: y=C1 e^(3x)+C2 e^(-2x) solves y''-y'-6y=0",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x, 2) - diff(Y, x) - 6 * Y)
+        )(C1 * exp(3 * x) + C2 * exp(-2 * x)),
+    ),
+    Check(
+        "c9 review P2: y=e^(-2x)(C1 cos 3x+C2 sin 3x) solves y''+4y'+13y=0",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x, 2) + 4 * diff(Y, x) + 13 * Y)
+        )(exp(-2 * x) * (C1 * cos(3 * x) + C2 * sin(3 * x))),
+    ),
+    Check(
+        "c9 review P3: y=(C1+C2 x)e^(-3x) solves y''+6y'+9y=0",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x, 2) + 6 * diff(Y, x) + 9 * Y)
+        )((C1 + C2 * x) * exp(-3 * x)),
+    ),
+    Check(
+        "c9 review P4: y=C1 e^x+C2 e^(2x)+2x+3 solves y''-3y'+2y=4x",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x, 2) - 3 * diff(Y, x) + 2 * Y - 4 * x)
+        )(C1 * exp(x) + C2 * exp(2 * x) + 2 * x + 3),
+    ),
+    Check(
+        "c9 review P5: y=C1 e^(2x)+C2 e^(-2x)+2xe^(2x) solves y''-4y=8e^(2x)",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x, 2) - 4 * Y - 8 * exp(2 * x))
+        )(C1 * exp(2 * x) + C2 * exp(-2 * x) + 2 * x * exp(2 * x)),
+    ),
+    Check(
+        "c9 review P6: y=7e^(2x)-2 solves y'-2y=4, y(0)=5",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x) - 2 * Y - 4) and Y.subs(x, 0) == 5
+        )(7 * exp(2 * x) - 2),
+    ),
+    Check(
+        "c9 review P7: y=C1 cos x+C2 sin x-(5/3)sin 2x solves y''+y=5 sin 2x",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x, 2) + Y - 5 * sin(2 * x))
+        )(C1 * cos(x) + C2 * sin(x) - R(5, 3) * sin(2 * x)),
+    ),
+    Check(
+        "c9 review quiz 3 feedback: y=2+C1 e^(-3x) solves y'+3y=6",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x) + 3 * Y - 6)
+        )(2 + C1 * exp(-3 * x)),
+    ),
+    Check(
+        "c9 review quiz 6 feedback: y=C1 ln x+C2 solves x y''+y'=0",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(x * diff(Y, x, 2) + diff(Y, x))
+        )(C1 * log(x) + C2),
+    ),
+    Check(
+        "c9 review quiz 7 feedback: y=c1+c2 e^x+c3 e^(-x) solves y'''-y'=0",
+        "source/c9-uc/review-constant-coefficient.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, x, 3) - diff(Y, x))
+        )(C1 + C2 * exp(x) + symbols("C3") * exp(-x)),
+    ),
+    # --- Chapter 12 review: full-toolkit method selection ---
+    Check(
+        "c12 review L1: y=3e^(-2t) solves y'+2y=0, y(0)=3; Y(s)=3/(s+2)",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, t) + 2 * Y) and Y.subs(t, 0) == 3
+            and laplace_matches(Y, 3 / (s + 2))
+        )(3 * exp(-2 * t)),
+    ),
+    Check(
+        "c12 review L2: y=1-cos t solves y''+y=1, y(0)=y'(0)=0; PFD of 1/(s(s^2+1))",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, t, 2) + Y - 1)
+            and Y.subs(t, 0) == 0 and diff(Y, t).subs(t, 0) == 0
+            and is_zero(1 / (s * (s**2 + 1)) - (1 / s - s / (s**2 + 1)))
+        )(1 - cos(t)),
+    ),
+    Check(
+        "c12 review L3: y=(1-e^(-(t-2)))u_2(t) solves y'+y=u_2(t), y(0)=0",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(
+                simplify(diff(Y, t) + Y - Heaviside(t - 2)).replace(
+                    DiracDelta(t - 2), 0
+                )
+            )
+            and is_zero(1 / (s * (s + 1)) - (1 / s - 1 / (s + 1)))
+        )(Heaviside(t - 2) * (1 - exp(-(t - 2)))),
+    ),
+    Check(
+        "c12 review L4: y=2-3e^t+e^(3t) solves y''-4y'+3y=6, y(0)=y'(0)=0; PFD",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, t, 2) - 4 * diff(Y, t) + 3 * Y - 6)
+            and Y.subs(t, 0) == 0 and diff(Y, t).subs(t, 0) == 0
+            and is_zero(
+                6 / (s * (s - 1) * (s - 3)) - (2 / s - 3 / (s - 1) + 1 / (s - 3))
+            )
+        )(2 - 3 * exp(t) + exp(3 * t)),
+    ),
+    Check(
+        "c12 review L5: y=4e^(-t^2) solves y'=-2ty, y(0)=4",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, t) + 2 * t * Y) and Y.subs(t, 0) == 4
+        )(4 * exp(-(t**2))),
+    ),
+    Check(
+        "c12 review L6: y=e^(-t)(c1 cos 2t+c2 sin 2t) solves y''+2y'+5y=0",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, t, 2) + 2 * diff(Y, t) + 5 * Y)
+        )(exp(-t) * (C1 * cos(2 * t) + C2 * sin(2 * t))),
+    ),
+    Check(
+        "c12 review quiz 3 feedback: y_p=2e^t solves y''+3y'+2y=12e^t; L{12e^t}=12/(s-1)",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, t, 2) + 3 * diff(Y, t) + 2 * Y - 12 * exp(t))
+            and laplace_matches(12 * exp(t), 12 / (s - 1))
+        )(2 * exp(t)),
+    ),
+    Check(
+        "c12 review quiz 4 feedback: y=C1 e^(-t^2/2) solves y'+ty=0",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, t) + t * Y)
+        )(C1 * exp(-(t**2) / 2)),
+    ),
+    Check(
+        "c12 review quiz 5 feedback: y=c1 cos 3t+c2 sin 3t solves y''+9y=0",
+        "source/c12-ltp/review-choosing-a-method.ptx",
+        lambda: (
+            lambda Y: is_zero(diff(Y, t, 2) + 9 * Y)
+        )(C1 * cos(3 * t) + C2 * sin(3 * t)),
     ),
 ]
 

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -42,10 +42,10 @@
 			respective divisions. Can't be more than the @level on 
 			divisions above.
 		-->
-		<blocks		level="0" />
-		<projects	level="0" />
-		<equations	level="1" />
-		<footnotes	level="0" />
+		<blocks level="0" />
+		<projects level="0" />
+		<equations level="0" />
+		<footnotes level="0" />
 	</numbering>
 
 	<!--

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# This file was automatically generated with PreTeXt 2.39.0.
-pretext == 2.39.0
+# This file was automatically generated with PreTeXt 2.44.0.
+pretext == 2.44.0

--- a/source/aa-bookends/a2-calculus/F-ibp.ptx
+++ b/source/aa-bookends/a2-calculus/F-ibp.ptx
@@ -15,9 +15,9 @@
 
 	<p>
 		Integration by parts may be a good choice when the integrand contains a product. Recall the formula for integration by parts.
-		<men xml:id="ibp-formula">
+		<md xml:id="ibp-formula">
 			\int u \cdot dv = u\cdot v - \int v \cdot du
-		</men>
+		</md>
 	</p>
 
 	<p>
@@ -28,9 +28,9 @@
 		
 		<p>
 			We choose <m>u</m> and <m>dv</m> as follows:
-			<me>  u = \ln t \hspace{2cm} dv = t^3 \ dt. </me>
+			<md>  u = \ln t \hspace{2cm} dv = t^3 \ dt. </md>
 			Then we find <m>du</m> by taking the derivative of <m>u</m> and <m>v</m> by taking the antiderivative of <m>dv</m>:
-			<me> du = \frac{1}{t}dt  \hspace{2cm} v = \frac{1}{4}t^4. </me>
+			<md> du = \frac{1}{t}dt  \hspace{2cm} v = \frac{1}{4}t^4. </md>
 			Thus we have:
 			<md>
 				<mrow>\int t^3 \ln t dt	\amp = \int  \ln t \cdot t^3dt					</mrow>
@@ -56,10 +56,10 @@
 				<solution>
 					<p>
 				We choose <m>u</m> and <m>dv</m> as follows:
-					<me>  u = x-1 \hspace{2cm} dv = e^x dx. </me>
+					<md>  u = x-1 \hspace{2cm} dv = e^x dx. </md>
 					Then we find <m>du</m> by taking the derivative of <m>u</m> and <m>v</m> by
 					taking the antiderivative of <m>dv</m>:
-					<me> du = dx  \hspace{2cm} v = e^x. </me>
+					<md> du = dx  \hspace{2cm} v = e^x. </md>
 					Thus we have:
 					<md>
 						<mrow>\int (x - 1)e^x dx	\amp = \int \ub{(x - 1)}_{u}
@@ -73,17 +73,17 @@
 					</md>
 					</p>
 				</solution>
-				<answer> <me> (x-2)e^x + C </me> </answer>
+				<answer> <md> (x-2)e^x + C </md> </answer>
 			</li>
 			<li>
 				<m>\ds \int x^2 \sin x \ dx \qquad</m>
 				<solution>
 					<p>
 				We choose <m>u</m> and <m>dv</m> as follows:
-					<me>  u = x^2 \hspace{2cm} dv = \sin x \ dx. </me>
+					<md>  u = x^2 \hspace{2cm} dv = \sin x \ dx. </md>
 					Then we find <m>du</m> by taking the derivative of <m>u</m> and <m>v</m> by
 					taking the antiderivative of <m>dv</m>:
-					<me> du = 2xdx  \hspace{2cm} v = -\cos x. </me>
+					<md> du = 2xdx  \hspace{2cm} v = -\cos x. </md>
 					Thus we have:
 					<md>
 						<mrow>\int x^2 \sin x dx\amp = \int \ub{x^2}_{u}
@@ -96,10 +96,10 @@
 					The remaining integral, <m>\int 2x\cos x dx,</m> is simpler than the one we
 					started with, but we will need to do another integration by parts in order to
 					evaluate it.  Here we choose
-					<me>  u = 2x \hspace{2cm} dv = \cos x dx. </me>
+					<md>  u = 2x \hspace{2cm} dv = \cos x dx. </md>
 					Then we find <m>du</m> by taking the derivative of <m>u</m> and <m>v</m> by
 					taking the antiderivative of <m>dv</m>:
-					<me> du = 2dx  \hspace{2cm} v = \sin x. </me>
+					<md> du = 2dx  \hspace{2cm} v = \sin x. </md>
 					Now we pick up where we left off:
 					<md>
 						<mrow>\int x^2 \sin x dx\amp = -x^2\cos x + \int 2x\cos x dx</mrow>
@@ -116,7 +116,7 @@
 					</md>
 					</p>
 				</solution>
-				<answer> <me> (2-x^2)\cos x + 2x\sin x +C </me> </answer>
+				<answer> <md> (2-x^2)\cos x + 2x\sin x +C </md> </answer>
 			</li>
 		</ol>
 	</p>
@@ -132,7 +132,7 @@
 			<title>Breaking Down the Integration by Parts Formula</title>
 			<p>
 			Let's break down the formula for integration by parts:
-			<me> \int u\, dv = uv - \int v\, du </me>.
+			<md> \int u\, dv = uv - \int v\, du </md>.
 			</p>
 			<p>
 			Here's how it works:
@@ -149,7 +149,7 @@
 			<title>Example: Applying Integration by Parts</title>
 			<p>
 			Consider the integral:
-			<me> \int t \, e^t \, dt </me>.
+			<md> \int t \, e^t \, dt </md>.
 			</p>
 			<p>
 			We'll apply integration by parts, following these steps:
@@ -163,23 +163,23 @@
 				<li>
 					<title>Step 2:</title>
 					<p>Step 2: Substitute into the integration by parts formula:
-					<me> \int t \, e^t \, dt = t \, e^t - \int e^t \, dt </me>.</p>
+					<md> \int t \, e^t \, dt = t \, e^t - \int e^t \, dt </md>.</p>
 				</li>
 				<li>
 					<title>Step 3:</title>
 					<p>Step 3: Solve the remaining integral:
-					<me> \int e^t \, dt = e^t </me>.</p>
+					<md> \int e^t \, dt = e^t </md>.</p>
 				</li>
 				<li>
 					<title>Step 4:</title>
 					<p>Step 4: Combine the results:
-					<me> t \, e^t - e^t + C </me>.</p>
+					<md> t \, e^t - e^t + C </md>.</p>
 				</li>
 			</dl>
 			
 			<p>
 			And that's the final result:
-			<me> \int t \, e^t \, dt = t \, e^t - e^t + C </me>.
+			<md> \int t \, e^t \, dt = t \, e^t - e^t + C </md>.
 			</p>
 		</subsubsection>
 		

--- a/source/aa-bookends/a3-quickref/c1-qref-basics.ptx
+++ b/source/aa-bookends/a3-quickref/c1-qref-basics.ptx
@@ -59,14 +59,13 @@
 							The highest order derivative present in a DE.
 						</p>
 					</li>
-					<li xml:id="summary-linear-term"><title>Linear Term</title>
+					<li xml:id="summary-linear-term">
+						<title>Linear Term</title>
 						<p>
 							A term of the form:
-						</p>
-						<p>
-							<me>a(t)\ y,\ a(t)\ y',\ a(t)\ y'',\ a(t)\ y''',\ \ldots</me>,
-						</p>
-						<p>
+							<md>
+								a(t)\ y,\ a(t)\ y',\ a(t)\ y'',\ a(t)\ y''',\ \ldots
+							</md>,
 							where <m>y</m> is the dependent variable, and <m>a(t)</m> is a coefficient that depends only on the independent variable <m>t</m>.
 						</p>
 					</li>

--- a/source/aa-bookends/back-matter.ptx
+++ b/source/aa-bookends/back-matter.ptx
@@ -16,7 +16,7 @@
 
 	<xi:include href="./glossary.ptx" />
 
-	<appendix label="review-topics">
+	<!-- <appendix label="review-topics">
 		<title>Review: Algebra Topics</title>
 
 		<xi:include href="./a1-algebra/LTM-like-terms.ptx" />
@@ -36,18 +36,18 @@
 		<xi:include href="./a1-algebra/O-interrelated-functions.ptx" />
 		<xi:include href="./a1-algebra/P-units-mass-balance.ptx" />
 	
-	</appendix>
+	</appendix> -->
 
 	<appendix label="calculus-review">
 		<title>Review: Calculus Topics</title>
 
-		<xi:include href="./a2-calculus/A-limits.ptx" />
-		<xi:include href="./a2-calculus/B-lhospital.ptx" />
-		<xi:include href="./a2-calculus/C-differentiation.ptx" />
-		<xi:include href="./a2-calculus/D-product-rule.ptx" />
-		<xi:include href="./a2-calculus/E-usub.ptx" />
+		<!-- <xi:include href="./a2-calculus/A-limits.ptx" /> -->
+		<!-- <xi:include href="./a2-calculus/B-lhospital.ptx" /> -->
+		<!-- <xi:include href="./a2-calculus/C-differentiation.ptx" /> -->
+		<!-- <xi:include href="./a2-calculus/D-product-rule.ptx" /> -->
+		<!-- <xi:include href="./a2-calculus/E-usub.ptx" /> -->
 		<xi:include href="./a2-calculus/F-ibp.ptx" />
-		<xi:include href="./a2-calculus/G-improper-integrals.ptx" />
+		<!-- <xi:include href="./a2-calculus/G-improper-integrals.ptx" /> -->
 	</appendix>
 	
 	<!-- <appendix>
@@ -75,17 +75,17 @@
 			</aside>
 
 			<xi:include href="./a3-quickref/c1-qref-basics.ptx" />
-			<xi:include href="./a3-quickref/c2-qref-solns.ptx" />
-			<xi:include href="./a3-quickref/c3-qref-sov.ptx" />
-			<xi:include href="./a3-quickref/c4-qref-if.ptx" />
-			<xi:include href="./a3-quickref/c5-qref-qm.ptx" />
-			<xi:include href="./a3-quickref/c6-qref-nm.ptx" />
-			<xi:include href="./a3-quickref/c7-qref-lhcc.ptx" />
-			<xi:include href="./a3-quickref/c8-qref-uc.ptx" />
-			<xi:include href="./a3-quickref/c9-qref-lt.ptx" />
-			<xi:include href="./a3-quickref/c10-qref-ltm.ptx" />
-			<xi:include href="./a3-quickref/c11-qref-ltp.ptx" />
-			<xi:include href="./a3-quickref/c12-qref-linsys1.ptx" />
+			<!-- <xi:include href="./a3-quickref/c2-qref-solns.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c3-qref-sov.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c4-qref-if.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c5-qref-qm.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c6-qref-nm.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c7-qref-lhcc.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c8-qref-uc.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c9-qref-lt.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c10-qref-ltm.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c11-qref-ltp.ptx" /> -->
+			<!-- <xi:include href="./a3-quickref/c12-qref-linsys1.ptx" /> -->
 		</section>
 
 

--- a/source/aa-bookends/glossary.ptx
+++ b/source/aa-bookends/glossary.ptx
@@ -414,9 +414,9 @@
     <title>separable form</title>
     <p>
       Separable form is the product form
-      <me>
-        \dfrac{dy}{dx}=f(x)\cdot g(y)
-      </me>
+      <md>
+        \frac{dy}{dx}=f(x)\cdot g(y)
+      </md>
       where one factor depends only on the independent variable and the other depends 
       only on the dependent variable. For example, 
       <md>
@@ -825,9 +825,9 @@
     <title>like terms</title>
     <p>
       In differential equation work, like terms are expressions with the same variable or function part that differ only by a constant coefficient. They can be combined by addition or subtraction.
-      <me>
+      <md>
         5e^{3x} - 2e^{3x} = 3e^{3x}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -835,9 +835,9 @@
     <title>constant coefficients</title>
     <p>
       A <xref ref="gi-linear-differential-equation" text="title"/> has constant coefficients if the coefficients of <m>y</m> and its derivatives are constants rather than functions of the independent variable.
-      <me>
+      <md>
         2y'' - 3y' + 5y = 0
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -845,9 +845,9 @@
     <title>homogeneous (linear differential equation)</title>
     <p>
       A <xref ref="gi-linear-differential-equation" text="title"/> is homogeneous if its <xref ref="gi-forcing-term-function" text="title"/> is zero.
-      <me>
+      <md>
         y'' - 3y' + 2y = 0
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -855,9 +855,9 @@
     <title>nonhomogeneous (linear differential equation)</title>
     <p>
       A <xref ref="gi-linear-differential-equation" text="title"/> is nonhomogeneous if its <xref ref="gi-forcing-term-function" text="title"/> is nonzero.
-      <me>
+      <md>
         y'' - 3y' + 2y = e^x
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -865,9 +865,9 @@
     <title>linear homogeneous constant coefficient (LHCC) differential equation</title>
     <p>
       A <xref ref="gi-linear-differential-equation" text="title"/> that is both <xref ref="gi-homogeneous-linear-differential-equation" text="custom">homogeneous</xref> and has <xref ref="gi-constant-coefficients" text="title"/>, so each <m>a_k</m> below is a constant.
-      <me>
+      <md>
         a_n y^{(n)} + a_{n-1} y^{(n-1)} + \cdots + a_1 y' + a_0 y = 0
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -875,9 +875,9 @@
     <title>characteristic equation</title>
     <p>
       The polynomial equation obtained from an <xref ref="gi-lhcc-equation" text="custom">LHCC equation</xref> by assuming an exponential solution, which reduces the differential equation to a polynomial in <m>r</m>.
-      <me>
+      <md>
         y=e^{rx}, \quad ay'' + by' + cy = 0 \quad\Rightarrow\quad ar^2 + br + c = 0
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -885,9 +885,9 @@
     <title>fundamental solutions</title>
     <p>
       The basic solution functions corresponding to the roots of the <xref ref="gi-characteristic-equation" text="title"/>, used to build the <xref ref="gi-general-solution" text="title"/> of an <xref ref="gi-lhcc-equation" text="custom">LHCC equation</xref>.
-      <me>
+      <md>
         r_1 = 2,\ r_2 = -1 \quad\Rightarrow\quad e^{2x},\ e^{-x}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -895,9 +895,9 @@
     <title>superposition principle</title>
     <p>
       If <m>y_1</m> and <m>y_2</m> are solutions of the same homogeneous linear differential equation, then every linear combination of them is also a solution.
-      <me>
+      <md>
         y_1,\ y_2 \text{ solve } ay'' + by' + cy = 0 \quad\Rightarrow\quad c_1y_1 + c_2y_2 \text{ also solves it}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -905,9 +905,9 @@
     <title>linear dependence</title>
     <p>
       A set of solutions is linearly dependent on an interval if there exist constants (not all zero) such that a linear combination of the solutions equals zero.
-      <me>
+      <md>
         1\bigl(3e^{2x}\bigr) - 3\bigl(e^{2x}\bigr) = 0
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -915,9 +915,9 @@
     <title>linear independence</title>
     <p>
       A set of solutions is linearly independent on an interval if the only linear combination that equals zero is the one with all coefficients equal to zero.
-      <me>
+      <md>
         c_1 e^{2x} + c_2 e^{-x} = 0 \Rightarrow c_1 = c_2 = 0
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -925,9 +925,9 @@
     <title>repeated root</title>
     <p>
       A repeated root is a root of the <xref ref="gi-characteristic-equation" text="title"/> that appears more than once, indicated by an exponent greater than <m>1</m> in the factored form of the characteristic polynomial.
-      <me>
+      <md>
         (r-3)^2 = 0 \quad\text{has a repeated root } r=3
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -935,9 +935,9 @@
     <title>multiplicity (of a root)</title>
     <p>
       The multiplicity of a root is the number of times that root occurs in the <xref ref="gi-characteristic-equation" text="title"/>.
-      <me>
+      <md>
         (r+1)^3 = 0 \quad\text{gives } r=-1 \text{ with multiplicity } 3
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -945,9 +945,9 @@
     <title>complex conjugate roots</title>
     <p>
       A pair of roots of the form <m>\alpha \pm i\beta</m>. For an <xref ref="gi-lhcc-equation" text="custom">LHCC equation</xref>, they contribute
-      <me>
+      <md>
         e^{\alpha x}\bigl(c_1\cos(\beta x) + c_2\sin(\beta x)\bigr)
-      </me>
+      </md>
       to the <xref ref="gi-general-solution" text="title"/>.
     </p>
   </gi>
@@ -956,9 +956,9 @@
     <title>characteristic polynomial</title>
     <p>
       The polynomial on the left side of a <xref ref="gi-characteristic-equation" text="title"/>. Its roots determine the form of the <xref ref="gi-general-solution" text="title"/>.
-      <me>
+      <md>
         y^{(4)} - 5y'' + 4y = 0 \quad\Rightarrow\quad r^4 - 5r^2 + 4
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -966,9 +966,9 @@
     <title>rational root theorem</title>
     <p>
       For a polynomial with integer coefficients, any rational root <m>\frac{p}{q}</m> in lowest terms must have <m>p</m> dividing the constant term and <m>q</m> dividing the leading coefficient. This helps narrow the possible rational roots of a <xref ref="gi-characteristic-polynomial" text="title"/>.
-      <me>
+      <md>
         2r^2 - 5r + 3 = 0 \Rightarrow \text{candidate rational roots are } \pm 1,\ \pm 3,\ \pm \frac{1}{2},\ \pm \frac{3}{2}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -980,9 +980,9 @@
     <title>linear nonhomogeneous constant coefficient (LNCC) differential equation</title>
     <p>
       A <xref ref="gi-linear-differential-equation" text="title"/> with <xref ref="gi-constant-coefficients" text="title"/> and a nonzero <xref ref="gi-forcing-term-function" text="title"/>, of the form
-      <me>
+      <md>
         a_n y^{(n)} + a_{n-1} y^{(n-1)} + \cdots + a_1 y' + a_0 y = f(x)
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -990,13 +990,13 @@
     <title>homogeneous solution</title>
     <p>
       For an <xref ref="gi-lncc-equation" text="custom">LNCC equation</xref>, the homogeneous solution, <m>y_h</m>, solves the associated homogeneous equation
-      <me>
+      <md>
         a_n y^{(n)} + a_{n-1} y^{(n-1)} + \cdots + a_1 y' + a_0 y = 0
-      </me>
+      </md>
       It is also called the complementary solution. The general solution combines the homogeneous and particular solutions:
-      <me>
+      <md>
         y = y_h + y_p
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1005,9 +1005,9 @@
     <p>
       The initially unknown constants in a guessed particular solution form that are determined by substituting into the differential equation and matching coefficients of like terms.
       For example, when the forcing function is a quadratic polynomial:
-      <me>
+      <md>
         y_p = Ax^2 + Bx + C
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1016,9 +1016,9 @@
     <p>
       If a term in the initial guess for <m>y_p</m> also appears in the <xref ref="gi-homogeneous-solution-lncc" text="custom">homogeneous solution</xref>, multiply any overlapping term in <m>y_p</m> by the smallest power of <m>x</m> that eliminates the overlap.
       For example, if <m>e^{3x}</m> already appears in <m>y_h</m>:
-      <me>
+      <md>
         Ae^{3x} \to Axe^{3x}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1037,9 +1037,9 @@
     <title>integration by parts</title>
     <p>
       A calculus method that rewrites an integral of a product using the product rule:
-      <me>
+      <md>
         \int_a^b u\,dv = uv\Big|_a^b - \int_a^b v\,du
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1047,9 +1047,9 @@
     <title>derivative transfer</title>
     <p>
       The process of moving a derivative from one function to another inside an integral using <xref ref="gi-integration-by-parts" text="title"/>. In Laplace work, this usually moves the derivative off the unknown function:
-      <me>
+      <md>
         \int_0^\infty e^{-st}f'(t)\,dt \to s\int_0^\infty e^{-st}f(t)\,dt - f(0)
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1057,9 +1057,9 @@
     <title>Laplace transform</title>
     <p>
       A transform that converts a function of <m>t</m> into a function of <m>s</m>, defined by
-      <me>
+      <md>
         \lap{f(t)} = \int_0^\infty e^{-st}f(t)\,dt
-      </me>
+      </md>
       when the integral converges. The transformed function is commonly written <m>F(s)=\lap{f(t)}</m>.
     </p>
   </gi>
@@ -1068,9 +1068,9 @@
     <title>improper integral</title>
     <p>
       An integral with an infinite limit or an unbounded integrand, evaluated as a limit. For example,
-      <me>
+      <md>
         \int_0^\infty e^{-st}f(t)\,dt = \lim_{b\to\infty}\int_0^b e^{-st}f(t)\,dt
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1078,9 +1078,9 @@
     <title>existence condition for a Laplace transform</title>
     <p>
       A condition on <m>s</m> that guarantees the defining improper integral converges to a finite value. In this text's real-valued setting, for example:
-      <me>
+      <md>
         \lap{e^{at}}=\frac{1}{s-a}\quad \text{requires } s>a
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1088,9 +1088,9 @@
     <title>transform pair</title>
     <p>
       A function in the <m>t</m>-domain together with its Laplace transform in the <m>s</m>-domain.
-      <me>
+      <md>
         f(t)=\cos(bt)\quad \longleftrightarrow \quad F(s)=\frac{s}{s^2+b^2}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1098,9 +1098,9 @@
     <title>linearity property of the Laplace transform</title>
     <p>
       The Laplace transform preserves sums and constant multiples:
-      <me>
+      <md>
         \lap{af(t)\pm bg(t)}=a\lap{f(t)}\pm b\lap{g(t)}
-      </me>
+      </md>
       for constants <m>a,b</m>.
     </p>
   </gi>
@@ -1109,9 +1109,9 @@
     <title>derivative transfer property of the Laplace transform</title>
     <p>
       A rule for transforming derivatives that introduces initial conditions. First derivative form:
-      <me>
+      <md>
         \lap{f'(t)}=sF(s)-f(0),\quad F(s)=\lap{f(t)}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1119,9 +1119,9 @@
     <title>exponential shifting property</title>
     <p>
       Multiplying by <m>e^{at}</m> in the <m>t</m>-domain shifts <m>s</m> by <m>a</m> in the transform:
-      <me>
+      <md>
         \lap{e^{at}f(t)}=F(s-a)
-      </me>
+      </md>
       where <m>F(s)=\lap{f(t)}</m>, for values of <m>s</m> where the shifted transform converges.
     </p>
   </gi>
@@ -1130,9 +1130,9 @@
     <title>Laplace derivative property</title>
     <p>
       Multiplication by powers of <m>t</m> corresponds to derivatives with respect to <m>s</m>:
-      <me>
+      <md>
         \lap{t^n f(t)} = (-1)^n\frac{d^n}{ds^n}\Big[F(s)\Big],\quad n=1,2,3,\ldots
-      </me>
+      </md>
       where <m>F(s)=\lap{f(t)}</m>.
     </p>
   </gi>
@@ -1159,9 +1159,9 @@
     <title>forward transform</title>
     <p>
       In the Laplace transform method, the forward transform means applying the <xref ref="gi-laplace-transform" text="title"/> to both sides of a differential equation so it becomes an algebraic equation in the <xref ref="gi-s-domain" text="title"/>.
-      <me>
+      <md>
         \lap{y'' - 9y} = \lap{10e^{2t}} \quad\Rightarrow\quad s^2Y - 9Y - s + 7 = \frac{10}{s-2}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1169,9 +1169,9 @@
     <title>Laplace-domain equation</title>
     <p>
       The algebraic equation in <m>Y(s)</m> obtained after the <xref ref="gi-forward-transform" text="title"/> of a differential equation.
-      <me>
+      <md>
         s^2Y - 9Y - s + 7 = \frac{10}{s-2}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1179,9 +1179,9 @@
     <title>partial fraction decomposition (PFD)</title>
     <p>
       A method for rewriting a rational function as a sum of simpler rational terms, usually so each term can match an inverse Laplace transform form.
-      <me>
+      <md>
         \frac{2s+5}{(s+1)(s+4)} = \frac{1}{s+1} + \frac{1}{s+4}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1189,9 +1189,9 @@
     <title>completing the square</title>
     <p>
       An algebra step used to rewrite a quadratic denominator so it matches a standard inverse Laplace transform form.
-      <me>
+      <md>
         s^2 - 6s + 14 = (s-3)^2 + 5
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1199,9 +1199,9 @@
     <title>inverse Laplace transform</title>
     <p>
       The operation that recovers a function in the <xref ref="gi-time-domain" text="title"/> from its Laplace transform in the <xref ref="gi-s-domain" text="title"/>, undoing the <xref ref="gi-forward-transform" text="title"/>.
-      <me>
+      <md>
         \ilap{\frac{1}{s-a}} = e^{at}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1227,12 +1227,12 @@
     <title>unit step function (Heaviside function)</title>
     <p>
       The basic ON-OFF switch that jumps from <m>0</m> to <m>1</m> at <m>t=0</m>:
-      <me>
+      <md>
         u(t)=\begin{cases}
           1, &amp; t\ge 0\\
           0, &amp; t&lt;0
         \end{cases}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1240,12 +1240,12 @@
     <title>shifted unit step function</title>
     <p>
       A <xref ref="gi-unit-step-function" text="title"/> that turns ON at <m>t=c</m> instead of at <m>t=0</m>:
-      <me>
+      <md>
         u_c(t)=u(t-c)=\begin{cases}
           1, &amp; t\ge c\\
           0, &amp; t&lt;c
         \end{cases}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1253,12 +1253,12 @@
     <title>reversed unit step function</title>
     <p>
       A step switch that is ON before <m>t=c</m> and OFF afterward:
-      <me>
+      <md>
         1-u_c(t)=\begin{cases}
           1, &amp; t&lt;c\\
           0, &amp; t\ge c
         \end{cases}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1266,12 +1266,12 @@
     <title>windowed unit step function</title>
     <p>
       A switch that is ON only on a finite interval, built from two <xref ref="gi-shifted-unit-step-function" text="custom">shifted unit step functions</xref>:
-      <me>
+      <md>
         u_c(t)-u_d(t)=\begin{cases}
           1, &amp; c\le t&lt;d\\
           0, &amp; \text{otherwise}
         \end{cases}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1279,13 +1279,13 @@
     <title>piecewise function</title>
     <p>
       A function defined by different formulas on different parts of its domain. For example,
-      <me>
+      <md>
         g(t)=\begin{cases}
           \sin t, &amp; t&lt;0\\
           2e^{-t}, &amp; 0\le t&lt;2\\
           1.5, &amp; t\ge 2
         \end{cases}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1293,9 +1293,9 @@
     <title>unit step form</title>
     <p>
       A way to rewrite a <xref ref="gi-piecewise-function" text="title"/> as a single expression using step-function switches, such as
-      <me>
+      <md>
         g(t)=2t\bigl(u_0(t)-u_1(t)\bigr)+3\bigl(u_1(t)-u_4(t)\bigr)
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1310,9 +1310,9 @@
     <title>Laplace step rule for <m>u_c(t)</m></title>
     <p>
       The <xref ref="gi-laplace-transform" text="title"/> of a shifted unit step function:
-      <me>
+      <md>
         \lap{u_c(t)}=\frac{e^{-cs}}{s},\qquad s&gt;0
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1320,9 +1320,9 @@
     <title>Laplace step rule for <m>f(t)u_c(t)</m></title>
     <p>
       A rule for transforming a function that turns ON at <m>t=c</m>:
-      <me>
+      <md>
         \lap{f(t)u_c(t)}=e^{-cs}\lap{f(t+c)}
-      </me>
+      </md>
     </p>
   </gi>
 
@@ -1330,9 +1330,9 @@
     <title>Laplace step rule for <m>f(t-c)u_c(t)</m></title>
     <p>
       A rule for transforming a shifted function that starts at <m>t=c</m>:
-      <me>
+      <md>
         \lap{f(t-c)u_c(t)}=e^{-cs}F(s),\qquad F(s)=\lap{f(t)}
-      </me>
+      </md>
     </p>
   </gi>
 

--- a/source/c0-whats-a-de/sec-de-defn.ptx
+++ b/source/c0-whats-a-de/sec-de-defn.ptx
@@ -59,14 +59,16 @@
 
 		<p>
 			This means all of the following are differential equations:
-			<me>
+			<md>
 				\frac{dy}{dx} + 1 = y, \qquad f^{\prime\prime} + x^2 + 3x = 19, \qquad e^t = \tan(y^\prime).
-			</me>
+			</md>
 		</p>
 
 		<p>
 			On the other hand, these are not differential equations, either because they do not contain a derivative or because they do not include an equals sign:
-			<me>\frac{d^2 y}{dx^2} + 2\frac{dy}{dx}, \qquad \sin y + e^x = 0.</me>
+			<md>
+				\frac{d^2 y}{dx^2} + 2\frac{dy}{dx}, \qquad \sin y + e^x = 0.
+			</md>
 		</p>
 
 		<exercise label="whats-a-de-cyu-2">

--- a/source/c0-whats-a-de/sec-terms-coeffs.ptx
+++ b/source/c0-whats-a-de/sec-terms-coeffs.ptx
@@ -34,9 +34,9 @@
 
 		<p>
 			So, a <xref ref="gi-term" text="title"/> in a <xref ref="gi-differential-equation" text="custom">differential equation</xref> is any piece of the equation separated by addition or subtraction. For example, we might have something like:
-			<me>
+			<md>
 				\text{term}\ 1 + \text{term}\ 2 - \text{term}\ 3 = \text{term}\ 4 - \text{term}\ 5.
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -50,9 +50,9 @@
 
 		<p>
 			For example, consider the five-term differential equation with dependent variable <m>y</m>:
-			<me>
+			<md>
 				\frac{3}{x} y^{(6)} + 5.3 y'' + x^2 y' + y = \frac12\ln(x)
-			</me>.
+			</md>.
 		</p>
 
 		<p>
@@ -61,27 +61,27 @@
 		
 		<tabular halign="center">
 			<row>
-				<cell bottom="minor"><me>y^{(6)}\ \text{term}</me></cell>
+				<cell bottom="minor"><md>y^{(6)}\ \text{term}</md></cell>
 				<cell/>
-				<cell bottom="minor"><me>y''\ \text{term}</me></cell>
+				<cell bottom="minor"><md>y''\ \text{term}</md></cell>
 				<cell/>
-				<cell bottom="minor"><me>y'\ \text{term}</me></cell>
+				<cell bottom="minor"><md>y'\ \text{term}</md></cell>
 				<cell/>
-				<cell bottom="minor"><me>y\ \text{term}</me></cell>
+				<cell bottom="minor"><md>y\ \text{term}</md></cell>
 				<cell/>
-				<cell bottom="minor"><me>\text{free term}</me></cell>
+				<cell bottom="minor"><md>\text{free term}</md></cell>
 			</row>
 			<row><cell/></row>
 			<row>
-				<cell><me>\frac{3}{x} y^{(6)}</me></cell>
+				<cell><md>\frac{3}{x} y^{(6)}</md></cell>
 				<cell/>
-				<cell><me>5.3 y''</me></cell>
+				<cell><md>5.3 y''</md></cell>
 				<cell/>
-				<cell><me>x^2 y'</me></cell>
+				<cell><md>x^2 y'</md></cell>
 				<cell/>
-				<cell><me>y</me></cell>
+				<cell><md>y</md></cell>
 				<cell/>
-				<cell><me>\frac12\ln(x)</me></cell>
+				<cell><md>\frac12\ln(x)</md></cell>
 			</row>
 		</tabular>
 
@@ -106,7 +106,7 @@
 			<statement>
 				<p>
 					Identify the free term in the differential equation
-					<me>3t^2 y' - 4t^2 = \frac{1}{t} y</me>.
+					<md>3t^2 y' - 4t^2 = \frac{1}{t} y</md>.
 				</p>
 			</statement>
 
@@ -157,17 +157,17 @@
 
 		<p>
 			For example, in the equation
-			<men xml:id="example-coefficients-of-a-de-1">
+			<md xml:id="example-coefficients-of-a-de-1">
 				y'' - 3y' + 2y = 0,
-			</men>
+			</md>
 			the coefficients of <m>y''</m>, <m>y'</m>, and <m>y</m> are the constants <m>1</m>, <m>-3</m>, and <m>2</m>, respectively.
 		</p>
 
 		<p>
 			Coefficients need not be constants. They can also be functions of the <xref ref="gi-independent-variable" text="title"/>. For instance, in the equation
-			<me>
+			<md>
 				t^2 y'' + 5t y' + 6y = \sin(t),
-			</me>
+			</md>
 			the coefficient of <m>y''</m> is <m>t^2</m>, the coefficient of <m>y'</m> is <m>5t</m>, and the coefficient of <m>y</m> is <m>6</m>.
 		</p>
 
@@ -182,7 +182,7 @@
 				<statement>	
 					<p>
 						Identify the coefficient of <m>y'</m> in the differential equation
-						<me>5y'' + 2\cos(t)y' - y = 7</me>
+						<md>5y'' + 2\cos(t)y' - y = 7</md>
 					</p>	
 				</statement>
 

--- a/source/c0-whats-a-de/sec-variables.ptx
+++ b/source/c0-whats-a-de/sec-variables.ptx
@@ -26,7 +26,9 @@
 
 	<p>
 		For example, consider the equation:
-		<men xml:id="variables-de-1">\frac{dy}{dx} + 2y = 4x^2.</men>
+		<md xml:id="variables-de-1">
+			\frac{dy}{dx} + 2y = 4x^2
+		</md>.
 	</p>
 
 	<p>
@@ -42,11 +44,11 @@
 		<statement>
 			<p>
 				Identify the dependent and independent variables in each equation:
-				<me>
+				<md>
 					\frac{dP}{ds} + \frac{P}{s^2} = 17s,\qquad
 					u'' + t^2 u = 0,\qquad
 					Q'' = 11Q
-				</me>
+				</md>
 			</p>
 		</statement>
 		<solution>
@@ -76,7 +78,20 @@
 	<assemblage xml:id="variables-different-letters">
 		<title><e component="emoji">✳️</e> Different Letters, Same Roles</title>
 		<p>
-			Throughout this book, the letters change with the context: we might solve for <m>y(x)</m>, <m>P(s)</m>, <m>u(t)</m>, or <m>Q(t)</m>. This variety is deliberate. Applications name variables after the quantities they measure—<m>P</m> for population, <m>V</m> for voltage, <m>T</m> for temperature, and <m>t</m> for time—so reading an equation in any letters is part of the skill you are building. What never changes are the <em>roles</em>: the dependent variable is the unknown function and carries the derivative, and the independent variable is what it depends on. When an equation looks unfamiliar, ask <q>which variable has the derivative applied to it?</q>—that is the dependent variable, whatever letter it wears.
+			Throughout this book, the letters change with the context: we might solve for 
+			<m>y(x)</m>, <m>P(s)</m>, <m>u(t)</m>, or <m>Q(t)</m>. This variety is deliberate 
+			since applications name variables after the quantities they measure. For example,
+			<m>P</m> for population, <m>V</m> for voltage, <m>T</m> for temperature, and 
+			<m>t</m> for time.
+		</p>
+	
+		<p>
+			So reading an equation in any letters is part of the skill you 
+			are building. What never changes are the <em>roles</em>: the dependent variable is 
+			the unknown function and carries the derivative, and the independent variable is 
+			what it depends on. When an equation looks unfamiliar, ask <q>which variable has 
+			the derivative applied to it?</q> The answer is the dependent variable or whatever 
+			letter it wears.
 		</p>
 	</assemblage>
 
@@ -118,9 +133,9 @@
 			<statement>
 				<p>
 					Which variable in the differential equation,
-					<me>
+					<md>
 						\frac{dP}{ds} + \frac{P}{s^2} = 17s
-					</me>,
+					</md>,
 					represents the unknown function we would like to find?
 				</p>
 			</statement>
@@ -179,19 +194,19 @@
 				<sbsgroup widths="5% 30% 15% 10%" margins="20% 20%" valign="middle">
 					<sidebyside>
 						<p><m>1.</m></p>
-						<p><me>tm' + t^2 = 0</me></p>
+						<p><md>tm' + t^2 = 0</md></p>
 						<p>Answer:</p>
 						<p><fillin width="2" mode="string" answer="m" /></p>
 					</sidebyside>
 					<sidebyside>
 						<p><m>2.</m></p>
-						<p><me>Q^2 - 11Q = P''</me></p>
+						<p><md>Q^2 - 11Q = P''</md></p>
 						<p>Answer:</p>
 						<p><fillin width="2" mode="string" answer="P" /></p>
 					</sidebyside>
 					<sidebyside>
 						<p><m>3.</m></p>
-						<p><me>\frac{dx}{dy} = 2xy + 1</me></p>
+						<p><md>\frac{dx}{dy} = 2xy + 1</md></p>
 						<p>Answer:</p>
 						<p><fillin width="2" mode="string" answer="x" /></p>
 					</sidebyside>

--- a/source/c1-classification/exercises-class.ptx
+++ b/source/c1-classification/exercises-class.ptx
@@ -186,7 +186,9 @@
 					<statement>
 						<p>
 							Consider the differential equation
-							<me>y'' + y' \cos t = 7e^y.</me>
+							<md>
+								y'' + y' \cos t = 7e^y
+							</md>.
 							Drag each expression (left) to the appropriate label (right).
 						</p>
 					</statement>
@@ -273,7 +275,9 @@
 					<statement>
 						<p>
 							Identify the <em>nonlinear</em> terms in the differential equation:
-							<me>yy'' + y^2 + \ln(y') = e^t</me>
+							<md>
+								yy'' + y^2 + \ln(y') = e^t
+							</md>
 						</p>
 					</statement>
 					<choices randomize="yes" multiple-correct="yes">
@@ -303,7 +307,9 @@
 					<statement>	
 						<p>
 							Select the linear terms in the differential equation:
-							<me>3t^2 + y \sin(t) = t\sin(y') + e^{ty}</me>
+							<md>
+								3t^2 + y \sin(t) = t\sin(y') + e^{ty}
+							</md>
 						</p>	
 					</statement>
 					<choices randomize="yes" multiple-correct="yes">
@@ -402,7 +408,9 @@
 					<statement>
 						<p>
 							Identify the linearity of the differential equation
-							<me>y'' + \sin(y) = 17t </me>.
+							<md>
+								y'' + \sin(y) = 17t
+							</md>.
 						</p>
 					</statement>
 					<choices randomize="no">
@@ -441,7 +449,9 @@
 					<statement>
 						<p>
 							Identify the linearity of the differential equation
-							<me>y'' + y' \cos t = 7y </me>.
+							<md>
+								y'' + y' \cos t = 7y
+							</md>.
 						</p>
 					</statement>
 
@@ -481,7 +491,9 @@
 					<statement>
 						<p>
 							Identify the linearity of the differential equation
-							<me>\dfrac{dy}{dt} + t^2 y = e^t.</me>
+							<md>
+								\frac{dy}{dt} + t^2 y = e^t
+							</md>.
 						</p>
 					</statement>
 					<choices randomize="no">
@@ -504,7 +516,9 @@
 					<statement>
 						<p>
 							Identify the linearity of the differential equation
-							<me>\dfrac{d^2x}{dt^2} + e^x = 0 </me>.
+							<md>
+								\frac{d^2x}{dt^2} + e^x = 0
+							</md>.
 						</p>
 					</statement>
 					<choices randomize="no">
@@ -643,9 +657,9 @@
 							<m>\quad</m>
 						</p>
 						<p>	
-							<me>
+							<md>
 									{\text{Differential Equation}}
-							</me>
+							</md>
 						</p>
 						<p>
 							<md>
@@ -654,7 +668,7 @@
 							</md>
 						</p>
 						<p>
-							<me> {\text{Order}} </me>
+							<md> {\text{Order}} </md>
 						</p>
 					</sidebyside>
 
@@ -663,7 +677,9 @@
 							(a)
 						</p>
 						<p>
-							<me>\dfrac{d^2R}{dt^2} + \dfrac{dR}{dt} = \cos(R) </me>
+							<md>
+								\frac{d^2R}{dt^2} + \frac{dR}{dt} = \cos(R)
+							</md>
 						</p>
 						<p><fillin mode="string" answer="R" width="3" /></p>
 						<p><fillin mode="string" answer="2" width="3" /></p>
@@ -674,7 +690,9 @@
 							(b)
 						</p>
 						<p>
-							<me>\vphantom{\dfrac{d^2R}{dt^2}} 4w y' - w^2 + 5w = 1</me>
+							<md>
+								\vphantom{\dfrac{d^2R}{dt^2}} 4w y' - w^2 + 5w = 1
+							</md>
 						</p>
 						<p><fillin mode="string" answer="y" width="3" /></p>
 						<p><fillin mode="string" answer="1" width="3" /></p>
@@ -685,7 +703,9 @@
 							(c)
 						</p>
 						<p>
-							<me>\vphantom{\dfrac{d^2R}{dt^2}} p^{5} - p^{(4)} + y = 0</me>
+							<md>
+								\vphantom{\frac{d^2R}{dt^2}} p^{5} - p^{(4)} + y = 0
+							</md>
 						</p>
 						<p><fillin mode="string" answer="p" width="3" /></p>
 						<p><fillin mode="string" answer="4" width="3" /></p>
@@ -696,7 +716,9 @@
 							(d)
 						</p>
 						<p>
-							<me>\vphantom{\dfrac{d^2R}{dt^2}} (\sin(x')) y - y^2 = 2 </me>
+							<md>
+								\vphantom{\frac{d^2R}{dt^2}} (\sin(x')) y - y^2 = 2
+							</md>
 						</p>
 						<p><fillin mode="string" answer="x" width="3" /></p>
 						<p><fillin mode="string" answer="1" width="3" /></p>
@@ -1520,9 +1542,9 @@
 				<statement>
 					<p>
 						Determine the linearity of each term in the differential equation:
-						<me>
-							e^{t}y^{(7)} + (t+1)y'y''' - t \ln y'' - y' \sin t - \tan y + \dfrac{4}{y} = \dfrac{3}{t}
-						</me>.
+						<md>
+							e^{t}y^{(7)} + (t+1)y'y''' - t \ln y'' - y' \sin t - \tan y + \frac{4}{y} = \frac{3}{t}
+						</md>.
 					</p>
 				</statement>
 				<solution>

--- a/source/c1-classification/sec-linear-terms.ptx
+++ b/source/c1-classification/sec-linear-terms.ptx
@@ -26,21 +26,21 @@
 		<p>
 			<idx><h>linear term</h></idx>
 			Let <m>y</m> be the dependent variable. A term is <term>linear</term> if it appears as either:
-			<men xml:id="linear-term-forms">
+			<md xml:id="linear-term-forms" number="yes">
 				a(t), \quad a(t)y, \quad \text{or} \quad a(t)y^{(n)}
-			</men>,
+			</md>,
 			where the coefficient, <m>a(t)</m>, can be a constant or a function of the independent variable <m>t</m> only, and <m>y^{(n)}</m> is the <m>n</m>-th derivative of <m>y</m>.
 		</p>
 
 		<p>
 			For example, the following terms are <xref ref="gi-linear-term" text="custom">linear</xref>:
-			<me>
+			<md>
 				\us{a(t)}{\us{\uparrow}{\ul{23}}}, \quad 
 				\us{a(t)}{\us{\uparrow}{\ul{2t^3}}}y'', \quad 
 				\us{a(t)}{\us{\uparrow}{\ul{\frac{1}{t}}}}y^{(5)}, \quad 
 				\us{a(t)}{\us{\uparrow}{\ul{e^{2t}}}}y, \quad 
 				\us{a(t)}{\us{\uparrow}{\ul{7\sin(t)}}}y'.
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -57,19 +57,19 @@
 
 				<sidebyside widths="5% 30% 25%" margins="20% 20%" valign="middle">
 					<p><m>1.</m></p>
-					<p><me>2ty''</me></p>
+					<p><md>2ty''</md></p>
 					<p><m>a(t) = </m> <fillin width="4" mode="string" answer="2t" /></p>
 				</sidebyside>
 
 				<sidebyside widths="5% 30% 25%" margins="20% 20%" valign="middle">
 					<p><m>2.</m></p>
-					<p><me>y^{(3)}\sin(t)</me></p>
+					<p><md>y^{(3)}\sin(t)</md></p>
 					<p><m>a(t) = </m> <fillin width="4" mode="string" answer="sin(t)" /></p>
 				</sidebyside>
 
 				<sidebyside widths="5% 30% 25%" margins="20% 20%" valign="middle">
 					<p><m>3.</m></p>
-					<p><me>y</me></p>
+					<p><md>y</md></p>
 					<p><m>a(t) = </m> <fillin width="4" mode="string" answer="1" /></p>
 				</sidebyside>
 			</statement>
@@ -137,9 +137,9 @@
 
 		<p>
 			Let's apply these strategies by breaking down the linearity of each term in the following differential equation:
-			<me>
-			y\frac{d^5y}{dt^5} + 2t^3\ \frac{d^2y}{dt^2} + \ln\left(\frac{dy}{dt}\right) + y^2 = t^3
-			</me>
+			<md>
+				y\frac{d^5y}{dt^5} + 2t^3\ \frac{d^2y}{dt^2} + \ln\left(\frac{dy}{dt}\right) + y^2 = t^3
+			</md>
 		</p>
 
 		<p>

--- a/source/c1-classification/sec-linearity.ptx
+++ b/source/c1-classification/sec-linearity.ptx
@@ -60,12 +60,12 @@
 				<fn>
 					This structure is known as a <term>linear combination</term> of the dependent variable and its derivatives.
 				</fn>
-				<men xml:id="linear-equation">
-				\underset{\text{linear term}}{\underbrace{a_n(t)\ y^{(n)}}} + \cdots +
-				\underset{\text{linear term}}{\underbrace{a_2(t)\ y''}} +
-				\underset{\text{linear term}}{\underbrace{a_1(t)\ y'}} +
-				\underset{\text{linear term}}{\underbrace{a_0(t)\ y}} = f(t)
-				</men>
+				<md xml:id="linear-equation" number="yes">
+					\underset{\text{linear term}}{\underbrace{a_n(t)\ y^{(n)}}} + \cdots +
+					\underset{\text{linear term}}{\underbrace{a_2(t)\ y''}} +
+					\underset{\text{linear term}}{\underbrace{a_1(t)\ y'}} +
+					\underset{\text{linear term}}{\underbrace{a_0(t)\ y}} = f(t)
+				</md>
 				where each <m>a_k(t)</m> is a function of the independent variable only, and <m>f(t)</m> is the input or forcing term.
 			</p>
 		</statement>
@@ -73,9 +73,9 @@
 
 	<p>
 		For example, the following differential equations are linear:
-		<men xml:id="linear-equation-examples">
+		<md xml:id="linear-equation-examples" number="yes">
 			3\frac{dy}{dx} + 2y = 0, \qquad y''' - 2y' - \frac{7}{x}y = e^x, \qquad w'' - \tan(t) = 3t.
-		</men>
+		</md>
 	</p>
 
 	<p>
@@ -85,11 +85,11 @@
 	<p>
 		<idx><h>nonlinear differential equation</h></idx>
 		In contrast, the following equations are <xref ref="gi-nonlinear-differential-equation" text="custom">nonlinear</xref> because they include at least one nonlinear term (✷):
-		<men xml:id="nonlinear-equation-examples">
+		<md xml:id="nonlinear-equation-examples" number="yes">
 			y' + \us{\large ✷}{\ul{ t y^2 }} = t, \qquad 
 			t \frac{dP}{dt} + \us{\large ✷}{\ul{ \sin(P) }} = t^2, \qquad
 			\us{\large ✷}{\ul{\omega\omega^{(5)}}} + s = \us{\large ✷}{\ul{ e^\omega }}
-		</men>
+		</md>
 	</p>
 
 	<p>
@@ -105,21 +105,21 @@
 		<statement>
 			<p>
 				Determine whether each of the following differential equations is linear:
-				<me>
-				y^{(5)} + \frac{y'}{x^2} + 5y = \ln x, \qquad P^{(6)} + \frac{m P'}{P} = (m - 1)^2
-				</me>
+				<md>
+					y^{(5)} + \frac{y'}{x^2} + 5y = \ln x, \qquad P^{(6)} + \frac{m P'}{P} = (m - 1)^2
+				</md>
 			</p>
 		</statement>
 		<solution>
 			<p>
 				In the first equation, all terms involving <m>y</m> or its derivatives appear linearly:
 				<md>
-				<mrow>
-					\underset{\overline{\text{linear}}}{\vphantom{\frac11}\color{BurntOrange} y^{(5)}} +
-					\underset{\overline{\text{linear}}}{\frac{1}{x^2} \color{BurntOrange} y'} +
-					\underset{\overline{\text{linear}}}{5 \color{BurntOrange} y} =\ 
-					\underset{\overline{\text{linear}}}{\ln x}
-				</mrow>
+					<mrow>
+						\underset{\overline{\text{linear}}}{\vphantom{\frac11}\color{BurntOrange} y^{(5)}} +
+						\underset{\overline{\text{linear}}}{\frac{1}{x^2} \color{BurntOrange} y'} +
+						\underset{\overline{\text{linear}}}{5 \color{BurntOrange} y} =\ 
+						\underset{\overline{\text{linear}}}{\ln x}
+					</mrow>
 				</md>
 				So the equation is linear.
 			</p>
@@ -127,11 +127,11 @@
 			<p>
 				In the second equation, the term <m>\frac{m P'}{P}</m> is nonlinear, since <m>P</m> appears in both the numerator and denominator:
 				<md>
-				<mrow>
-					\underset{\text{linear}}{\underline{\color{BurntOrange} P^{(6)}}} +
-					\underset{\overline{\text{nonlinear}}}{\frac{m \color{BurntOrange} P'}{\color{BurntOrange} P}} =\ 
-					\underset{\text{linear}}{(m - 1)^2}
-				</mrow>
+					<mrow>
+						\underset{\text{linear}}{\underline{\color{BurntOrange} P^{(6)}}} +
+						\underset{\overline{\text{nonlinear}}}{\frac{m \color{BurntOrange} P'}{\color{BurntOrange} P}} =\ 
+						\underset{\text{linear}}{(m - 1)^2}
+					</mrow>
 				</md>
 				This makes the entire equation nonlinear.
 			</p>
@@ -156,7 +156,7 @@
 						<cell><area correct="yes"><m>y'' + \dfrac{y'}{t^2} + y = 17t </m>	</area></cell>
 						<cell><area correct="yes"><m>y'' + 3y' + 2y = 0 </m>				</area></cell>
 					</row>
-					<row><cell><me/></cell></row>
+					<row><cell><md/></cell></row>
 					<row>
 						<cell><area correct="no"><m>y'' + y^2 = 17t </m>	</area></cell>
 						<cell><area correct="no"><m>yy'' + y' = 0	</m>	</area></cell>

--- a/source/c1-classification/sec-order.ptx
+++ b/source/c1-classification/sec-order.ptx
@@ -64,7 +64,9 @@
 
 	<p>
 		For example, the equation
-		<me>\frac{dy}{dx} + y = x</me>
+		<md>
+			\frac{dy}{dx} + y = x
+		</md>
 		<idx><h>first-order differential equation</h></idx>
 		is a <em><xref ref="gi-order" text="custom">first-order</xref></em> differential equation because the highest derivative is <m>\frac{dy}{dx}</m>. On the other hand, the differential equation
 		<md>
@@ -141,9 +143,9 @@
 		<statement>
 			<p>
 				For each of the following differential equations, identify the order:
-				<me>
-				\frac{d^2 A}{dt^2} + \frac{dA}{dt} + A = 17, \qquad w^6 + \sin\big(w^{(5)}\big) = 0
-				</me>
+				<md>
+					\frac{d^2 A}{dt^2} + \frac{dA}{dt} + A = 17, \qquad w^6 + \sin\big(w^{(5)}\big) = 0
+				</md>
 			</p>
 		</statement>
 		<solution>
@@ -176,15 +178,15 @@
 					<cell><p>Order</p></cell>
 				</row>
 				<row>
-					<cell><p><me>(1 - x)\dfrac{d^2y}{dx^2} - x^4\dfrac{dy}{dx} + y^5 = \cos x\quad </me></p></cell>
+					<cell><p><md>(1 - x)\dfrac{d^2y}{dx^2} - x^4\dfrac{dy}{dx} + y^5 = \cos x\quad </md></p></cell>
 					<cell><p><fillin characters="4" mode="number" answer="2" /></p></cell>
 				</row>
 				<row>
-					<cell><p><me>y''' + 3y' - 4y = 0</me></p></cell>
+					<cell><p><md>y''' + 3y' - 4y = 0</md></p></cell>
 					<cell><p><fillin characters="4" mode="number" answer="3" /></p></cell>
 				</row>
 				<row>
-					<cell><p><me>t^3 \dfrac{d^2y}{dt^2} + \dfrac{d^5y}{dt^5} = \sin(t)</me></p></cell>
+					<cell><p><md>t^3 \dfrac{d^2y}{dt^2} + \dfrac{d^5y}{dt^5} = \sin(t)</md></p></cell>
 					<cell><p><fillin characters="4" mode="number" answer="5" /></p></cell>
 				</row>
 			</tabular>

--- a/source/c11-ltm/sec-laplace-transform-method.ptx
+++ b/source/c11-ltm/sec-laplace-transform-method.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section xml:id="lt-method-steps-examples" label="lt-method-steps-examples">
+<section xml:id="lt-method-steps-examples">
 	<title>Summary &amp; Worked Examples</title>
 
 	<introduction>

--- a/source/c11-ltm/sec-laplace-transform-method.ptx
+++ b/source/c11-ltm/sec-laplace-transform-method.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section label="lt-method-steps-examples">
+<section xml:id="lt-method-steps-examples" label="lt-method-steps-examples">
 	<title>Summary &amp; Worked Examples</title>
 
 	<introduction>

--- a/source/c12-ltp/review-choosing-a-method.ptx
+++ b/source/c12-ltp/review-choosing-a-method.ptx
@@ -198,7 +198,7 @@
 				<choices randomize="yes">
 					<choice correct="yes">
 						<statement>The characteristic equation—Laplace is the wrong shape for a general-solution request.</statement>
-						<feedback>Correct! <m>r^2 + 9 = 0</m> gives <m>r = \pm 3i</m> and <m>y = c_1\cos 3t + c_2\sin 3t</m> in two lines. The Laplace method wants specific initial conditions at <m>t=0</m>; with none given, the characteristic equation is the natural tool.</feedback>
+						<feedback>Correct! <m>r^2 + 9 = 0</m> gives <m>r = \pm 3i</m> and <m>y = C_1\cos 3t + C_2\sin 3t</m> in two lines. The Laplace method wants specific initial conditions at <m>t=0</m>; with none given, the characteristic equation is the natural tool.</feedback>
 					</choice>
 					<choice>
 						<statement>The Laplace transform method.</statement>
@@ -374,7 +374,7 @@
 						<me>y(t) = 2 - 3e^{t} + e^{3t}</me>
 					</p>
 					<p>
-						<em>Check via undetermined coefficients:</em> <m>r^2 - 4r + 3 = (r-1)(r-3)</m> gives <m>y_h = c_1 e^{t} + c_2 e^{3t}</m>, and the constant guess gives <m>y_p = 2</m>. Applying the initial conditions to <m>y = 2 + c_1 e^t + c_2 e^{3t}</m>: <m>c_1 + c_2 = -2</m> and <m>c_1 + 3c_2 = 0</m>, so <m>c_2 = 1</m>, <m>c_1 = -3</m>. Both roads agree. <e component="emoji">✅</e>
+						<em>Check via undetermined coefficients:</em> <m>r^2 - 4r + 3 = (r-1)(r-3)</m> gives <m>y_h = C_1 e^{t} + C_2 e^{3t}</m>, and the constant guess gives <m>y_p = 2</m>. Applying the initial conditions to <m>y = 2 + C_1 e^t + C_2 e^{3t}</m>: <m>C_1 + C_2 = -2</m> and <m>C_1 + 3C_2 = 0</m>, so <m>C_2 = 1</m>, <m>C_1 = -3</m>. Both roads agree. <e component="emoji">✅</e>
 					</p>
 				</solution>
 				<answer>
@@ -395,7 +395,7 @@
 					<p>
 						<md>
 							<mrow>\frac{dy}{y} \amp = -2t\,dt</mrow>
-							<mrow>\ln|y| \amp = -t^2 + c</mrow>
+							<mrow>\ln|y| \amp = -t^2 + C_1</mrow>
 							<mrow>y \amp = Ce^{-t^2}</mrow>
 						</md>
 					</p>
@@ -424,11 +424,11 @@
 					</p>
 					<p>
 						Complex roots <m>-1 \pm 2i</m> give
-						<me>y = e^{-t}\left(c_1 \cos 2t + c_2 \sin 2t\right)</me>.
+						<me>y = e^{-t}\left(C_1 \cos 2t + C_2 \sin 2t\right)</me>.
 					</p>
 				</solution>
 				<answer>
-					<p>Characteristic equation; <m>y = e^{-t}\left(c_1\cos 2t + c_2 \sin 2t\right)</m>.</p>
+					<p>Characteristic equation; <m>y = e^{-t}\left(C_1\cos 2t + C_2 \sin 2t\right)</m>.</p>
 				</answer>
 			</exercise>
 		</exercisegroup>

--- a/source/c12-ltp/review-choosing-a-method.ptx
+++ b/source/c12-ltp/review-choosing-a-method.ptx
@@ -1,0 +1,436 @@
+<!-- LICENSING
+  This file is part of the textbook "Exploring Differential Equations, An Interactive, Student-Centered Approach" by Geoffrey Cox.
+  License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+  You are free to:
+    • Share — copy and redistribute the material in any medium or format.
+    • Adapt — remix, transform, and build upon the material for any purpose, even commercially.
+  Under the following terms:
+    • Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.
+    • ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license.
+  Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
+  Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
+-->
+<section xml:id="lap-mixed-review" label="lap-mixed-review">
+	<title>Mixed Review: Choosing Your Method</title>
+
+	<introduction>
+		<p>
+			The Laplace unit is complete, and your toolkit is now at full strength for this part of the book: three first-order methods, the characteristic equation, undetermined coefficients, and the Laplace transform method—including piecewise forcing. The Laplace transform is the newest road, but new doesn't mean best: for many equations an older tool gets there faster. Choosing well is the skill exams actually test, so this review mixes everything together.
+		</p>
+
+		<p>
+			A quick profile of when the Laplace method is the right call.
+			<ul>
+				<li>
+					<p>
+						<em>Reach for Laplace when</em> the equation is linear with constant coefficients <em>and</em> you're handed an initial value problem—especially one whose forcing function switches on or off. Initial conditions fold in during the forward transform (no solving for constants afterward), and step-function forcing is something no earlier method can touch.
+					</p>
+				</li>
+				<li>
+					<p>
+						<em>Reach for an older tool when</em> the problem asks for a <em>general</em> solution (Laplace is built around initial conditions), when the equation is homogeneous with constant coefficients (the characteristic equation is almost always faster), or when the equation is nonlinear or has variable coefficients—our Laplace method requires linear equations with constant coefficients, but separation of variables may still work.
+					</p>
+				</li>
+			</ul>
+		</p>
+
+		<p>
+			The full decision map so far:
+		</p>
+
+		<tabular halign="left" top="minor" bottom="minor" left="minor" right="minor">
+			<col width="42%" />
+			<col width="58%" />
+			<row header="yes" bottom="medium">
+				<cell>If the problem is …</cell>
+				<cell>then …</cell>
+			</row>
+			<row>
+				<cell><p><em>first order</em></p></cell>
+				<cell><p>walk the <xref ref="fo-mixed-review" text="custom">first-order flowchart</xref>: direct integration <m>\rightarrow</m> separation of variables <m>\rightarrow</m> integrating factor.</p></cell>
+			</row>
+			<row>
+				<cell><p>LHCC (any order), general solution wanted</p></cell>
+				<cell><p>characteristic equation, as in the <xref ref="cc-mixed-review" text="custom">constant-coefficient mixed review</xref>.</p></cell>
+			</row>
+			<row>
+				<cell><p>LNCC with polynomial, exponential, sine, or cosine forcing; general solution wanted</p></cell>
+				<cell><p>undetermined coefficients: <m>y = y_h + y_p</m>.</p></cell>
+			</row>
+			<row>
+				<cell><p>linear, constant coefficients, an IVP with conditions at <m>t = 0</m></p></cell>
+				<cell><p>the <xref ref="lt-method-steps-examples" text="custom">Laplace transform method</xref>—especially if the forcing function is <xref ref="piecewise-laplace-method" text="custom">piecewise</xref>. (For smooth forcing, undetermined coefficients plus solving for the constants works too; use whichever you execute faster.)</p></cell>
+			</row>
+			<row>
+				<cell><p>nonlinear, or variable coefficients</p></cell>
+				<cell><p>separation of variables if it separates; otherwise <xref ref="chpt-qualitative" text="custom">qualitative</xref> or <xref ref="chpt-eulers-method" text="custom">numerical</xref> tools.</p></cell>
+			</row>
+		</tabular>
+	</introduction>
+
+	<exercises label="lap-review-quiz">
+		<title><e component="emoji">💡</e> Which Method? Quiz</title>
+
+		<introduction>
+			<p>
+				For each problem, choose the best plan of attack. <em>Do not solve any of the equations</em>—practice making the call the way you would on an exam.
+			</p>
+		</introduction>
+
+		<exercise label="lap-review-wm">
+
+			<task label="lap-review-wm-01">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>y'' + 4y = u_{3}(t), \qquad y(0) = 0, \quad y'(0) = 0</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>The Laplace transform method—step-function forcing is exactly what it's built for.</statement>
+						<feedback>Correct! The equation is linear with constant coefficients, the initial conditions sit at <m>t = 0</m>, and no earlier method can absorb a forcing function that switches on at <m>t = 3</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Undetermined coefficients, guessing <m>y_p = A\,u_3(t)</m>.</statement>
+						<feedback>Undetermined coefficients only handles forcing built from polynomials, exponentials, sines, and cosines—a step function is none of these, and its jump breaks the guess-and-match machinery.</feedback>
+					</choice>
+					<choice>
+						<statement>The characteristic equation alone.</statement>
+						<feedback>The characteristic equation handles the homogeneous part, but the step forcing still needs to enter the solution—that's the Laplace method's job.</feedback>
+					</choice>
+					<choice>
+						<statement>Separation of variables.</statement>
+						<feedback>Separation of variables is a first-order tool; this equation is second order.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="lap-review-wm-02">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>\frac{dy}{dt} = y\left(1 - y\right)</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Separation of variables—the Laplace method doesn't apply.</statement>
+						<feedback>Correct! The <m>y^2</m> hiding in <m>y(1-y)</m> makes this logistic equation nonlinear, and our Laplace method requires linear constant-coefficient equations. But the right side factors as a function of <m>y</m> alone, so it separates (and qualitative tools describe its behavior beautifully).</feedback>
+					</choice>
+					<choice>
+						<statement>The Laplace transform method.</statement>
+						<feedback>Transforming the nonlinear term <m>y^2</m> is beyond the Laplace machinery we've built—there's no table entry for the transform of a product of unknown functions. The equation is nonlinear, so look to first-order tools instead.</feedback>
+					</choice>
+					<choice>
+						<statement>Undetermined coefficients.</statement>
+						<feedback>Undetermined coefficients is for linear constant-coefficient equations with forcing; this equation is nonlinear.</feedback>
+					</choice>
+					<choice>
+						<statement>The characteristic equation.</statement>
+						<feedback>Substituting <m>y = e^{rt}</m> only works for <em>linear</em> equations—the <m>y^2</m> term breaks it.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="lap-review-wm-03">
+				<title>More Than One Way</title>
+				<statement>
+					<p>
+						<me>y'' + 3y' + 2y = 12e^{t}, \qquad y(0) = 1, \quad y'(0) = 0</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Either undetermined coefficients or the Laplace method—both apply; Laplace folds the initial conditions in automatically.</statement>
+						<feedback>Correct! Linear, constant coefficients, forcing <m>12e^t</m> in the undetermined-coefficients family (<m>y_p = 2e^t</m>), and an IVP at <m>t = 0</m>—so both roads are open. Undetermined coefficients needs a follow-up step to fit the constants; Laplace handles them during the forward transform.</feedback>
+					</choice>
+					<choice>
+						<statement>Only the Laplace method—undetermined coefficients can't handle initial conditions.</statement>
+						<feedback>Undetermined coefficients handles this fine: find the general solution <m>y = y_h + y_p</m>, then use the initial conditions to fix the constants. Laplace just merges those steps.</feedback>
+					</choice>
+					<choice>
+						<statement>Only undetermined coefficients—Laplace can't handle exponential forcing.</statement>
+						<feedback>Exponentials are one of the easiest things to transform: <m>\lap{12e^{t}} = \frac{12}{s-1}</m>. Both methods apply here.</feedback>
+					</choice>
+					<choice>
+						<statement>Neither—the forcing function rules both out.</statement>
+						<feedback><m>12e^t</m> is in the undetermined-coefficients family <em>and</em> has a known Laplace transform, so both methods apply.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="lap-review-wm-04">
+				<title>Check the Fine Print</title>
+				<statement>
+					<p>
+						<me>y' + t\,y = 0</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Separation of variables—the coefficient <m>t</m> puts this outside our Laplace method.</statement>
+						<feedback>Correct! The variable coefficient <m>t</m> means this isn't a constant-coefficient equation, so our Laplace playbook doesn't cover it. But <m>y' = -t\,y</m> separates immediately: <m>\frac{dy}{y} = -t\,dt</m> gives <m>y = Ce^{-t^2/2}</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>The Laplace transform method.</statement>
+						<feedback>The variable coefficient <m>t</m> multiplying <m>y</m> takes this outside the constant-coefficient equations our Laplace method covers. A first-order tool is the way in—notice the equation is separable.</feedback>
+					</choice>
+					<choice>
+						<statement>The characteristic equation.</statement>
+						<feedback>Characteristic equations require constant coefficients; the coefficient here is <m>t</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>No method applies.</statement>
+						<feedback>Isolate the derivative: <m>y' = -t\,y</m>. Can the right side be written as a function of <m>t</m> times a function of <m>y</m>?</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="lap-review-wm-05">
+				<title>Match the Tool to the Question</title>
+				<statement>
+					<p>
+						Find the <em>general</em> solution:
+						<me>y'' + 9y = 0</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>The characteristic equation—Laplace is the wrong shape for a general-solution request.</statement>
+						<feedback>Correct! <m>r^2 + 9 = 0</m> gives <m>r = \pm 3i</m> and <m>y = c_1\cos 3t + c_2\sin 3t</m> in two lines. The Laplace method wants specific initial conditions at <m>t=0</m>; with none given, the characteristic equation is the natural tool.</feedback>
+					</choice>
+					<choice>
+						<statement>The Laplace transform method.</statement>
+						<feedback>With no initial conditions given, the forward transform would carry the unknowns <m>y(0)</m> and <m>y'(0)</m> through every step. It can be done, but the characteristic equation gives the general solution far more directly.</feedback>
+					</choice>
+					<choice>
+						<statement>Undetermined coefficients.</statement>
+						<feedback>The forcing function is <m>0</m>, so there is no particular solution to build—the characteristic equation alone finishes the problem.</feedback>
+					</choice>
+					<choice>
+						<statement>The integrating factor method.</statement>
+						<feedback>The integrating factor method is a first-order tool; this equation is second order.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="lap-review-wm-06">
+				<title>Piecewise Forcing Protocol</title>
+				<statement>
+					<p>
+						What is the right <em>first step</em> for this IVP?
+						<me>y' + 4y = f(t), \qquad y(0) = 0, \qquad \text{where } f(t) = \begin{cases} 5, &amp; 0 \le t \lt 2 \\ 0, &amp; t \ge 2 \end{cases}</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Rewrite <m>f(t)</m> with unit step functions as <m>5\left(1 - u_2(t)\right)</m>, then run the Laplace method.</statement>
+						<feedback>Correct! Piecewise forcing enters the Laplace machinery through unit step notation—rewrite first, transform second. Here <m>f(t)</m> is ON at value <m>5</m> until it switches OFF at <m>t = 2</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Solve on <m>0 \le t \lt 2</m> and <m>t \ge 2</m> separately with an integrating factor, then glue the pieces.</statement>
+						<feedback>This can be made to work, but matching the pieces at <m>t = 2</m> by hand is exactly the bookkeeping the unit-step approach eliminates. Rewrite the forcing with step functions and transform once.</feedback>
+					</choice>
+					<choice>
+						<statement>Apply undetermined coefficients with guess <m>y_p = A</m>.</statement>
+						<feedback>A constant guess matches constant forcing—but this forcing isn't constant; it shuts off at <m>t = 2</m>. Undetermined coefficients can't represent the switch.</feedback>
+					</choice>
+					<choice>
+						<statement>Take the Laplace transform immediately, integrating the piecewise definition term by term from the definition.</statement>
+						<feedback>Retreating to the integral definition works but is slow. The whole point of the unit-step rules is to skip it: rewrite <m>f(t) = 5\left(1 - u_2(t)\right)</m> and use the table.</feedback>
+					</choice>
+				</choices>
+			</task>
+		</exercise>
+	</exercises>
+
+	<exercises label="lap-review-problems">
+		<title><e component="emoji">✍🏻</e> Mixed Problem Set</title>
+
+		<exercisegroup cols="2" label="lap-review-mixed">
+			<title>Choose, Then Solve</title>
+
+			<introduction>
+				<p>
+					Solve each problem. No method is announced—begin each solution by naming the method you chose and why. When two methods apply, feel free to use one to check the other.
+				</p>
+			</introduction>
+
+			<exercise label="lap-review-mixed-1">
+				<statement>
+					<p>
+						<m>y' + 2y = 0, \quad y(0) = 3</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> linear, constant coefficients, an IVP at <m>t = 0</m>—Laplace applies. (So do separation of variables and the integrating factor; this one is a three-way tie, and we use it to see the Laplace steps at their cleanest.)
+					</p>
+					<p>
+						<em>Forward transform:</em>
+						<me>\lap{y'} + 2\lap{y} = 0 \quad\implies\quad \left(sY(s) - 3\right) + 2Y(s) = 0</me>
+					</p>
+					<p>
+						<em>Solve for <m>Y(s)</m>:</em>
+						<me>Y(s) = \frac{3}{s + 2}</me>
+					</p>
+					<p>
+						<em>Backward transform:</em> matching <m>\frac{1}{s - a}</m> with <m>a = -2</m>,
+						<me>y(t) = 3e^{-2t}</me>.
+					</p>
+					<p>
+						Separation of variables confirms it: <m>\frac{dy}{y} = -2\,dt</m> gives <m>y = Ce^{-2t}</m>, and <m>y(0) = 3</m> forces <m>C = 3</m>.
+					</p>
+				</solution>
+				<answer>
+					<p>Laplace method (or SOV/IF); <m>y = 3e^{-2t}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="lap-review-mixed-2">
+				<statement>
+					<p>
+						<m>y'' + y = 1, \quad y(0) = 0, \quad y'(0) = 0</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> linear, constant coefficients, IVP at <m>t = 0</m>—Laplace. (Undetermined coefficients with <m>y_p = A</m> also works; try it as a check.)
+					</p>
+					<p>
+						<em>Forward transform:</em> with both initial conditions zero, <m>\lap{y''} = s^2 Y(s)</m>, so
+						<me>s^2 Y(s) + Y(s) = \frac{1}{s} \quad\implies\quad Y(s) = \frac{1}{s\left(s^2 + 1\right)}</me>
+					</p>
+					<p>
+						<em>Prepare:</em> partial fractions split this into table-ready pieces:
+						<me>\frac{1}{s\left(s^2+1\right)} = \frac{1}{s} - \frac{s}{s^2 + 1}</me>
+					</p>
+					<p>
+						<em>Backward transform:</em>
+						<me>y(t) = \ilap{\frac{1}{s}} - \ilap{\frac{s}{s^2+1}} = 1 - \cos t</me>
+					</p>
+					<p>
+						A quick check: <m>y'' + y = \cos t + \left(1 - \cos t\right) = 1</m>, and both initial conditions hold. <e component="emoji">✅</e>
+					</p>
+				</solution>
+				<answer>
+					<p>Laplace method (or undetermined coefficients); <m>y = 1 - \cos t</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="lap-review-mixed-3">
+				<statement>
+					<p>
+						<m>y' + y = u_2(t), \quad y(0) = 0</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> the step-function forcing decides it—only the Laplace method handles <m>u_2(t)</m>.
+					</p>
+					<p>
+						<em>Forward transform:</em>
+						<me>sY(s) + Y(s) = \frac{e^{-2s}}{s} \quad\implies\quad Y(s) = e^{-2s}\cdot\frac{1}{s\left(s+1\right)}</me>
+					</p>
+					<p>
+						<em>Prepare:</em> partial fractions on the non-exponential factor:
+						<me>\frac{1}{s\left(s+1\right)} = \frac{1}{s} - \frac{1}{s+1}</me>
+						whose inverse is <m>f(t) = 1 - e^{-t}</m>.
+					</p>
+					<p>
+						<em>Backward transform:</em> the <m>e^{-2s}</m> factor triggers the delay rule <m>\ilap{e^{-cs}F(s)} = f(t-c)\,u_c(t)</m>:
+						<me>y(t) = \left(1 - e^{-(t-2)}\right) u_2(t)</me>
+					</p>
+					<p>
+						Interpretation: the solution stays at <m>0</m> until the forcing switches on at <m>t = 2</m>, then rises toward <m>1</m>—exactly what the ON switch should produce.
+					</p>
+				</solution>
+				<answer>
+					<p>Laplace method; <m>y = \left(1 - e^{-(t-2)}\right)u_2(t)</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="lap-review-mixed-4">
+				<statement>
+					<p>
+						<m>y'' - 4y' + 3y = 6, \quad y(0) = 0, \quad y'(0) = 0</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> both undetermined coefficients and the Laplace method apply. We run Laplace and use undetermined coefficients as the check.
+					</p>
+					<p>
+						<em>Forward transform:</em> both initial conditions are zero, so
+						<me>\left(s^2 - 4s + 3\right) Y(s) = \frac{6}{s} \quad\implies\quad Y(s) = \frac{6}{s\left(s-1\right)\left(s-3\right)}</me>
+					</p>
+					<p>
+						<em>Prepare:</em> partial fractions:
+						<me>\frac{6}{s\left(s-1\right)\left(s-3\right)} = \frac{2}{s} - \frac{3}{s-1} + \frac{1}{s-3}</me>
+					</p>
+					<p>
+						<em>Backward transform:</em>
+						<me>y(t) = 2 - 3e^{t} + e^{3t}</me>
+					</p>
+					<p>
+						<em>Check via undetermined coefficients:</em> <m>r^2 - 4r + 3 = (r-1)(r-3)</m> gives <m>y_h = c_1 e^{t} + c_2 e^{3t}</m>, and the constant guess gives <m>y_p = 2</m>. Applying the initial conditions to <m>y = 2 + c_1 e^t + c_2 e^{3t}</m>: <m>c_1 + c_2 = -2</m> and <m>c_1 + 3c_2 = 0</m>, so <m>c_2 = 1</m>, <m>c_1 = -3</m>. Both roads agree. <e component="emoji">✅</e>
+					</p>
+				</solution>
+				<answer>
+					<p>Laplace method (or undetermined coefficients); <m>y = 2 - 3e^{t} + e^{3t}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="lap-review-mixed-5">
+				<statement>
+					<p>
+						<m>y' = -2t\,y, \quad y(0) = 4</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> the coefficient <m>-2t</m> is not constant, so the Laplace method and the characteristic equation are both out. The right side is the product <m>(-2t)\cdot y</m>—<em>separation of variables</em>.
+					</p>
+					<p>
+						<md>
+							<mrow>\frac{dy}{y} \amp = -2t\,dt</mrow>
+							<mrow>\ln|y| \amp = -t^2 + c</mrow>
+							<mrow>y \amp = Ce^{-t^2}</mrow>
+						</md>
+					</p>
+					<p>
+						Applying <m>y(0) = 4</m> gives <m>C = 4</m>, so
+						<me>y = 4e^{-t^2}</me>.
+					</p>
+				</solution>
+				<answer>
+					<p>Separation of variables; <m>y = 4e^{-t^2}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="lap-review-mixed-6">
+				<statement>
+					<p>
+						Find the general solution: <m>\ y'' + 2y' + 5y = 0</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> a general solution is requested and the equation is LHCC—the characteristic equation is the direct route (Laplace would drag unknown initial values through every step).
+					</p>
+					<p>
+						<me>r^2 + 2r + 5 = 0 \quad\implies\quad r = \frac{-2 \pm \sqrt{4 - 20}}{2} = -1 \pm 2i</me>
+					</p>
+					<p>
+						Complex roots <m>-1 \pm 2i</m> give
+						<me>y = e^{-t}\left(c_1 \cos 2t + c_2 \sin 2t\right)</me>.
+					</p>
+				</solution>
+				<answer>
+					<p>Characteristic equation; <m>y = e^{-t}\left(c_1\cos 2t + c_2 \sin 2t\right)</m>.</p>
+				</answer>
+			</exercise>
+		</exercisegroup>
+	</exercises>
+</section>

--- a/source/c12-ltp/review-choosing-a-method.ptx
+++ b/source/c12-ltp/review-choosing-a-method.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section xml:id="lap-mixed-review" label="lap-mixed-review">
+<section xml:id="lap-mixed-review">
 	<title>Mixed Review: Choosing Your Method</title>
 
 	<introduction>

--- a/source/c12-ltp/sec-laplace-piecewise-method.ptx
+++ b/source/c12-ltp/sec-laplace-piecewise-method.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section label="piecewise-laplace-method">
+<section xml:id="piecewise-laplace-method" label="piecewise-laplace-method">
 	<title>Laplace Method with Piecewise Forcing Terms</title>
 	
 	<introduction>

--- a/source/c12-ltp/sec-laplace-piecewise-method.ptx
+++ b/source/c12-ltp/sec-laplace-piecewise-method.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section xml:id="piecewise-laplace-method" label="piecewise-laplace-method">
+<section xml:id="piecewise-laplace-method">
 	<title>Laplace Method with Piecewise Forcing Terms</title>
 	
 	<introduction>

--- a/source/c2-solns/exercises-solns.ptx
+++ b/source/c2-solns/exercises-solns.ptx
@@ -18,7 +18,7 @@
 
 		<exercises label="solns-cq">
 
-			<aside>
+			<!-- <aside>
 				<title>Abbreviations</title>
 				<tabular>
 					<col width="10%" />
@@ -32,7 +32,7 @@
 						<cell><em>Initial Value Problem</em></cell>
 					</row>
 				</tabular>
-			</aside>
+			</aside> -->
 
 			<exercise label="solns-cq-tf">
 				<title>True or False</title>
@@ -76,13 +76,10 @@
 					</statement>
 					<feedback>
 						<p>
-							False. This would be true only if there were a single constant in the general solution. When there are multiple constants, multiple initial conditions are required.
+							False. This would be true only if there were a single constant in the general
+							solution. When there are multiple constants, multiple initial conditions are
+							required. <em>It does, however, limit the possible values of the constants.</em>
 						</p>
-						<aside>
-							<p>
-								It does, however, limit the possible values of the constants.
-							</p>
-						</aside>
 					</feedback>
 				</task>
 
@@ -90,7 +87,7 @@
 					<statement>
 						<p>
 							<m>y = x^2 + 3</m> is a solution to the differential equation
-							<me>\frac{dy}{dx} - 3 = 2x</me>.
+							<md>\frac{dy}{dx} - 3 = 2x</md>.
 						</p>
 					</statement>
 					<choices>
@@ -135,9 +132,9 @@
 					<statement>
 						<p>
 							The differential equation,
-							<me>
+							<md>
 								\frac{dy}{dx} = 2xy - 6x
-							</me>,
+							</md>,
 							is an example of an initial-value problem.
 						</p>
 					</statement>
@@ -304,7 +301,7 @@
 					<statement>
 						<p>
 							Consider the differential equation with a missing right side:
-							<me>y'' - \frac{4}{x}y' = <fillin characters="5" /></me>.
+							<md>y'' - \frac{4}{x}y' = <fillin characters="5" /></md>.
 							If <m>y = 2x^3</m> is a solution to this equation, what must the right side be?
 						</p>
 					</statement>
@@ -578,9 +575,9 @@
 					<statement>
 						<p>
 							Consider the algebraic equation
-							<me>
+							<md>
 								2x^2 + 3 = 7x
-							</me>.
+							</md>.
 							<ol marker="i. ">
 							<li>
 								<p>
@@ -666,22 +663,22 @@
 									<li>
 										<p>
 											The process of verifying solutions to differential equations is exactly the same. However, with differential equations, we have to be more careful about confirming a <q>true statement</q>. With numbers, it is easy to see if <m>21=21</m> is true, but with functions, it's a bit trickier. We must ensure that the functions are equal for all values of <m>x</m> (the independent variable). For example, the statement
-											<me>
+											<md>
 												e^x + \sin^2 x + \cos^2 x = e^x + 1
-											</me>
+											</md>
 											is true since <m>\sin^2 x + \cos^2 x = 1</m>. In contrast, the statement
-											<me>
+											<md>
 												e^x + \sin x + \cos x = e^x + 1
-											</me>
+											</md>
 											is not true since <m>\sin x + \cos x = 1</m> does not hold for all values of <m>x</m>. It only takes one value of <m>x</m> to make the statement false. Let's try a few values of <m>x</m> to see this.
 										</p>
 	
 										<p>
 											<sidebyside widths="16% 80%">
 												<p>
-													<me>
+													<md>
 														x = 0:
-													</me>
+													</md>
 												</p>
 												<p>
 													<md>
@@ -695,9 +692,9 @@
 										<p>
 											<sidebyside widths="16% 80%">
 												<p>
-													<me>
+													<md>
 														x = \frac{\pi}{2}:
-													</me>
+													</md>
 												</p>
 												<p>
 													<md>
@@ -711,9 +708,9 @@
 										<p>
 											<sidebyside widths="16% 80%">
 												<p>
-													<me>
+													<md>
 														x = \pi:
-													</me>
+													</md>
 												</p>
 												<p>
 													<md>
@@ -760,7 +757,7 @@
 
 	</subsection>
 
-	<subsection label="solns-practice-drills">
+	<!-- <subsection label="solns-practice-drills">
 		<title><e component="emoji">🏋️‍♂️</e> Practice Drills</title>
 
 		<exercises label="solns-drills">
@@ -970,9 +967,9 @@
 				</exercise>
 			</exercisegroup>
 		</exercises>
-	</subsection>
+	</subsection> -->
 
-	<subsection label="solns-problems-main">
+	<!-- <subsection label="solns-problems-main">
 		<title><e component="emoji">✍🏻</e> Problems </title>
 
 		<exercises label="solns-problems">
@@ -1023,16 +1020,16 @@
 					<solution>
 						<p>
 							The function <m>\ds y = c_{1}e^{2x} + c_{2}xe^{2x}</m> is a solution to the differential equation
-							<me>
+							<md>
 								\frac{d^{2}y}{dx^{2}} - 4\frac{dy}{dx} + 4y = 0
-							</me>
+							</md>
 							since plugging it in gives
-							<me>
+							<md>
 								4c_{1}e^{2x} + 4c_{2}e^{2x} + 4c_{2}xe^{2x} - 4(2c_{1}e^{2x} + c_{2}e^{2x} + 2c_{2}xe^{2x}) + 4(c_{1}e^{2x} + c_{2}xe^{2x}) = 0
-							</me>
-							<me>
+							</md>
+							<md>
 								0 = 0 \quad <e component="emoji">✅</e>
-							</me>
+							</md>
 						</p>
 					</solution>
 				</exercise>
@@ -1108,7 +1105,7 @@
 						<p>
 							Since <m>LHS = RHS</m>, we have verified that
 							<m>y = Ce^{-5x^2} + \frac{3}{5}</m> is a solution to
-							<me>\frac{dy}{dx} = \big( 2x \big) \big( 3 - 5y \big)</me>
+							<md>\frac{dy}{dx} = \big( 2x \big) \big( 3 - 5y \big)</md>
 						</p>
 					</solution>
 				</exercise>
@@ -1352,9 +1349,9 @@
 					<solution>
 						<p>
 							Given that <m>y = mx^2</m>, we first find the derivative:
-							<me>
+							<md>
 								y' = 2mx
-							</me>
+							</md>
 							We need this to equal <m>5x</m>, so:
 							<md>
 								<mrow>	2mx	\amp = 5x	</mrow>
@@ -1458,9 +1455,9 @@
 								<li>
 									<p>
 										Show that <m>y = \dfrac{\ln x + c}{x}</m> is a solution to the differential equation
-										<me>
+										<md>
 											x^2y' + xy = 1, \qquad y(9)=8
-										</me>.
+										</md>.
 									</p>
 								</li>
 								<li>
@@ -1493,9 +1490,9 @@
 									</p>
 
 									<p>
-										<me>
+										<md>
 											\os{\large{\text{LHS}}}{\overline{x^2y^\prime + xy - 1}} = 0
-										</me>
+										</md>
 									</p>
 
 									<p>
@@ -1515,13 +1512,13 @@
 
 									<p>
 										Applying the initial condition <m>y(9)=8</m> gives
-										<me>
+										<md>
 											8 = \frac{\ln 9 + c}{9} \quad \implies \quad c = 72-\ln(9)
-										</me>
+										</md>
 										and so the particular solution is
-										<me>
+										<md>
 											\ds y = \frac{\ln x + 72-\ln(9)}{x}
-										</me>
+										</md>
 									</p>
 								</li>
 							</ol>
@@ -1538,7 +1535,7 @@
 					</statement>
 					<solution>
 						<p>
-							To verify that the function <m>y = -3e^{x^2} + 3</m> is a particular solution to the initial-value problem <me>\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0,</me> we must show the following two things:
+							To verify that the function <m>y = -3e^{x^2} + 3</m> is a particular solution to the initial-value problem <md>\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0,</md> we must show the following two things:
 						</p>
 
 						<p>
@@ -1592,9 +1589,9 @@
 					<statement>
 						<p>
 							Show <m>y = 3x^2 - 2x + 1</m> is a particular solution to
-							<me>
+							<md>
 								\frac{dy}{dx} = 6x - 2, \qquad y(0) = 1
-							</me>.
+							</md>.
 						</p>
 					</statement>
 					<answer><p>Yes</p></answer>
@@ -1627,15 +1624,15 @@
 					<statement>
 						<p>
 							Show <m>y = -3e^{x^2} + 3</m> is a particular solution to
-							<me>
+							<md>
 								\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0
-							</me>.
+							</md>.
 						</p>
 					</statement>
 					<answer><p>Yes.</p></answer>
 					<solution>
 						<p>
-							To verify that the function <m>y = -3e^{x^2} + 3</m> is a particular solution to the initial-value problem <me>\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0</me>, we must show the following two things:
+							To verify that the function <m>y = -3e^{x^2} + 3</m> is a particular solution to the initial-value problem <md>\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0</md>, we must show the following two things:
 						</p>
 
 						<p>
@@ -1683,13 +1680,13 @@
 					<statement>
 						<p>
 							Consider the differential equation
-							<me>
+							<md>
 								y^\prime = y-y^2, \qquad y(0) = 7
-							</me>
+							</md>
 							and the following three functions
-							<me>
+							<md>
 								y_1 = c\sin(-x), \quad y_2 = \frac{1}{c+x^2}, \quad y_3 = \frac{1}{1+ce^{-x}}
-							</me>.
+							</md>.
 							<ol>
 								<li>
 									<p>
@@ -1724,9 +1721,9 @@
 									</p>
 
 									<p>
-										<me>
+										<md>
 											\os{\large{\text{LHS}}}{\overline{y^{\prime}-y+y^2}} = 0
-										</me>
+										</md>
 									</p>
 
 									<p>
@@ -1737,9 +1734,9 @@
 										<ol type="i.">
 											<li>
 											<p>
-												<me>
+												<md>
 													y=c\sin(-x) \quad \implies \quad y^\prime = -c\cos(-x)
-												</me>
+												</md>
 											</p>
 
 											<p>
@@ -1759,9 +1756,9 @@
 											</li>
 											<li>
 											<p>
-												<me>
+												<md>
 													y = \frac{1}{c+x^2} \quad \implies \quad y^\prime = \frac{-2x}{(c+x^2)^2}
-												</me>
+												</md>
 											</p>
 
 											<p>
@@ -1784,9 +1781,9 @@
 											</li>
 											<li>
 											<p>
-												<me>
+												<md>
 													y = \frac{1}{1+ce^{-x}} \quad \implies \quad y^\prime = \frac{ce^{-x}}{(1+ce^{-x})^2}
-												</me>
+												</md>
 											</p>
 
 											<p>
@@ -1816,16 +1813,16 @@
 									</p>
 
 									<p>
-										<me>
+										<md>
 											7 = \frac{1}{1+c} \quad \implies \quad c = \frac{1}{7}-1 = -\frac{6}{7}
-										</me>
+										</md>
 									</p>
 
 									<p>
 										So the particular solution for this initial condition is
-										<me>
+										<md>
 											y = \frac{1}{1-\frac{6}{7}e^{-x}}
-										</me>
+										</md>
 									</p>
 								</li>
 							</ol>
@@ -1837,6 +1834,6 @@
 
 		</exercises>
 		
-	</subsection>
+	</subsection> -->
 
 </section>

--- a/source/c2-solns/sec-general-particular-solns.ptx
+++ b/source/c2-solns/sec-general-particular-solns.ptx
@@ -15,17 +15,17 @@
 
 	<p>
 			You know that a solution to a differential equation is a function that satisfies the equation. But <xref ref="example-whats-a-soln-1"/> shows that the differential equation
-			<me>
+			<md>
 				y' - 2y = 0
-			</me>
+			</md>
 			has multiple solutions, all of which differ by a constant factor:
-			<me>
+			<md>
 				y = e^{2x},\quad y = 3e^{2x},\quad y = -5e^{2x},\quad y = \pi e^{2x}, \quad\text{ etc. } 
-			</me>
+			</md>
 			Rather than listing all possible solutions, we can express them all at once using a formula that includes an arbitrary constant:
-			<me>
+			<md>
 				y = ce^{2x},
-			</me>
+			</md>
 			where <m>c</m> can be any real number. This formula is called the <xref ref="gi-general-solution" text="custom">general solution</xref> of the differential equation, and each choice of <m>c</m> gives a different <xref ref="gi-particular-solution" text="custom">particular solution</xref>.
 	</p>
 
@@ -102,9 +102,9 @@
 		<title>Not all solutions with constants are general solutions</title>
 		<p>
 			Keep in mind, solutions with arbitrary constants are not general solutions by default. For example, both of the functions
-			<me>
+			<md>
 				y = \frac{1}{2}x^2 + c_1 x \quad \text{and} \quad y = \frac{1}{2}x^2 + c_1 x + c_2
-			</me>
+			</md>
 			are solutions to the equation <m>y'' = 1</m>, but only the second is the general solution. The first is a special case of the second, obtained when <m>c_2 = 0</m>.
 		</p>
 	</warning>
@@ -117,13 +117,13 @@
 			<statement>
 				<p>
 					Given that the differential equation 
-					<me>
+					<md>
 						2t\ y' + 4y = 3
-					</me>
+					</md>
 					has the general solution
-					<me>
+					<md>
 						y = \frac{3}{4} + \frac{c}{t^2}
-					</me>
+					</md>
 					select all the solutions to this equation.
 				</p>
 			</statement>
@@ -243,9 +243,9 @@
 					<feedback>
 						<p>
 							Keep in mind, solutions with arbitrary constants are not general solutions by default. For example, both of the functions
-							<me>
+							<md>
 								y = \frac{1}{2}x^2 + c_1 x \quad \text{and} \quad y = \frac{1}{2}x^2 + c_1 x + c_2
-							</me>
+							</md>
 							are solutions to the equation <m>y'' = 1</m>, but only the second is the general solution. The first is a special case of the second, obtained when <m>c_2 = 0</m>.
 						</p>
 					</feedback>

--- a/source/c2-solns/sec-initial-valued-problems.ptx
+++ b/source/c2-solns/sec-initial-valued-problems.ptx
@@ -42,11 +42,11 @@
 
 	<p>
 		The <xref ref="gi-general-solution" text="custom">general solution</xref> can be found by integrating <m>h''(t)</m> twice:
-		<me>
+		<md>
 			h''(t) = -32 \quad\Rightarrow\quad
 			h'(t) = c_1 - 32t \quad\Rightarrow\quad
 			h(t) = c_2 + c_1t - 16t^2
-		</me>
+		</md>
 	</p>
 
 	<p>
@@ -73,13 +73,13 @@
 		<statement>
 			<p>
 				Find the particular solution to the initial-value problem:
-				<me xml:id="eqn-initial-conditions-1">
+				<md xml:id="eqn-initial-conditions-1" number="yes">
 					\frac{dy}{dx} = 2xy - 6x, \quad y(0) = 2
-				</me>
+				</md>
 				given that the general solution is:
-				<me>
+				<md>
 					y = ce^{x^2} + 3.
-				</me>
+				</md>
 			</p>
 		</statement>
 
@@ -94,9 +94,9 @@
 			</p>
 			<p>
 				Thus, the particular solution is:
-				<me>
+				<md>
 					y = -e^{x^2} + 3.
-				</me>
+				</md>
 			</p>
 		</solution>
 	</example>
@@ -110,17 +110,17 @@
 		<statement>
 			<p>
 				Verify that the function
-				<me>
+				<md>
 					y = c_1 e^{-3t} + c_2 e^{4t}
-				</me>
+				</md>
 				is a solution to
-				<me>
+				<md>
 					y'' - y' - 12y = 0,
-				</me>
+				</md>
 				and then find the particular solution satisfying:
-				<me>
+				<md>
 					y(0) = 4, \quad y'(0) = -5.
-				</me>
+				</md>
 			</p>
 		</statement>
 
@@ -176,16 +176,16 @@
 					<mrow> -3c_1 + 4c_2 \amp = -5 </mrow>
 				</md>
 				Substituting and solving yields:
-				<me>
+				<md>
 					c_1 = 3, \quad c_2 = 1.
-				</me>
+				</md>
 			</p>
 
 			<p>
 				The particular solution is:
-				<me>
+				<md>
 					y = 3e^{-3t} + e^{4t}.
-				</me>
+				</md>
 			</p>
 		</solution>
 	</example>
@@ -260,9 +260,9 @@
 			<statement>
 				<p>
 					The differential equation
-					<me>
+					<md>
 						\frac{dy}{dx} = 2xy - 6x
-					</me>
+					</md>
 					is an example of an initial-value problem.
 				</p>
 			</statement>
@@ -355,9 +355,9 @@
 		<title>✳️ Existence &amp; Uniqueness (Informal)</title>
 		<p>
 			Consider the first-order initial value problem
-			<me>
+			<md>
 				\frac{dy}{dx} = f(x, y), \qquad y(x_0) = y_0.
-			</me>
+			</md>
 			If <m>f</m> is continuous and changes smoothly with respect to <m>y</m> near the starting point <m>(x_0, y_0)</m><fn>The precise condition is that <m>f</m> and its partial derivative <m>\frac{\partial f}{\partial y}</m> (the derivative treating <m>x</m> as constant) are both continuous on a rectangle containing <m>(x_0, y_0)</m>. This result is known as the Picard–Lindelöf theorem.</fn>, then the initial value problem has <em>exactly one</em> solution on some interval around <m>x_0</m>.
 		</p>
 	</assemblage>
@@ -375,18 +375,18 @@
 		<statement>
 			<p>
 				Show that the initial value problem
-				<me>
+				<md>
 					\frac{dy}{dx} = 3y^{2/3}, \qquad y(0) = 0
-				</me>
+				</md>
 				has at least two different solutions.
 			</p>
 		</statement>
 		<solution>
 			<p>
 				The constant function <m>y_1(x) = 0</m> works: both sides are <m>0</m>, and <m>y_1(0) = 0</m>. But so does <m>y_2(x) = x^3</m>: substituting gives
-				<me>
+				<md>
 					y_2' = 3x^2 \qquad \text{and} \qquad 3y_2^{2/3} = 3\left(x^3\right)^{2/3} = 3x^2,
-				</me>
+				</md>
 				and <m>y_2(0) = 0</m>. Two genuinely different solutions pass through the same initial point (in fact, infinitely many do — a solution can follow <m>y = 0</m> for a while and then peel off onto a shifted cubic).
 			</p>
 			<p>

--- a/source/c2-solns/sec-solns-to-eqns.ptx
+++ b/source/c2-solns/sec-solns-to-eqns.ptx
@@ -22,9 +22,9 @@
 
 		<p>
 			For example, consider the equation:
-			<me>
+			<md>
 				y^3 = 3y + 2.
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -63,9 +63,9 @@
 
 		<p>
 			For instance, consider the differential equation:
-			<me>
+			<md>
 				y' = 3y.
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -124,7 +124,7 @@
 				<statement correct="no">
 					<p>
 						The function, <m>y = x^2 + 3</m>, is a solution to the equation
-						<me>\frac{dy}{dx} - 3 = 2x</me>.
+						<md>\frac{dy}{dx} - 3 = 2x</md>.
 					</p>
 				</statement>
 

--- a/source/c2-solns/sec-verifying-solns.ptx
+++ b/source/c2-solns/sec-verifying-solns.ptx
@@ -48,9 +48,9 @@
 		<solution>
 			<p>
 				Since <m>P''</m> appears, compute the derivatives first:
-				<me>	
+				<md>	
 					P = \sin t, \quad P' = \cos t, \quad P'' = -\sin t
-				</me>
+				</md>
 			</p>
 
 			<p>
@@ -75,9 +75,9 @@
 		<statement>
 			<p>
 				Show that the functions
-				<me>y = e^{2x},\quad y = -5e^{2x},\quad y = \pi e^{2x},\quad y = 0</me>
+				<md>y = e^{2x},\quad y = -5e^{2x},\quad y = \pi e^{2x},\quad y = 0</md>
 				are all solutions to the differential equation
-				<me>y' - 2y = 0</me>.
+				<md>y' - 2y = 0</md>.
 			</p>
 		</statement>
 		<solution>
@@ -87,13 +87,13 @@
 			
 			<p>
 				Substitute <m>y = c e^{2x}</m> into the equation:
-				<me>
+				<md>
 					y' - 2y = (c e^{2x})' - 2(c e^{2x})	= 2c e^{2x} - 2c e^{2x}	= 0 \quad <e component="emoji">✅</e>
-				</me>
+				</md>
 				So <m>y = c e^{2x}</m> is a solution for any constant <m>c</m>. In particular, this includes the functions
-				<me>
+				<md>
 					y = e^{2x},\quad y = -5e^{2x},\quad y = \pi e^{2x},\quad y = 0
-				</me>
+				</md>
 				for the constants <m>c = 1, -5, \pi, 0</m> respectively.
 			</p>
 		</solution>
@@ -107,17 +107,17 @@
 		<statement>
 			<p>
 				Verify that <m>\ y = c_1\ x^2 + c_2 - \ln x\ </m> is a solution to
-				<me>x^2y'' - xy' = 2</me>.
+				<md>x^2y'' - xy' = 2</md>.
 			</p>
 		</statement>
 		<solution>
 			<p>
 				Compute the needed derivatives:
-				<me>
+				<md>
 					y = c_1\ x^2 + c_2 - \ln x \ \ \Rightarrow \ \ 
 					y' = 2 c_1\ x - \frac{1}{x} \ \ \Rightarrow \ \ 
 					y'' = 2 c_1 + \frac{1}{x^2}
-				</me>
+				</md>
 				and substitute into the equation:
 				<md>
 					<mrow> 

--- a/source/c2-solns/sec-visualizing-solns.ptx
+++ b/source/c2-solns/sec-visualizing-solns.ptx
@@ -30,13 +30,13 @@
 		<title><e component="emoji">📈</e> Interactive: Visualizing Solutions</title>
 		<p>
 			Consider the differential equation:
-			<me>
+			<md>
 				\frac{dy}{dx} = 2xy - 6x,
-			</me>
+			</md>
 			which has the general solution:
-			<me>
+			<md>
 				y = c e^{x^2} + 3.
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -47,7 +47,10 @@
 			<caption>Particular solutions with different initial conditions.</caption>
 			<sidebyside width="50%">
 				<p>
-					<interactive xml:id="interactive-drag-ic" platform="jsxgraph" source="code/initial-condition.js">
+					<interactive xml:id="interactive-drag-ic" 
+						platform="jsxgraph" 
+						source="code/initial-condition.js"
+					>
 						<slate xml:id="interactive-drag-ic-slate" surface="jsxboard"/>
 					</interactive>
 				</p>
@@ -95,7 +98,7 @@
 				<statement>
 					<p>
 						What is the initial condition for the particular solution
-						<me>y = 1.3e^{x^2} + 3</me>?
+						<md>y = 1.3e^{x^2} + 3</md>?
 					</p>
 				</statement>
 				<choices randomize="yes">

--- a/source/c3-di/exercises-di.ptx
+++ b/source/c3-di/exercises-di.ptx
@@ -27,9 +27,9 @@
 					<statement>
 						<p>
 							We can solve
-							<me>
+							<md>
 								\dfrac{dy}{dx} = x^3 - 7
-							</me>
+							</md>
 							for <m>y</m> by differentiating both sides with respect to <m>x</m>.
 						</p>
 					</statement>
@@ -69,9 +69,9 @@
 					<statement>
 						<p>
 							Solving for <m>y</m> in the equation
-							<me>
+							<md>
 								\dfrac{dy}{dx} = \ln(3x+1)
-							</me>
+							</md>
 							amounts to finding the antiderivative of <m>\ln(3x+1)</m>.
 						</p>
 					</statement>
@@ -86,9 +86,9 @@
 							<feedback>
 								<p>
 									Correct, integrating both sides gives
-									<me>
+									<md>
 										y = \int \ln(3x+1)\ dx \quad \leftarrow \text{antiderivative of } \ln(3x+1)
-									</me>.
+									</md>.
 								</p>
 							</feedback>
 						</choice>
@@ -146,9 +146,9 @@
 					<statement correct="yes">
 						<p>
 							Direct integration could be used to solve the equation
-							<me>
-								\dfrac{d}{dx}\left[y^2 + x^3\right] = \sqrt{x}
-							</me>.
+							<md>
+								\frac{d}{dx}\left[y^2 + x^3\right] = \sqrt{x}
+							</md>.
 						</p>
 					</statement>
 
@@ -214,9 +214,9 @@
 					<statement>
 						<p>
 							How could you solve for <m>y</m> in the equation
-							<me>
-								\frac12\dfrac{dy}{dx} - \tan(2x) = x
-							</me>?
+							<md>
+								\frac12\frac{dy}{dx} - \tan(2x) = x
+							</md>?
 						</p>
 					</statement>
 
@@ -277,7 +277,7 @@
 
 					<statement>
 						<p>
-							The solution to the differential equation <me>\frac13 y' - 7x + x^2 = 1</me> is the antiderivative of which function?
+							The solution to the differential equation <md>\frac13 y' - 7x + x^2 = 1</md> is the antiderivative of which function?
 						</p>
 					</statement>
 
@@ -307,9 +307,9 @@
 							<feedback>
 								<p>
 									Correct! Isolating <m>y'</m> gives
-									<me>
+									<md>
 										y' = 21x - 3x^2 + 3
-									</me>,
+									</md>,
 									so the solution is the antiderivative of <m>21x - 3x^2 + 3</m>.
 								</p>
 							</feedback>
@@ -324,9 +324,9 @@
 					<statement>
 						<p>
 							Give the reason direct integration cannot be applied to the equation
-							<me>
+							<md>
 								\dfrac{d}{dx}\left[\dfrac{x}{y^2}\right] = \sin(x+y)
-							</me>.
+							</md>.
 						</p>
 					</statement>
 
@@ -374,9 +374,9 @@
 					<statement>
 						<p>
 							In the differential equation
-							<me>
+							<md>
 								\dfrac{d}{dx}\left[5x \cdot y\right] = \dfrac{1}{x^2}
-							</me>,
+							</md>,
 							what is the first step in solving for <m>y</m>?
 						</p>
 					</statement>
@@ -471,7 +471,9 @@
 					<statement>
 						<p>
 							Attempt to apply direct integration to the differential equation
-							<me> \dfrac{dy}{dx} = x + y</me>.
+							<md>
+								\frac{dy}{dx} = x + y
+							</md>.
 							Get to the point where it becomes clear that you cannot solve for <m>y</m> directly. What is the obstacle?
 						</p>
 					</statement>
@@ -891,7 +893,7 @@
 				<introduction>
 					<p>
 						Given the differential equation
-						<me>y'= e^{2t} - 4t</me>
+						<md>y'= e^{2t} - 4t</md>
 						Find the general solution.
 					</p>
 					<p>
@@ -933,7 +935,7 @@
 				<statement>
 					<p>
 						Solve the initial-value problem
-						<me>2y' - 4\sin x = 2, \quad y(0) = 5 </me>.
+						<md>2y' - 4\sin x = 2, \quad y(0) = 5 </md>.
 					</p>
 				</statement>
 
@@ -941,7 +943,7 @@
 
 					<p>
 						Start by isolating the derivative, <m>y'</m>, on one side of the equation
-						<me> y' = 1 + 2 \sin x </me>.
+						<md> y' = 1 + 2 \sin x </md>.
 						Integrate both sides with respect to <m>x</m> to leave us with <m>y</m> on the left side
 						<md>
 							<mrow> \int y'\ dx 	\amp = \int \left(1 + 2 \sin x\right) \ dx 				</mrow>
@@ -973,7 +975,7 @@
 
 			<p>
 				At this point, you should be comfortable solving an equation such as
-				<me>\left[x^7 y \right]^{\prime} = e^x</me>.
+				<md>\left[x^7 y \right]^{\prime} = e^x</md>.
 				The problem is that most equations do not start in this form. Instead, they start in another form and, after some algebra, are put into this convenient form and solved. The process of rewriting an equation in this way forms the basis of another technique, the integrating factor method. The question we want to answer here is <q>what type of equations can be written in this form?</q>
 			</p>
 
@@ -982,9 +984,9 @@
 					<statement>
 						<p>
 							To understand which equation can be rewritten in the form
-							<me>
+							<md>
 								\left[x^7 y \right]^{\prime} = e^x
-							</me>,
+							</md>,
 							we will work backwards and expand the derivative on the left side using the product rule from calculus to turn our equation into
 						</p>
 
@@ -1070,9 +1072,9 @@
 								<mrow> \amp = 7x^6 y + x^7 y' </mrow>
 							</md>
 							So the equation becomes:
-							<me>
+							<md>
 								x^7 y' + 7x^6 y = e^x
-							</me>
+							</md>
 						</p>
 						<p>
 							To rewrite this in the form <m>y' + P(x) y = Q(x)</m>, divide both sides by <m>x^7</m>:
@@ -1103,9 +1105,9 @@
 							<li>
 								<p>
 									Use the product rule to rewrite each differential equation in the form
-									<me>
+									<md>
 										y^{\prime} + P(x) y = Q(x)
-									</me>.
+									</md>.
 								</p>
 							</li>
 							<li>

--- a/source/c3-di/sec-antiderivatives.ptx
+++ b/source/c3-di/sec-antiderivatives.ptx
@@ -52,13 +52,13 @@
 		<title>Solutions as Antiderivatives</title>
 		<p>
 			The general solution to any differential equation of the form
-			<me>
+			<md>
 				\dfrac{dy}{dx} = f(x)
-			</me>
+			</md>
 			where only the independent variable appears on the right side, is given by
-			<me>
+			<md>
 				y(x) = F(x) + c
-			</me>
+			</md>
 			where <m>F(x)</m> is any antiderivative of <m>f(x)</m> and <m>c</m> is any constant.
 		</p>
 	</assemblage> -->
@@ -70,9 +70,9 @@
 			<statement>
 				<p>
 					Solving for <m>y</m> in the equation
-					<me>
+					<md>
 						\frac{dy}{dx} = \ln(3x+1)
-					</me>
+					</md>
 					amounts to finding the antiderivative of <m>\ln(3x+1)</m>.
 				</p>
 			</statement>
@@ -82,9 +82,9 @@
 					<feedback>
 						<p>
 							Correct, integrating both sides gives
-							<me>
+							<md>
 								y = \int \ln(3x+1)\ dx \quad \leftarrow \text{antiderivative of } \ln(3x+1)
-							</me>.
+							</md>.
 						</p>
 					</feedback>
 				</choice>
@@ -101,9 +101,9 @@
 			<statement>
 				<p>
 					Give the general solution to the differential equation:
-					<me>
+					<md>
 						\frac{dy}{dx} = x^3 - 7.
-					</me>
+					</md>
 				</p>
 			</statement>
 			<hint>
@@ -149,9 +149,9 @@
 			<statement>
 				<p>
 					Suppose you saw the following expression from calculus:
-					<me>
+					<md>
 						\frac{dy}{dx} = x^3 - 7.
-					</me>
+					</md>
 					Select all of the true statements.
 				</p>
 			</statement>

--- a/source/c3-di/sec-di-method.ptx
+++ b/source/c3-di/sec-di-method.ptx
@@ -16,18 +16,18 @@
 	<introduction>
 		<p>
 			In the previous section, we saw how finding the <xref ref="gi-antiderivative" text="title"/> of <m>x^2</m> can be rephrased as solving the differential equation
-			<me>
+			<md>
 				y'(x) = x^2.
-			</me>
+			</md>
 		</p>
 
 		<aside>
 			<title>Link to Algebra</title>
 			<p>
 				Just as taking the square root of both sides of the equation
-				<me>x^2 = 9</me>
+				<md>x^2 = 9</md>
 				helps isolate <m>x</m>, integrating both sides of
-				<me>y' = x^2</me>
+				<md>y' = x^2</md>
 				helps isolate the unknown function, <m>y</m>.
 			</p>	
 		</aside>
@@ -43,16 +43,16 @@
 
 		<p>
 			Let's use integration to solve the following equation:
-			<me>
+			<md>
 				2y' - 4\sin x = 2
-			</me>.
+			</md>.
 		</p>
 
 		<p>
 			We begin by isolating <m>y'</m>:
-			<me>
+			<md>
 				2y' = 2 + 4\sin x \quad \Rightarrow \quad y' = \frac12(2 + 4\sin x) \quad \Rightarrow \quad y' = 1 + 2\sin x
-			</me>.
+			</md>.
 		</p>
 
 		<p>
@@ -77,16 +77,16 @@
 
 		<p>
 			Let's extend this idea to solve the equation:
-			<me>
+			<md>
 				x^2\frac{d}{dx}\left[5x \cdot y\right] - 1 = 0
-			</me>.
+			</md>.
 		</p>
 
 		<p>
 			Currently, <m>y</m> is trapped inside a derivative, but perhaps integration could release it. Start by isolating this derivative:
-			<me>
+			<md>
 				\frac{d}{dx}\left[5x \cdot y\right] = \frac{1}{x^2}.
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -116,9 +116,9 @@
 			<p>
 				<idx><h>direct integration</h></idx>
 				If a differential equation can be expressed in one of the forms:
-				<men xml:id="direct-integration-equation">
+				<md xml:id="direct-integration-equation" number="yes">
 					\frac{dy}{dx} = f(x) \quad\text{or}\quad \frac{d}{dx}\left[g(x,y)\right] = f(x)
-				</men>,
+				</md>,
 				then the <xref ref="gi-general-solution" text="title"/> can be found by
 				<ol marker="(1)">
 					<li>integrating both sides with respect to <m>x</m>, and</li>
@@ -132,9 +132,9 @@
 			<statement>
 				<p>
 					Find the general solution to the differential equation
-					<me>
+					<md>
 						\frac{1}{\cos x}\frac{d}{dx}\Big[y\sin(2x)\Big] - 1 = \sec x
-					</me>
+					</md>
 				</p>
 			</statement>
 
@@ -143,9 +143,9 @@
 					First, we get the derivative by itself on the left-hand side
 					<aside><title>☝️ Recall the Identity</title>
 						<p>
-							<me>
+							<md>
 								\sec x = \frac{1}{\cos x}
-							</me>
+							</md>
 						</p>
 					</aside>
 					<md>
@@ -185,18 +185,18 @@
 			<statement>
 				<p>
 					Show why direct integration doesn't apply to the equation: 
-					<me>
+					<md>
 						\frac{dy}{dx} - y = x
-					</me>
+					</md>
 				</p>
 			</statement>
 
 			<solution>
 				<p>
 					Isolating the derivative gives:
-					<me>
+					<md>
 						\frac{dy}{dx} = x + y.
-					</me>
+					</md>
 					Since the derivative is with respect to <m>x</m>, we must integrate both sides with respect to <m>x</m> as well:
 					<md>
 						<mrow>\int\frac{dy}{dx}\ dx	\amp = \int (x + y)\ dx</mrow>
@@ -215,9 +215,9 @@
 
 		<p>
 			<xref ref="gi-direct-integration" text="title"/> is a simple method for solving differential equations, provided the structure permits it. If your equation can be written as
-			<me>
+			<md>
 				\frac{d}{dx}[x\ \text{and}\ y\ \text{terms}] = \text{only}\ x\ \text{terms}
-			</me>,
+			</md>,
 			you're in business. Just integrate both sides and solve for <m>y</m>.
 		</p>
 
@@ -228,9 +228,9 @@
 				<statement>
 					<p>
 						How could you solve for <m>y</m> in the equation
-						<me>
+						<md>
 							\frac12\frac{dy}{dx} - \tan(2x) = x
-						</me>?
+						</md>?
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -258,9 +258,9 @@
 				<statement>
 					<p>
 						The solution to the differential equation
-						<me>
+						<md>
 							\frac13 y' - 7x + x^2 = 1
-						</me>
+						</md>
 						is the integral of which function?
 					</p>
 				</statement>
@@ -284,9 +284,9 @@
 						<feedback>
 							<p>
 								Correct! Isolating <m>y'</m> gives
-								<me>
+								<md>
 									y' = 21x - 3x^2 + 3
-								</me>,
+								</md>,
 								so the solution is <m>\int (21x - 3x^2 + 3)\ dx</m>.
 							</p>
 						</feedback>
@@ -300,9 +300,9 @@
 				<statement>
 					<p>
 						Direct integration could be used to solve the equation
-						<me>
+						<md>
 							\frac{d}{dx}\left[y^2 + x^3\right] = \sqrt{x}
-						</me>.
+						</md>.
 					</p>
 				</statement>
 				<choices>
@@ -322,9 +322,9 @@
 				<statement>
 					<p>
 						Give the reason direct integration cannot be applied to the equation
-						<me>
+						<md>
 							\frac{d}{dx}\left[\frac{x}{y^2}\right] = \sin(x+y)
-						</me>.
+						</md>.
 					</p>
 				</statement>
 

--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -85,22 +85,22 @@
 					<statement correct="yes">
 						<p>
 							Any differential equation that can be written in the form
-							<me>
+							<md>
 								h(y) \frac{dy}{dx} = g(x)
-							</me>,
+							</md>,
 							is separable.
 						</p>
 					</statement>
 					<feedback>
 						<p>
 							True. Any differential equation that can be written in the form
-							<me>
+							<md>
 								h(y) \frac{dy}{dx} = g(x)
-							</me>
+							</md>
 							can also be rewritten in the separable form
-							<me>
+							<md>
 								\frac{dy}{dx} = g(x)\cdot \frac{1}{h(y)}
-							</me>.
+							</md>.
 						</p>
 					</feedback>
 				</task>
@@ -110,9 +110,9 @@
 					<statement correct="yes">
 						<p>
 							The differential equation, below, is <xref ref="separable" text="custom">separable</xref>.
-							<me>
+							<md>
 								\frac{dy}{dx} = \frac{\cos x}{y}
-							</me>
+							</md>
 						</p>
 					</statement>
 					<feedback>
@@ -124,17 +124,17 @@
 						</p>
 						<p>
 							This differential equation is the same as
-							<me>
+							<md>
 								\frac{dy}{dx} = g(x) \cdot (1)
-							</me>,
+							</md>,
 							which shows that the equation is separable since the function of <m>y</m> can be constant.
 						</p>
 					
 						<p>
 							The equation is separable because it is first-order and can be written in the separable form
-							<me>
+							<md>
 								\frac{dy}{dx} = \cos x \left(\frac{1}{y}\right)
-							</me>.
+							</md>.
 						</p>
 					</feedback>
 				</task>
@@ -144,17 +144,17 @@
 					<statement correct="yes">
 						<p>
 							The differential equation, below, is <xref ref="separable" text="custom">separable</xref>.
-							<me>
+							<md>
 								\frac{dy}{dx} = y^2
-							</me>
+							</md>
 						</p>
 					</statement>
 					<feedback>
 						<p>
 							The equation is separable because it is first-order and can be written in the separable form
-							<me>
+							<md>
 								\frac{dy}{dx} = y^2 = (1)(y^2) = \underset{f(x)}{\left(\boxed{1}\right)}\underset{g(y)}{\left(\boxed{y^2}\right)}
-							</me>.
+							</md>.
 						</p>
 					</feedback>
 				</task>
@@ -164,17 +164,17 @@
 					<statement correct="yes">
 						<p>
 							The differential equation, below, is <xref ref="separable" text="custom">separable</xref>.
-							<me>
+							<md>
 								\frac{dy}{dx} = x - 1
-							</me>
+							</md>
 						</p>
 					</statement>
 					<feedback>
 						<p>
 							The equation is separable because it is first-order and can be written in the separable form
-							<me>
+							<md>
 								\frac{dy}{dx} = x - 1 = (x - 1)(1) = \underset{f(x)}{\left(\boxed{x - 1}\right)}\underset{g(y)}{\left(\boxed{1}\right)}.
-							</me>
+							</md>
 						</p>
 					</feedback>
 				</task>
@@ -184,17 +184,17 @@
 					<statement correct="yes">
 						<p>
 							The differential equation, below, is <xref ref="separable" text="custom">separable</xref>.
-							<me>
+							<md>
 								\frac{dy}{dx} = 15
-							</me>
+							</md>
 						</p>
 					</statement>
 					<feedback>
 						<p>
 							The equation is separable because it is first-order and can be written in the separable form
-							<me>
+							<md>
 								\frac{dy}{dx} = 15 = (15)(1) = \underset{f(x)}{\left(\boxed{15}\right)}\underset{g(y)}{\left(\boxed{1}\right)}.
-							</me>
+							</md>
 						</p>
 					</feedback>
 				</task>
@@ -204,18 +204,18 @@
 					<statement correct="no">
 						<p>
 							The differential equation,
-							<me>
+							<md>
 								x + \frac{dy}{dx} = y
-							</me>,
+							</md>,
 							can be solved using the separation of variables method.
 						</p>
 					</statement>
 					<feedback>
 						<p>
 							The differential equation is first order, but it is equivalent to
-							<me>
+							<md>
 								\frac{dy}{dx}=y-x
-							</me>,
+							</md>,
 							which can not be written in the form <m>\dfrac{dy}{dx}=f(x)g(y)</m>.
 						</p>
 					</feedback>
@@ -231,9 +231,9 @@
 					<statement correct="no">
 						<p>
 							The differential equation,
-							<me>
+							<md>
 								\frac{d^2z}{dt^2} = \cos^2(z)
-							</me>,
+							</md>,
 							can be solved using the separation of variables method.
 						</p>
 					</statement>
@@ -275,9 +275,9 @@
 					<statement>
 						<p>
 							What is the first step to verify that the differential equation below is separable?
-							<me>
+							<md>
 								\frac{dy}{dx} + \frac{x}{y^2} = 0
-							</me>
+							</md>
 						</p>
 					</statement>
 
@@ -392,7 +392,7 @@
 					<statement>
 						<p>
 							What can you say about any differential equation that can be written in the form
-							<me>\frac{dy}{dx} = g(x)</me>?
+							<md>\frac{dy}{dx} = g(x)</md>?
 						</p>
 					</statement>
 
@@ -714,9 +714,9 @@
 					<statement>
 						<p>
 							Ignoring the fact that the following equation is not separable, suppose we applied the separation of variables process to
-							<me>
+							<md>
 								\frac{dy}{dx} = y^2 + x
-							</me>.
+							</md>.
 							What breaks down leading up to the <xref ref="sov-step-2" text="custom">integrate step</xref>?
 						</p>
 					</statement>
@@ -726,13 +726,13 @@
 					<feedback>
 						<p>
 							The next step in the process says to divide both sides by the function of <m>y</m>. In our case, this is <m>y^2</m>, so we would get
-							<me>
+							<md>
 								\frac{1}{y^2} \frac{dy}{dx} = 1 + \frac{x}{y^2}
-							</me>.
+							</md>.
 							Now, multiplying both sides by <m>dx</m> and integrating would yield
-							<me>
+							<md>
 								\int \frac{1}{y^2} dy = \int \left( 1 + \frac{x}{y^2} \right) dx
-							</me>.
+							</md>.
 							The integral on the left side is fine, but the one on the right is where the process breaks down, since it wants to integrate with respect to <m>x</m>. Therefore, you are stuck unless you know <m>y</m> as a function of <m>x</m>. However, if this were the case, you would have already solved the problem!
 						</p>
 					</feedback>
@@ -764,9 +764,9 @@
 					<statement>
 						<p>
 							All first-order linear differential equations with dependent variable, <m>y</m>, can be written in the form
-							<me>
+							<md>
 								\frac{dy}{dx} + P(x) y = Q(x)
-							</me>
+							</md>
 							where <m>P(x)</m> and <m>Q(x)</m> are known functions of <m>x</m>. What must be true about <m>P(x)</m> and <m>Q(x)</m> for a first-order linear differential equation to be separable?
 						</p>
 						<hint>
@@ -781,28 +781,28 @@
 					<feedback>
 						<p>
 							Attempting to isolate the derivative on the left, we get:
-							<me>
+							<md>
 								\frac{dy}{dx} = Q(x) -  P(x) y
-							</me>
+							</md>
 							Since <m>Q(x)</m> and <m>P(x)</m> can only contain the variable <m>x</m> or constants, then this form is only separable in the following cases:
 							<ol>
 								<li>
 									Both <m>Q(x) = Q_0</m> and <m>P(x)=P_0</m> are constant. Then
-									<me>
+									<md>
 										\frac{dy}{dx} = Q_0 - P_0 y = (1) \cdot (Q_0 -  P_0 y)
-									</me>
+									</md>
 								</li>
 								<li>
 									<m>Q(x) = 0</m> and <m>P(x)</m> is anything. Then
-									<me>
+									<md>
 										\frac{dy}{dx} = 0 - P(x) y = (-P(x)) \cdot (y)
-									</me>
+									</md>
 								</li>
 								<li>
 									<m>Q(x) = 0</m> is anything and <m>P(x) = 0</m>. Then
-									<me>
+									<md>
 										\frac{dy}{dx} = Q(x) - (0) y = (Q(x)) \cdot (1)
-									</me>
+									</md>
 								</li>
 							</ol>
 						</p>
@@ -811,28 +811,28 @@
 					<solution>
 						<p>
 							Attempting to isolate the derivative on the left, we get:
-							<me>
+							<md>
 								\frac{dy}{dx} = Q(x) -  P(x) y
-							</me>
+							</md>
 							Since <m>Q(x)</m> and <m>P(x)</m> can only contain the variable <m>x</m> or constants, then this form is only separable in the following cases:
 							<ol>
 								<li>
 									Both <m>Q(x) = Q_0</m> and <m>P(x)=P_0</m> are constant. Then
-									<me>
+									<md>
 										\frac{dy}{dx} = Q_0 - P_0 y = (1) \cdot (Q_0 -  P_0 y)
-									</me>
+									</md>
 								</li>
 								<li>
 									<m>Q(x) = 0</m> and <m>P(x)</m> is anything. Then
-									<me>
+									<md>
 										\frac{dy}{dx} = 0 - P(x) y = (-P(x)) \cdot (y)
-									</me>
+									</md>
 								</li>
 								<li>
 									<m>Q(x) = 0</m> is anything and <m>P(x) = 0</m>. Then
-									<me>
+									<md>
 										\frac{dy}{dx} = Q(x) - (0) y = (Q(x)) \cdot (1)
-									</me>
+									</md>
 								</li>
 							</ol>
 						</p>
@@ -860,7 +860,7 @@
 				<statement>
 					<p>
 						Verify that <m>z = \tan(t+C)</m> is a solution to the initial value problem
-						<me>z' - 1 = z^2, \quad z(4) = 9</me> then find the particular solution.
+						<md>z' - 1 = z^2, \quad z(4) = 9</md> then find the particular solution.
 					</p>
 				</statement>
 
@@ -877,12 +877,12 @@
 
 					<p>
 						Now, let's find <m>C</m> with the initial condition <m>z(4) = 9</m>:
-						<me>9 = z(4) = \tan(4+C)\quad\Rightarrow\quad C = \arctan(9) - 4</me>
+						<md>9 = z(4) = \tan(4+C)\quad\Rightarrow\quad C = \arctan(9) - 4</md>
 					</p>
 
 					<p>
 						So the particular solution is:
-						<me>z = \tan(t + \arctan(9) - 4)</me>
+						<md>z = \tan(t + \arctan(9) - 4)</md>
 					</p>
 				</solution>
 				<answer>
@@ -894,13 +894,13 @@
 				<title>Show the differential equation is separable</title>
 
 				<statement>
-					<p><me>t - ss' = - s</me></p>
+					<p><md>t - ss' = - s</md></p>
 				</statement>
 
 				<solution>
 					<p>
 						To see that this equation is separable, we need to check that it can be rearranged in <xref ref="separable" text="custom">separable form</xref>. Isolating <m> s' </m> we get
-						<me> s' = \frac{s + t}{s} </me> and it should be clear that there is no way to separate <m>t</m> and <m>s</m> by <em>multiplication</em> in the numerator, so this equation <em>is not separable</em>.
+						<md> s' = \frac{s + t}{s} </md> and it should be clear that there is no way to separate <m>t</m> and <m>s</m> by <em>multiplication</em> in the numerator, so this equation <em>is not separable</em>.
 					</p>
 				</solution>
 				<answer>
@@ -1043,9 +1043,9 @@
 					<introduction>
 						<p>
 							Write each differential equation in the separable form
-							<me>
+							<md>
 								\frac{dy}{dx} = f(x)\cdot g(y)
-							</me>.
+							</md>.
 							<em>Type your answer for <m>f(x)</m> into the left box and <m>g(y)</m> into the right box.</em>
 						</p>
 					</introduction>
@@ -1152,9 +1152,9 @@
 					<statement>
 						<p>
 							Reorder the steps required to solve the differential equation,
-							<me>
+							<md>
 								\frac{dy}{dx} - y\cos(x) = y
-							</me>,
+							</md>,
 							using the separation of variables method.
 						</p>
 					</statement>
@@ -1226,9 +1226,9 @@
 					<statement>
 						<p>
 							Use separation of variables to solve the initial value problem
-							<me>
+							<md>
 								\frac{du}{dy} - u^2y = u^2, \hspace{1cm} u(0) = 5
-							</me>.
+							</md>.
 						</p>
 					</statement>
 
@@ -1365,7 +1365,7 @@
 								<li>
 									<p>
 										Separating variables:
-										<me>\frac{1}{u^2}du = (y+1)dy</me>
+										<md>\frac{1}{u^2}du = (y+1)dy</md>
 									</p>
 								</li>
 								<li>
@@ -1380,7 +1380,7 @@
 								<li>
 									<p>
 										Solving for <m>u</m>:
-										<me>u = \left(-\frac{y^2}{2} - y - c\right)^{-1}</me>
+										<md>u = \left(-\frac{y^2}{2} - y - c\right)^{-1}</md>
 									</p>
 								</li>
 								<li>
@@ -1391,7 +1391,7 @@
 											<mrow> c \amp = -\frac{1}{5} </mrow>
 										</md>
 										Therefore, the particular solution is:
-										<me>u = \left(-\frac{y^2}{2} - y + \frac{1}{5}\right)^{-1}</me>
+										<md>u = \left(-\frac{y^2}{2} - y + \frac{1}{5}\right)^{-1}</md>
 									</p>
 								</li>
 							</ol>
@@ -1502,12 +1502,12 @@
 						</p>
 						<p>
 							<em>Order and Separable Form:</em> This is a first-order equation. It can be written as
-							<me>\frac{dy}{dx} = (e^{2x} - 4x) \cdot (1)</me>
+							<md>\frac{dy}{dx} = (e^{2x} - 4x) \cdot (1)</md>
 							which is in separable form with <m>f(x) = e^{2x} - 4x</m> and <m>g(y) = 1</m>.
 						</p>
 						<p>
 							<em>Separate Variables:</em> Since <m>g(y) = 1</m>, we have
-							<me>\int 1\, dy = \int (e^{2x} - 4x)\, dx</me>
+							<md>\int 1\, dy = \int (e^{2x} - 4x)\, dx</md>
 						</p>
 						<p>
 							<em>Integrate:</em> Computing the integrals:
@@ -1626,7 +1626,7 @@
 						</p>
 						<p>
 							<em>Separate Variables:</em> Dividing both sides by <m>y^2</m>:
-							<me>\int \frac{1}{y^2}\, dy = \int x\, dx</me>
+							<md>\int \frac{1}{y^2}\, dy = \int x\, dx</md>
 						</p>
 						<p>
 							<em>Integrate:</em> Computing the integrals:
@@ -1643,7 +1643,7 @@
 								<mrow> y \amp = \frac{1}{-\frac{1}{2}x^2 - c} </mrow>
 							</md>
 							We can now absorb the minus sign into the arbitrary constant by substituting <m>c \to -c</m>, which does not change the family of solutions:
-							<me> y = \frac{1}{-\frac{1}{2}x^2 + c} </me>
+							<md> y = \frac{1}{-\frac{1}{2}x^2 + c} </md>
 						</p>
 					</solution>
 
@@ -1759,7 +1759,7 @@
 						</p>
 						<p>
 							<em>Separate Variables:</em> Dividing both sides by <m>y</m>:
-							<me>\int \frac{1}{y}\, dy = \int (1 + \cos(x))\, dx</me>
+							<md>\int \frac{1}{y}\, dy = \int (1 + \cos(x))\, dx</md>
 						</p>
 						<p>
 							<em>Integrate:</em> Computing the integrals:
@@ -1826,7 +1826,7 @@
 								<mrow> \frac{y^3}{3} \amp = 2x^3 + x + c </mrow>
 							</md>
 							Multiplying through and isolating <m>y</m> gives the general solution:
-							<me> y = \sqrt[3]{6x^3 + 3x + c} </me>
+							<md> y = \sqrt[3]{6x^3 + 3x + c} </md>
 						</p>
 					</solution>
 					<answer><m> y = \sqrt[3]{6x^3 + 3x + c}</m></answer>
@@ -2112,8 +2112,8 @@
 					<solution>
 						<p>
 							When we separate the variables and integrate both sides, we get
-							<me> \int (3y^2-5)dy =  \int (4-2x)dx</me>
-							<me> y^3-5y=4x-x^2+C </me>
+							<md> \int (3y^2-5)dy =  \int (4-2x)dx</md>
+							<md> y^3-5y=4x-x^2+C </md>
 							Since the equation cannot readily be solved for <m>y</m> as an explicit function of <m>x</m>, we are done.
 						</p>
 					</solution>
@@ -2158,26 +2158,26 @@
 					<solution>
 						<p>
 							Informally, we divide both side of the differential equation by <m>y</m> and multiply each side by <m>dx</m> to get
-							<me> \frac{dy}y = -6xdx.	</me>
-							<me> \int \frac{dy}y =  \int (-6x)dx</me>
-							<me> \ln|y|=-3x^2+C </me>
-							<me>\ln|y|=-3x^2+C</me>
-							<me>|y|=e^{-3x^2+C}</me>
-							<me>y=\pm e^C e^{-3x^2}</me>
+							<md> \frac{dy}y = -6xdx.	</md>
+							<md> \int \frac{dy}y =  \int (-6x)dx</md>
+							<md> \ln|y|=-3x^2+C </md>
+							<md>\ln|y|=-3x^2+C</md>
+							<md>|y|=e^{-3x^2+C}</md>
+							<md>y=\pm e^C e^{-3x^2}</md>
 
 							and hence
 
-							<me>y(x) = Ae^{-3x^2} \qquad (A = \pm e^C)</me>
+							<md>y(x) = Ae^{-3x^2} \qquad (A = \pm e^C)</md>
 
 							The condition <m>y(0) = 7</m> yields <m>A =7</m>, so the desired solution is
 
-							<me>y(x) = 7e^{-3x^2}</me>
+							<md>y(x) = 7e^{-3x^2}</md>
 
 						</p>
 					</solution>
 					<answer>
 						<p>
-							<me>y(x) = 7e^{-3x^2}</me>
+							<md>y(x) = 7e^{-3x^2}</md>
 						</p>
 					</answer>
 				</exercise>
@@ -2315,21 +2315,21 @@
 					<solution>
 						<p>
 							We want to find a non-zero function <m>\mu(x)</m> such that
-							<me>
+							<md>
 								\frac{d}{dx}\left[\mu\sin x\right] = \mu \cos x + 6 \mu \sin x.
-							</me>
+							</md>
 							Applying the product rule to the left side of this equation gives
-							<me>
+							<md>
 								\mu \cos x + \frac{d\mu}{dx} \sin x = \mu \cos x + 6 \mu \sin x.
-							</me>
+							</md>
 							Subtracting <m>\mu \cos x</m> from both sides gives
-							<me>
+							<md>
 								\frac{d\mu}{dx} \sin x = 6 \mu \sin x
-							</me>,
+							</md>,
 							which implies that
-							<me>
+							<md>
 								\frac{d\mu}{dx} = 6 \mu.
-							</me>
+							</md>
 							This is a separable differential equation that we can solve with separation of variables:
 							<md>
 								<mrow>	\frac{d\mu}{\mu}		\amp = 6 dx								</mrow>
@@ -2339,9 +2339,9 @@
 								<mrow>	\mu						\amp = \pm e^{c_1} e^{6x}				</mrow>
 							</md>
 							But, <m>\pm e^{c_1}</m> is just a constant, so we can write this as
-							<me>
+							<md>
 								\mu = ce^{6x}.
-							</me>
+							</md>
 							Since the question asks for a non-zero function, we can take <m>c = 1</m>. Thus, <m>\mu = e^{6x}</m> satisfies the given differential equation.
 						</p>
 					</solution>
@@ -2353,21 +2353,21 @@
 					<solution>
 						<p>
 							We want to find a non-zero function <m>\mu(x)</m> such that
-							<me>
+							<md>
 								\frac{d}{dx}\left[\mu\ln x\right] = \frac{\mu}{x} + 2x \mu \ln x.
-							</me>
+							</md>
 							Applying the product rule to the left side of this equation gives
-							<me>
+							<md>
 								\mu \frac{1}{x} + \frac{d\mu}{dx} \ln x = \frac{\mu}{x} + 2x \mu \ln x.
-							</me>
+							</md>
 							Subtracting <m>\frac{\mu}{x}</m> from both sides gives
-							<me>
+							<md>
 								\frac{d\mu}{dx} \ln x = 2x \mu \ln x
-							</me>,
+							</md>,
 							which implies that
-							<me>
+							<md>
 								\frac{d\mu}{dx} = 2x \mu.
-							</me>
+							</md>
 							This is a separable differential equation that we can solve with separation of variables:
 							<md>
 								<mrow>	\frac{d\mu}{\mu}		\amp = 2x\ dx								</mrow>
@@ -2377,9 +2377,9 @@
 								<mrow>	\mu						\amp = \pm e^{c_1} e^{x^2}				</mrow>
 							</md>
 							But, <m>\pm e^{c_1}</m> is just a constant, so we can write this as
-							<me>
+							<md>
 								\mu = ce^{x^2}.
-							</me>
+							</md>
 							Since the question asks for a non-zero function, we can take <m>c = 1</m>. Thus, <m>\mu = e^{x^2}</m> satisfies the given differential equation.
 						</p>
 					</solution>
@@ -2392,21 +2392,21 @@
 					<solution>
 						<p>
 							We want to find a non-zero function <m>\mu(x)</m> such that
-							<me>
+							<md>
 								\frac{d}{dx}\left[\mu y\right] = \mu \frac{dy}{dx} + 5 \mu y.
-							</me>
+							</md>
 							Applying the product rule to the left side of this equation gives
-							<me>
+							<md>
 								\mu \frac{dy}{dx} + \frac{d\mu}{dx} y = \mu \frac{dy}{dx} + 5 \mu y.
-							</me>
+							</md>
 							Subtracting <m>\mu \frac{dy}{dx}</m> from both sides gives
-							<me>
+							<md>
 								\frac{d\mu}{dx} y = 5 \mu y
-							</me>,
+							</md>,
 							which implies that
-							<me>
+							<md>
 								\frac{d\mu}{dx} = 5 \mu.
-							</me>
+							</md>
 							This is a separable differential equation that we can solve with separation of variables:
 							<md>
 								<mrow>	\frac{d\mu}{\mu}		\amp = 5 dx								</mrow>
@@ -2416,9 +2416,9 @@
 								<mrow>	\mu						\amp = \pm e^{c_1} e^{5x}				</mrow>
 							</md>
 							But, <m>\pm e^{c_1}</m> is just a constant, so we can write this as
-							<me>
+							<md>
 								\mu = ce^{5x}.
-							</me>
+							</md>
 							Since the question asks for a non-zero function, we can take <m>c = 1</m>. Thus, <m>\mu = e^{5x}</m> satisfies the given differential equation.
 						</p>
 					</solution>
@@ -2447,11 +2447,11 @@
 
 							Now <m>T(0)=50</m>, implies that <m>B = 325</m>, so <m>T(t) = 375-325e^{-kt}</m>. We also know that <m>T = 125</m> when <m>t = 75</m>. Substitution of these values in the preceding equation yields
 
-							<me> k=-\frac{1}{75}\ln\left(\frac{250}{325}\right)\approx 0.0035.</me>
+							<md> k=-\frac{1}{75}\ln\left(\frac{250}{325}\right)\approx 0.0035.</md>
 
 							Hence we finally solve the equation
 
-							<me>150=375-325e^{-0.0035t}</me>
+							<md>150=375-325e^{-0.0035t}</md>
 
 							for <m>t = -[\ln(225/325)]/[0.0035] \approx 105</m> (min), the total cooking time required. Because the roast was placed in the oven at 5:00 PM, it should be removed at about 6:45 PM.
 						</p>

--- a/source/c4-sov/sec-separable-form.ptx
+++ b/source/c4-sov/sec-separable-form.ptx
@@ -30,9 +30,9 @@
 			<statement>
 				<p>
 					A first-order differential equation is <term>separable</term> if it can be written in the following <term>separable form</term>
-					<men xml:id="separable-form-eqn">
+					<md xml:id="separable-form-eqn">
 						\dfrac{dy}{dx} = f(x) \cdot g(y)
-					</men>.
+					</md>.
 				</p>
 			</statement>
 
@@ -44,16 +44,16 @@
 
 		<p>
 			Here, <m>f(x)</m> is just a stand-in for any expression that only involves the variable <m>x</m> and possibly a constant. For example, it might be:
-			<me>
+			<md>
 				13\sin(3x), \quad 3x - 2e^{4x}, \quad \dfrac{2^x}{1+x}, \quad 1, \quad \text{etc.}
-			</me>
+			</md>
 		</p>
 
 		<p>
 			Likewise, <m>g(y)</m> stands for any expression involving only <m>y</m> and constants:
-			<me>
+			<md>
 				\sin(y+\cos y), \quad 3y^2 + 1, \quad \dfrac{1}{y}, \quad 1, \quad \text{etc.}
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -65,7 +65,7 @@
 			<statement>
 				<p>
 					Match each expression to the function notation that best describes it.
-					<me/><!-- Vertical space hack. Is there a better way? -->
+					<md/><!-- Vertical space hack. Is there a better way? -->
 				</p>
 
 				<sidebyside widths="36% 64%">
@@ -113,10 +113,10 @@
 
 		<p>
 			Now that the notation makes sense, here are some examples of differential equations in separable form:
-			<me>
-				\dfrac{dy}{dx} = \ub{(x^2 + 1) \cdot (y - 6)}_{\large f(x)\ \cdot\ g(y)}, \qquad
-				\dfrac{dy}{dx} = \ub{\sin(y) \cdot \cos(x)}_{\large g(y)\ \cdot\ f(x)}.
-			</me>
+			<md>
+				\frac{dy}{dx} = \ub{(x^2 + 1) \cdot (y - 6)}_{\large f(x)\ \cdot\ g(y)}, \qquad
+				\frac{dy}{dx} = \ub{\sin(y) \cdot \cos(x)}_{\large g(y)\ \cdot\ f(x)}.
+			</md>
 		</p>
 
 		<p>

--- a/source/c4-sov/sec-showing-separability.ptx
+++ b/source/c4-sov/sec-showing-separability.ptx
@@ -78,9 +78,9 @@
 			<solution>
 				<p>
 					To show this equation is separable, we convert <xref ref="sums-to-products" text="title"/> by factoring out the common <m>y</m>:
-					<me>
+					<md>
 						y' = \ub{y \cdot (x^2 - 1)}_{f(x)\ \cdot\ g(y)} \quad\leftarrow\text{separable}.
-					</me>
+					</md>
 				</p>
 			</solution>
 		</example>
@@ -91,9 +91,9 @@
 			<solution>
 				<p>
 					This time we isolate <m>y'</m> first, then factor out <m>x</m>:
-					<me>
+					<md>
 						y' = 6x - 18xy = 6x \cdot \left(1 - 3y\right) \quad\leftarrow\textit{separable}.
-					</me>
+					</md>
 				</p>
 			</solution>
 		</example>
@@ -104,15 +104,15 @@
 			<solution>
 				<p>
 					First, isolate <m>y'</m>:
-					<me>
+					<md>
 						yy' = x + 1 \quad \Rightarrow \quad y' = \frac{x + 1}{y},
-					</me>
+					</md>
 					then convert <xref ref="fractions-to-products" text="title"/>:
-					<me>
+					<md>
 						y' 
 							= \frac{x + 1}{1} \cdot \frac{1}{y} 
 							= \ub{(x+1) \cdot \frac{1}{y}}_{f(x)\ \cdot\ g(y)} \quad \leftarrow \text{separable}.
-					</me>
+					</md>
 				</p>
 			</solution>
 		</example>
@@ -123,9 +123,9 @@
 			<solution>
 				<p>
 					At first glance, this doesn't look separable because of the <m>x+y</m>, but applying <xref ref="exponents-to-products" text="title"/> we get: 
-					<me>
+					<md>
 						{\large y' = e^{x+y} = \ub{e^x \cdot e^{y}}_{f(x)\ \cdot\ g(y)}} \quad\leftarrow\text{separable}.
-					</me>
+					</md>
 				</p>
 			</solution>
 		</example>
@@ -149,7 +149,7 @@
 			<solution>
 				<p>
 					Since the variables in this equation are <m>t</m> and <m>P</m>, the separable form will look like
-					<me>\dfrac{dP}{dt} = f(P) \cdot g(t)</me>.
+					<md>\dfrac{dP}{dt} = f(P) \cdot g(t)</md>.
 				</p>
 
 				<p>
@@ -163,14 +163,14 @@
 
 				<p>
 					Now, we split the fraction so that <m>P</m> and <m>t</m> can be separated:
-					<me>
+					<md>
 						\dfrac{dP}{dt}
 							= \dfrac{P\cdot t}{(P^2 + 1) \cdot (1)}
 							= \ub{
 								{\color{RoyalBlue}	\os{f(P)}{\os{\downarrow}{	\dfrac{P}{P^2 + 1}}}		} \cdot
 								{\color{green}	\os{g(t)}{\os{\downarrow}{	\dfrac{t}{1}}}			}
 							}_{\text{separable form}}.
-					</me>
+					</md>
 					So, the equation is <em>separable</em>.
 				</p>
 			</solution>
@@ -182,7 +182,7 @@
 			<solution>
 				<p>
 					Isolating the derivative and applying <m>e^{A + B} = e^{A} \cdot e^{B}</m> leads to the separable form:
-					<me>
+					<md>
 						\dfrac{dM}{d\omega}
 							= 11e^{\omega + 3M}
 							= 11(e^{\omega} \cdot e^{3M})
@@ -190,7 +190,7 @@
 								{\color{RoyalBlue} \os{f(\omega)}{ \os{\downarrow}{ 11e^{\omega} }}	} \cdot
 								{\color{green}\os{g(M)}{ \os{\downarrow}{ e^{3M} }}	}
 							}_{\text{separable form}}.
-					</me>
+					</md>
 				</p>
 			</solution>
 		</example> -->
@@ -217,20 +217,20 @@
 
 				<p>
 					Next, we can rewrite the exponent in the numerator as a product
-					<me>
+					<md>
 						\dfrac{dy}{dx} = \dfrac{6x^2e^x - 8x^2e^{x}e^{\cos y}}{y}
-					</me>
+					</md>
 					and recognize that there is a common factor in the numerator
-					<me>
+					<md>
 						\dfrac{dy}{dx} = \dfrac{2x^2e^x(3 - 4e^{\cos y})}{y}
-					</me>.
+					</md>.
 				</p>
 
 				<p>
 					From here, we write the result as a product of fractions,
-					<me>
+					<md>
 						\dfrac{dy}{dx} = \dfrac{2x^2e^x}{1} \cdot \dfrac{3 - 4e^{\cos y}}{y}
-					</me>,
+					</md>,
 					and the equation is now clearly <em>separable</em>.
 				</p>
 			</solution>
@@ -247,7 +247,7 @@
 				<statement>
 					<p>
 						Suppose you want to show that the differential equation
-						<me>\dfrac{dq}{dt} - 3qt^2 = 2q</me>
+						<md>\dfrac{dq}{dt} - 3qt^2 = 2q</md>
 						is separable.
 					</p>
 					<p>
@@ -359,9 +359,9 @@
 				<statement>
 					<p>
 						How can the equation, below, be rewritten to show it is separable?
-						<me>
+						<md>
 							\dfrac{dy}{dx} = \dfrac{y}{x+y}.
-						</me>	
+						</md>	
 					</p>
 				</statement>
 

--- a/source/c4-sov/sec-sov-implicit-solns.ptx
+++ b/source/c4-sov/sec-sov-implicit-solns.ptx
@@ -27,16 +27,16 @@
 
 		<p>
 			The best way to understand why and how you can get <em>implicit solutions</em> using the <xref ref="gi-separation-of-variables-method" text="custom">separation of variables method</xref> is to see it in a concrete example. So, let's solve the following initial-value problem:
-			<me>
+			<md>
 				Q Q' + e^Q Q' = t, \quad Q(2) = 0.
-			</me>
+			</md>
 		</p>
 
 		<p>
 			Notice the variables separate naturally once we factor out <m>Q'</m>:
-			<me>
+			<md>
 				(Q + e^Q)\frac{dQ}{dt} = t
-			</me>.
+			</md>.
 		</p>
 
 		<p>
@@ -51,7 +51,7 @@
 
 		<p>
 			The general implicit solution is:
-			<me>Q^2 + 2e^Q = t^2 + c.\qquad (c=2c_1)</me>
+			<md>Q^2 + 2e^Q = t^2 + c.\qquad (c=2c_1)</md>
 		</p>
 
 		<p>
@@ -64,7 +64,7 @@
 
 		<p>
 			Thus, the particular implicit solution is:
-			<me>Q^2 + 2e^Q = t^2 - 2.</me>
+			<md>Q^2 + 2e^Q = t^2 - 2.</md>
 		</p>
 
 		<exercise label="sov-implicit-solns-cyu-1">
@@ -103,9 +103,9 @@
 			<statement>
 				<p>
 					Select the solutions to the equation
-					<me>
+					<md>
 						|x| = 14
-					</me>.
+					</md>.
 				</p>
 			</statement>
 
@@ -131,18 +131,18 @@
 		<p>
 			<idx><h>absolute value in a general solution</h></idx>
 			When solving differential equations, it's common to encounter absolute values in the general solution. For instance, suppose you want to solve for <m>y</m>, but arrive at:
-			<men xml:id="sov-abs-value-eqn">
+			<md xml:id="sov-abs-value-eqn">
 				|y| = e^{\sin(x) + c}.
-			</men>
+			</md>
 		</p>
 
 		<p>
 			To fully isolate <m>y</m>, you need to replace the absolute value with <q><m>\pm</m></q>, like so:
-			<men xml:id="sov-abs-value-eqn-solution">
+			<md xml:id="sov-abs-value-eqn-solution">
 				y = \pm e^{\sin(x) + c}.
-			</men>
+			</md>
 			To understand why, consider a simplified problem with the same goal:
-			<me>|y| = 5.</me>
+			<md>|y| = 5.</md>
 			Clearly, both <m>5</m> and <m>-5</m> satisfy this equation, so <m>\ |y| = 5\ \Rightarrow\ y=\pm 5</m>.
 		</p>
 
@@ -151,9 +151,9 @@
 			<statement>
 				<p>
 					Find the <xref ref="gi-general-solution" text="custom">general solution</xref> to the differential equation
-					<me>
+					<md>
 						x\frac{dy}{dx} + 10x^2y = 6x^2
-					</me>
+					</md>
 				</p>
 			</statement>
 
@@ -175,7 +175,7 @@
 
 					<sidebyside>
 						<p>Separate variables</p>
-						<p><me> \frac{1}{3 - 5y}dy = 2x\ dx </me></p>
+						<p><md> \frac{1}{3 - 5y}dy = 2x\ dx </md></p>
 					</sidebyside>
 
 					<sidebyside>
@@ -190,7 +190,7 @@
 								\right| \rightarrow
 							</m>
 						</p>
-						<p><me>\int \frac{1}{3 - 5y}dy = \int 2x\ dx</me></p>
+						<p><md>\int \frac{1}{3 - 5y}dy = \int 2x\ dx</md></p>
 					</sidebyside>
 
 					<sidebyside>
@@ -207,9 +207,9 @@
 
 				<p>
 					At this point, we replace the absolute value with <m>\pm</m>:
-					<me>
+					<md>
 						3 - 5y = \pm e^{x^2 + c_1}.
-					</me>
+					</md>
 				</p>
 
 				<p>
@@ -222,7 +222,7 @@
 
 				<p>
 					Setting the combined constant, <m>c=\dfrac{\pm e^{c_1}}{5}</m>, we get the general solution:
-					<me>y = ce^{x^2} + \frac{3}{5}</me>.
+					<md>y = ce^{x^2} + \frac{3}{5}</md>.
 				</p>
 
 			</solution>
@@ -242,9 +242,9 @@
 			<statement>
 				<p>
 					Solve the <xref ref="gi-initial-value-problem" text="custom">initial-value problem</xref>
-					<me>
+					<md>
 						\frac{dy}{dx} = \frac{\cos x}{y}, \quad y(0) = -5
-					</me>.
+					</md>.
 				</p>
 			</statement>
 
@@ -258,13 +258,13 @@
 						<mrow>\frac{y^2}{2} \amp = \sin(x) + c_1</mrow>
 					</md>
 					we arrive at the implicit general solution:
-					<me>y^2 = 2\sin(x) + c</me>
+					<md>y^2 = 2\sin(x) + c</md>
 					where <m>c=2c_1</m>.
 				</p>
 
 				<p>
 					Explicitly solving for <m>y</m>, shows our general solution has two branches:
-					<me>
+					<md>
 						y(x)
 						= \pm\sqrt{2\sin(x) + c}
 						= \left\{
@@ -273,22 +273,22 @@
 								\sqrt{2\sin(x) + c}
 							\end{array}
 							\right.
-					</me>
+					</md>
 				</p>
 
 				<p>
 					Since our solution must satisfy <m>y(0)=-5</m>, which has a negative <m>y</m>-value, our particular solution must come from the negative branch:
-					<me>y(x) = -\sqrt{2\sin x + c}.</me>
+					<md>y(x) = -\sqrt{2\sin x + c}.</md>
 				</p>
 
 				<p>
 					Finally, we find <m>c</m> with the initial condition <m>y(0) = -5</m>:
-					<me>-5 = -\sqrt{2\sin(0) + c} \ \Rightarrow\ c = 25.</me>
+					<md>-5 = -\sqrt{2\sin(0) + c} \ \Rightarrow\ c = 25.</md>
 				</p>
 
 				<p>
 					Thus, the explicit particular solution is:
-					<me>y = -\sqrt{2\sin x + 25}.</me>
+					<md>y = -\sqrt{2\sin x + 25}.</md>
 				</p>
 
 			</solution>
@@ -303,7 +303,7 @@
 
 			<statement>
 				<p>
-					Reorder the scrambled steps used to solve <me>\frac{dq}{dt} - 3qt^2 = 2q</me> using the <xref ref="sov-method" text="title"/> method.
+					Reorder the scrambled steps used to solve <md>\frac{dq}{dt} - 3qt^2 = 2q</md> using the <xref ref="sov-method" text="title"/> method.
 				</p>
 			</statement>
 

--- a/source/c4-sov/sec-sov-method.ptx
+++ b/source/c4-sov/sec-sov-method.ptx
@@ -31,12 +31,12 @@
 				<dl width="medium">
 					<li xml:id="sov-step-1"><title>1. Verify Separable, Separate Variables</title>
 						<p>Check that the equation is first-order</p>
-						<p>If possible, put into separable form: <me>\frac{dy}{dx} = f(x) \cdot g(y)</me></p>
-						<p><idx><h>separate variables</h></idx>Separate <m>x</m> and <m>y</m> on opposite sides: <me>\frac{1}{g(y)}\ dy = f(x)\ dx</me></p>
+						<p>If possible, put into separable form: <md>\frac{dy}{dx} = f(x) \cdot g(y)</md></p>
+						<p><idx><h>separate variables</h></idx>Separate <m>x</m> and <m>y</m> on opposite sides: <md>\frac{1}{g(y)}\ dy = f(x)\ dx</md></p>
 					</li>
 
 					<li xml:id="sov-step-2"><title>2. Integrate</title>
-						<p><me>\int \frac{1}{g(y)}\, dy = \int f(x)\, dx.</me></p>
+						<p><md>\int \frac{1}{g(y)}\, dy = \int f(x)\, dx.</md></p>
 					</li>
 
 					<li xml:id="sov-step-3"><title>3. Solve for <m>y</m></title>
@@ -59,27 +59,27 @@
 
 			<p>
 				To see why, start with the separable form,
-				<me>
+				<md>
 					\frac{dy}{dx} = f(x) \cdot g(y)
-				</me>,
+				</md>,
 				and divide both sides by <m>g(y)</m>, leaving the derivative intact:
-				<me>
+				<md>
 					\frac{1}{g(y)}\ \frac{dy}{dx} = f(x)
-				</me>.
+				</md>.
 			</p>
 
 			<p>
 				From here, integrate both sides with respect to <m>x</m>:
-				<me>
+				<md>
 					\int \frac{1}{g(y)}\ \frac{dy}{dx}\ dx = \int f(x)\ dx
-				</me>.
+				</md>.
 			</p>
 
 			<p>
 				Since the product, <m>\sfrac{dy}{dx}\cdot dx</m>, is defined as the differential, <m>dy</m>, we can substitute it in to get the form of the integral you see in <xref ref="sov-step-2" text="custom">Step 2</xref>:
-				<me>
+				<md>
 					\int \frac{1}{g(y)}\ dy = \int f(x)\ dx,
-				</me>
+				</md>
 				which justifies the informal splitting of <m>dy</m> and <m>dx</m> in the derivative, <m>\sfrac{dy}{dx}</m>.
 			</p>
 
@@ -92,9 +92,9 @@
 			</p>
 			<p>
 				For example, separating <m>\frac{dy}{dx} = y^2</m> gives
-				<me>
+				<md>
 					\int \frac{1}{y^2}\, dy = \int dx \quad\implies\quad y = -\frac{1}{x + c},
-				</me>
+				</md>
 				but dividing by <m>y^2</m> assumed <m>y \neq 0</m> — and the constant function <m>y(x) = 0</m> also satisfies <m>y' = y^2</m>. It is a solution the algebra lost, and no choice of the integration constant <m>c</m> in <m>-\frac{1}{x+c}</m> recovers it.
 			</p>
 			<p>
@@ -124,18 +124,18 @@
 				<block order="2">
 					<p>
 						Verify separable form:
-						<me>\frac{dy}{dx} = f(x)g(y)</me>
+						<md>\frac{dy}{dx} = f(x)g(y)</md>
 					</p>
 				</block>
 				<block order="3">
 					<p>
 						Separate variables:
-						<me>\frac{1}{g(y)}\ dy = f(x)\ dx</me>
+						<md>\frac{1}{g(y)}\ dy = f(x)\ dx</md>
 					</p>
 				</block>
 				<block order="4">
 					<p>
-						<me>\int \frac{1}{g(y)}\ dy = \int f(x)\ dx</me>
+						<md>\int \frac{1}{g(y)}\ dy = \int f(x)\ dx</md>
 					</p>
 				</block>
 				<block order="5">
@@ -177,9 +177,9 @@
 					<feedback>
 						<p>
 							Moving <m>y</m> over you get
-							<me>
+							<md>
 								\dfrac{dy}{dx} = x + y
-							</me>.
+							</md>.
 							Can a sum like this be converted into the form <m>f(x) \cdot g(y)</m>?
 						</p>
 					</feedback>
@@ -262,15 +262,15 @@
 
 				<sidebyside widths="25% 5% 55%" valign="top" margins="1%">
 					<p>
-						<me>
+						<md>
 							\boxed{y = \frac{1}{5}x^5 + c}
-						</me>
+						</md>
 					</p>
 					<p/>
 					<p>
-						<me>
+						<md>
 							\frac{1}{y} = -x + c \ \Rightarrow\ \boxed{y = \frac{1}{-x + c}}
-						</me>
+						</md>
 					</p>
 				</sidebyside>
 
@@ -306,9 +306,9 @@
 
 				<p>
 					<xref ref="sov-step-3" text="custom">Step 3</xref> - Combine constants and solve explicitly for <m>y</m>:
-					<me>
+					<md>
 						\frac{y^3}{3} = -\frac{x^2}{2} + c \quad\Rightarrow\quad \boxed{y = \left(-\frac{3}{2}x^2 + c\right)^{1/3}}.
-					</me>
+					</md>
 				</p>
 
 			</solution>
@@ -342,23 +342,23 @@
 				</p>
 
 				<sidebyside widths="80% 20%" valign="middle" margins="0% 0%">
-					<p><me>\frac{1}{z^2+1}dz = 1\ dt</me></p>
+					<p><md>\frac{1}{z^2+1}dz = 1\ dt</md></p>
 					<p>Separate</p>
 				</sidebyside>
 
 				<sidebyside widths="80% 20%" valign="middle" margins="0% 0%">
-					<p><me> \int\frac{1}{z^2+1}\ dz = \int 1\ dt </me></p>
+					<p><md> \int\frac{1}{z^2+1}\ dz = \int 1\ dt </md></p>
 					<p>Integrate</p>
 				</sidebyside>
 
 				<sidebyside widths="80% 20%" valign="middle" margins="0% 0%">
-					<p><me> \arctan z = t + c </me></p>
+					<p><md> \arctan z = t + c </md></p>
 					<p></p>
 				</sidebyside>
 
 				<p>
 					So, the general solution is
-					<me> z = \tan(t+c) </me>.
+					<md> z = \tan(t+c) </md>.
 				</p>
 
 				<p>
@@ -371,14 +371,14 @@
 
 				<p>
 					Therefore,
-					<me>
+					<md>
 						z = \tan(t + \arctan(9) - 4)
-					</me>
+					</md>
 					is the particular solution to the initial-value problem.
 					<fn>
 						<p>
 							Be cautious about rewriting constants in decimal form. For instance, if you approximate <m>\arctan(9) - 4 \approx -2.54</m>, the solution becomes:
-							<me>z = \tan(t - 2.54),</me>
+							<md>z = \tan(t - 2.54),</md>
 							which may not exactly satisfy the original initial condition due to rounding errors. It's usually better to leave constants in exact form.
 						</p>
 					</fn>

--- a/source/c5-if/exercises-if.ptx
+++ b/source/c5-if/exercises-if.ptx
@@ -428,7 +428,7 @@
 				</answer>
 			</exercise>
 
-			<exercisegroup cols="2" label="if-drill-which-method">
+			<exercisegroup cols="2" xml:id="if-drill-which-method" label="if-drill-which-method">
 				<title>Which Method Applies</title>
 
 				<introduction>

--- a/source/c5-if/exercises-if.ptx
+++ b/source/c5-if/exercises-if.ptx
@@ -39,9 +39,9 @@
 					<statement correct="no">
 						<p>
 							The differential equation, below, is in standard form.
-							<me>
+							<md>
 								xy'+2xy=x^2
-							</me>
+							</md>
 						</p>
 					</statement>
 					<feedback>
@@ -61,9 +61,9 @@
 					<statement correct="no">
 						<p>
 							The integrating factor method can be applied to the differential equation
-							<me>
+							<md>
 								y' = y^2 + x
-							</me>.
+							</md>.
 						</p>
 					</statement>
 					<feedback>Since the term, <m>y^2</m>, is nonlinear, the differential equation is nonlinear and the integrating factor method does not apply here.</feedback>
@@ -74,7 +74,7 @@
 					<statement>
 						<p>
 						What integration technique is used to evaluate 
-						<me>\int t^3 \ln t \, dt</me>?
+						<md>\int t^3 \ln t \, dt</md>?
 						</p>
 					</statement>
 					<choices randomize="yes">
@@ -102,7 +102,7 @@
 					<statement>
 						<p>
 						What method is used to solve a differential equation of the form 
-						<me>\frac{d}{dx}[g(x,y)] = f(x)</me>?
+						<md>\frac{d}{dx}[g(x,y)] = f(x)</md>?
 						</p>
 					</statement>
 					<choices randomize="yes">
@@ -211,7 +211,7 @@
 					<statement>
 						<p>
 						You rewrote <m>\dfrac{dy}{dx} + 2y = 5</m> as 
-						<me>\frac{d}{dx} \left[e^{2x} y\right] = 5e^{2x}</me>. 
+						<md>\frac{d}{dx} \left[e^{2x} y\right] = 5e^{2x}</md>. 
 						What should you do next?
 						</p>
 					</statement>
@@ -240,7 +240,7 @@
 					<statement>
 						<p>
 						Find the integrating factor for 
-						<me>x^2 y' - y = 1</me>.
+						<md>x^2 y' - y = 1</md>.
 						</p>
 					</statement>
 					<choices randomize="yes">
@@ -317,10 +317,10 @@
 						</p>
 						<p>
 							Examples include:
-							<me>
+							<md>
 								\frac{dy}{dx} = y^2 + x, \qquad \left(y + \frac{dy}{dx}\right)^2 
 									= e^x, \qquad y' = \ln\left(x^3 y\right)
-							</me>
+							</md>
 						</p>
 					</solution>
 <answer>
@@ -336,7 +336,7 @@
 						<p>
 							Rewrite the differential equation below in the standard form <m>y' + P(x)y = Q(x)</m>. 
 							Identify <m>P(x)</m> and <m>Q(x)</m>, state its order, and determine whether it is linear.
-							<me>-4xy' + 5y = \cos (x)\,y - 1</me>
+							<md>-4xy' + 5y = \cos (x)\,y - 1</md>
 						</p>
 					</statement>
 
@@ -454,7 +454,7 @@
 					</p>
 					<p>
 						It is <em>not</em> separable. After isolating the derivative:
-						<me>\dfrac{dy}{dx} = \dfrac{y - \cos x}{x^2},</me>
+						<md>\dfrac{dy}{dx} = \dfrac{y - \cos x}{x^2},</md>
 						we see that <m>y</m> and <m>x</m> cannot be separated by multiplication or division.
 					</p>
 					<p>
@@ -476,7 +476,7 @@
 					</p>
 					<p>
 						It is also not separable. After isolating the derivative:
-						<me>\frac{dx}{dt} = e^x - xt,</me>
+						<md>\frac{dx}{dt} = e^x - xt,</md>
 						there's no way to write the right-hand side as a product of a function of <m>x</m> and a function of <m>t</m>.
 					</p>
 					<p>
@@ -551,7 +551,7 @@
 					</p>
 					<p>
 						It is <em>not</em> separable. Solving for the derivative:
-						<me>\frac{dr}{d\theta} = 3r + \theta^3,</me>
+						<md>\frac{dr}{d\theta} = 3r + \theta^3,</md>
 						shows no way to separate <m>r</m> and <m>\theta</m> into separate multiplicative terms.
 					</p>
 					<p>
@@ -620,10 +620,10 @@
 						</p>
 					
 						<p>
-							<me>
+							<md>
 								y' + \us{P}{\boxed{-\frac{1}{x^2}}}\ y = \frac{1}{x^2} \quad \implies \quad
 								\mu(x) = e^{\large \int -\sfrac{1}{x^2} dx} = e^{1/x}
-							</me>
+							</md>
 						</p>
 					
 						<p>
@@ -750,9 +750,9 @@
 						<sidebyside widths="35% 65%" valign="middle">
 							<p>Find Integrating Factor, <m>\mu</m></p>
 							<p>
-								<me>
+								<md>
 									\mu = e\vphantom{\large|}^{\int \sfrac{-4}{t}\ dt} = e^{-4\ln t} = e^{\ln t^{-4}} = t^{-4}
-								</me>
+								</md>
 							</p>
 						</sidebyside>
 
@@ -806,9 +806,9 @@
 						<sidebyside widths="35% 65%" valign="middle">		
 							<p>General Solution</p>
 							<p>
-								<me>
+								<md>
 									M = \frac{1}{3}t^{7} - \frac{1}{2}t^2 + Ct^4
-								</me>.
+								</md>.
 							</p>
 						</sidebyside>
 					</solution>
@@ -879,15 +879,15 @@
 					</p>
 					<p>
 						Apply <m>y(1) = e - 1</m>:
-						<me>
+						<md>
 							e - 1 = 1(e + C) \Rightarrow C = -1.
-						</me>
+						</md>
 					</p>
 					<p>
 						Final solution:
-						<me>
+						<md>
 							y(x) = x(e^x - 1).
-						</me>
+						</md>
 					</p>
 					</solution>
 					<answer>
@@ -911,15 +911,15 @@
 					</p>
 					<p>
 						Apply <m>z(0) = \frac{4}{3}</m>:
-						<me>
+						<md>
 							\frac{4}{3} = \frac{1}{3} + C \Rightarrow C = 1.
-						</me>
+						</md>
 					</p>
 					<p>
 						Final solution:
-						<me>
+						<md>
 							z(t) = \frac{1}{3}e^{-t} + e^{-4t}.
-						</me>
+						</md>
 					</p>
 					</solution>
 					<answer>
@@ -943,15 +943,15 @@
 						</p>
 						<p>
 							Apply <m>y(0) = 5</m>:
-							<me>
+							<md>
 								5 = -2 + C \Rightarrow C = 7.
-							</me>
+							</md>
 						</p>
 						<p>
 							Final solution:
-							<me>
+							<md>
 								y(x) = -2 + 7e^{3x}.
-							</me>
+							</md>
 						</p>
 					</solution>
 					<answer>

--- a/source/c5-if/exercises-if.ptx
+++ b/source/c5-if/exercises-if.ptx
@@ -428,7 +428,7 @@
 				</answer>
 			</exercise>
 
-			<exercisegroup cols="2" xml:id="if-drill-which-method" label="if-drill-which-method">
+			<exercisegroup cols="2" xml:id="if-drill-which-method">
 				<title>Which Method Applies</title>
 
 				<introduction>

--- a/source/c5-if/review-first-order-methods.ptx
+++ b/source/c5-if/review-first-order-methods.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section xml:id="fo-mixed-review" label="fo-mixed-review">
+<section xml:id="fo-mixed-review">
 	<title>Mixed Review: Choosing Your Method</title>
 
 	<introduction>

--- a/source/c5-if/review-first-order-methods.ptx
+++ b/source/c5-if/review-first-order-methods.ptx
@@ -1,0 +1,480 @@
+<!-- LICENSING
+  This file is part of the textbook "Exploring Differential Equations, An Interactive, Student-Centered Approach" by Geoffrey Cox.
+  License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+  You are free to:
+    • Share — copy and redistribute the material in any medium or format.
+    • Adapt — remix, transform, and build upon the material for any purpose, even commercially.
+  Under the following terms:
+    • Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.
+    • ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license.
+  Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
+  Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
+-->
+<section xml:id="fo-mixed-review" label="fo-mixed-review">
+	<title>Mixed Review: Choosing Your Method</title>
+
+	<introduction>
+		<p>
+			You now own three solution methods: <xref ref="di-method" text="custom">direct integration</xref>, <xref ref="sov-method" text="custom">separation of variables</xref>, and the <xref ref="if-method-exploration" text="custom">integrating factor method</xref>. Each one was introduced in its own chapter, where every practice problem conveniently matched the method being taught. Exams are rarely so polite. A typical exam problem hands you an equation and asks only: <q>solve it.</q> Deciding <em>which</em> tool fits is a skill of its own, and this review is where you practice it.
+		</p>
+
+		<p>
+			The flowchart below organizes the decision. Each method has an entrance requirement: direct integration needs the equation to already be a single derivative, separation of variables needs the form <m>\frac{dy}{dx} = f(x)\cdot g(y)</m>, and the integrating factor method needs a first-order <em>linear</em> equation <m>y' + P(x)y = Q(x)</m>. Think of an equation you'd like to classify, then walk the chart by answering each highlighted question with the <c>Yes</c>/<c>No</c> buttons; press <c>Reset</c> to start over with a new equation.
+		</p>
+
+		<sidebyside width="90%" margins="5% 5%">
+			<interactive xml:id="method-flowchart"
+				platform="jsxgraph"
+				aspect="1.31:1"
+				dark-mode-enabled="yes"
+				source="code/jsxgraph/method-flowchart/method-flowchart.js"
+			>
+				<description>
+					Interactive decision-tree flowchart for choosing a first-order solution method. Starting from a given differential equation, it asks in order: Is the equation first order? If no, higher-order tools come in later chapters. Is it already a derivative of the form d/dx of something equals f of x? If yes, use direct integration. Is it separable? If yes, use separation of variables. Is it linear? If yes, use the integrating factor method; if no, use qualitative or numerical tools. Yes and No buttons advance the highlighted question and the chosen path is highlighted in green.
+				</description>
+				<slate xml:id="method-flowchart-plot1" surface="jsxboard" aspect="1.31:1" />
+			</interactive>
+		</sidebyside>
+
+		<p>
+			Two notes before you start practicing.
+			<ul>
+				<li>
+					<p>
+						Some equations qualify for more than one method. If an equation is both separable and linear, either tool reaches the same general solution—pick whichever integrals look friendlier.
+					</p>
+				</li>
+				<li>
+					<p>
+						If an equation fails every test in the chart, that doesn't mean it's hopeless—it means none of our <em>formula</em> methods apply. The next two chapters build tools for exactly this situation: <xref ref="chpt-qualitative" text="custom">qualitative methods</xref> to describe how solutions behave, and <xref ref="chpt-eulers-method" text="custom">Euler's method</xref> to approximate them numerically.
+					</p>
+				</li>
+			</ul>
+		</p>
+
+		<p>
+			The <xref ref="if-drill-which-method" text="custom">Which Method Applies</xref> drills earlier in this chapter are the perfect companion to the flowchart—work them alongside this review if you haven't already.
+		</p>
+	</introduction>
+
+	<exercises label="fo-review-quiz">
+		<title><e component="emoji">💡</e> Which Method? Quiz</title>
+
+		<introduction>
+			<p>
+				For each differential equation, choose the best plan of attack. <em>Do not solve any of the equations</em>—the goal is to make the call quickly, the way you would when first reading an exam problem.
+			</p>
+		</introduction>
+
+		<exercise label="fo-review-wm">
+
+			<task label="fo-review-wm-01">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>\frac{dy}{dx} = x^2 e^{-x}</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Direct integration.</statement>
+						<feedback>Correct! The right-hand side involves only <m>x</m>, so integrating both sides gives the general solution.</feedback>
+					</choice>
+					<choice>
+						<statement>Separation of variables (and direct integration won't work).</statement>
+						<feedback>Separation technically applies with <m>g(y) = 1</m>, but there's nothing to separate—the equation is already set up to integrate directly.</feedback>
+					</choice>
+					<choice>
+						<statement>Integrating factor, since the equation is linear.</statement>
+						<feedback>The equation is linear, but with no <m>y</m> term at all there's nothing for an integrating factor to fix—just integrate both sides.</feedback>
+					</choice>
+					<choice>
+						<statement>None of our methods apply.</statement>
+						<feedback>Look again: the right-hand side is a function of <m>x</m> alone.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-wm-02">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>\frac{dy}{dx} = x y^2</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Separation of variables.</statement>
+						<feedback>Correct! The right side is the product <m>f(x)\cdot g(y)</m> with <m>f(x) = x</m> and <m>g(y) = y^2</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Integrating factor.</statement>
+						<feedback>The <m>y^2</m> term makes this equation nonlinear, so the integrating factor method does not apply.</feedback>
+					</choice>
+					<choice>
+						<statement>Direct integration.</statement>
+						<feedback>The right side involves <m>y</m>, so we cannot simply integrate both sides with respect to <m>x</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>None of our methods apply.</statement>
+						<feedback>Check the separability test: can the right side be written as (a function of <m>x</m>) <m>\times</m> (a function of <m>y</m>)?</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-wm-03">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>y' + 3y = e^{2x}</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Integrating factor.</statement>
+						<feedback>Correct! The equation is first-order linear, already in standard form with <m>P(x) = 3</m>, and it is not separable.</feedback>
+					</choice>
+					<choice>
+						<statement>Separation of variables.</statement>
+						<feedback>Isolating the derivative gives <m>y' = e^{2x} - 3y</m>, a <em>difference</em>, not a product of an <m>x</m>-part and a <m>y</m>-part. Not separable.</feedback>
+					</choice>
+					<choice>
+						<statement>Direct integration.</statement>
+						<feedback>The left side is not the derivative of a single expression as written—that's exactly what multiplying by an integrating factor will fix.</feedback>
+					</choice>
+					<choice>
+						<statement>None of our methods apply.</statement>
+						<feedback>Check the linearity test: <m>y</m> and <m>y'</m> each appear once, to the first power.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-wm-04">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>x\, y' = y + x^2 \sin x</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Integrating factor.</statement>
+						<feedback>Correct! Dividing by <m>x</m> gives the standard form <m>y' - \frac{1}{x}y = x\sin x</m>, which is linear but not separable.</feedback>
+					</choice>
+					<choice>
+						<statement>Separation of variables.</statement>
+						<feedback>Isolating the derivative gives <m>y' = \frac{y}{x} + x\sin x</m>, a sum that cannot be factored into <m>f(x)\cdot g(y)</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Direct integration.</statement>
+						<feedback>The right side involves <m>y</m>, so both sides cannot be integrated as-is.</feedback>
+					</choice>
+					<choice>
+						<statement>None of our methods apply.</statement>
+						<feedback>Try dividing both sides by <m>x</m> and rearranging into standard linear form.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-wm-05">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>\frac{dy}{dx} = \left(1 + y^2\right) e^{x}</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Separation of variables.</statement>
+						<feedback>Correct! The right side factors as <m>f(x)\cdot g(y)</m> with <m>f(x) = e^x</m> and <m>g(y) = 1 + y^2</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Integrating factor.</statement>
+						<feedback>The <m>y^2</m> term makes the equation nonlinear, so the integrating factor method is out.</feedback>
+					</choice>
+					<choice>
+						<statement>Direct integration.</statement>
+						<feedback>The right side involves <m>y</m>, so we cannot simply integrate both sides.</feedback>
+					</choice>
+					<choice>
+						<statement>None of our methods apply.</statement>
+						<feedback>Check the separability test—the right side is already factored for you.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-wm-06">
+				<title>More Than One Way</title>
+				<statement>
+					<p>
+						<me>\frac{dy}{dx} = 2y</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Either separation of variables or an integrating factor—both apply.</statement>
+						<feedback>Correct! It separates as <m>\frac{dy}{y} = 2\,dx</m>, and rewriting it as <m>y' - 2y = 0</m> shows it's also first-order linear. Both routes give <m>y = Ce^{2x}</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Separation of variables only.</statement>
+						<feedback>Separation works, but so does an integrating factor: <m>y' - 2y = 0</m> is first-order linear with <m>Q(x) = 0</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Integrating factor only.</statement>
+						<feedback>An integrating factor works, but so does separation: <m>\frac{dy}{y} = 2\,dx</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Direct integration only.</statement>
+						<feedback>The right side involves <m>y</m>, so direct integration is the one method that <em>doesn't</em> apply here.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-wm-07">
+				<title>The Fastest Route</title>
+				<statement>
+					<p>
+						This equation can be solved by more than one of our methods. Which observation gives the <em>fastest</em> route to the solution?
+						<me>x^2 y' + 2x y = 4x</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>The left side is already the derivative <m>\frac{d}{dx}\left[x^2 y\right]</m>, so integrate both sides directly.</statement>
+						<feedback>Correct! The left side is a completed product rule, so direct integration gives <m>x^2 y = 2x^2 + C</m> in one step. Always scan for this shortcut first.</feedback>
+					</choice>
+					<choice>
+						<statement>Divide by <m>x^2</m> to reach standard form, then compute the integrating factor <m>\mu(x)</m>.</statement>
+						<feedback>This works—but the integrating factor you'd build is <m>x^2</m>, which the equation already has in place! Recognizing the completed product rule skips the whole computation.</feedback>
+					</choice>
+					<choice>
+						<statement>Isolate <m>y'</m> and separate the variables.</statement>
+						<feedback>Surprisingly, this works too: <m>y' = \frac{2(2 - y)}{x}</m> is separable. But it's the slowest route—look at the left side of the original equation again.</feedback>
+					</choice>
+					<choice>
+						<statement>No method applies without more information.</statement>
+						<feedback>Look at the left side: does it match the expanded form of a product rule?</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-wm-08">
+				<title>Know When to Fold</title>
+				<statement>
+					<p>
+						<me>y' = y^2 + x</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>None of our formula methods apply.</statement>
+						<feedback>Correct! The <m>y^2</m> term rules out linearity, and <m>y^2 + x</m> is a sum that won't factor into <m>f(x)\cdot g(y)</m>. Equations like this are why the next two chapters develop qualitative and numerical tools.</feedback>
+					</choice>
+					<choice>
+						<statement>Separation of variables.</statement>
+						<feedback>The right side <m>y^2 + x</m> is a sum, not a product of an <m>x</m>-part and a <m>y</m>-part—it cannot be separated.</feedback>
+					</choice>
+					<choice>
+						<statement>Integrating factor.</statement>
+						<feedback>The <m>y^2</m> term makes the equation nonlinear, so the integrating factor method does not apply.</feedback>
+					</choice>
+					<choice>
+						<statement>Direct integration.</statement>
+						<feedback>The right side involves <m>y</m>, so both sides cannot simply be integrated with respect to <m>x</m>.</feedback>
+					</choice>
+				</choices>
+			</task>
+		</exercise>
+	</exercises>
+
+	<exercises label="fo-review-problems">
+		<title><e component="emoji">✍🏻</e> Mixed Problem Set</title>
+
+		<exercisegroup cols="2" label="fo-review-mixed">
+			<title>Choose, Then Solve</title>
+
+			<introduction>
+				<p>
+					Solve each equation. No method is announced—begin each solution by naming the method you chose and the feature of the equation that told you it applies.
+				</p>
+			</introduction>
+
+			<exercise label="fo-review-mixed-1">
+				<statement>
+					<p>
+						<m>\dfrac{dy}{dx} = 6x^2 - 4x + 1, \quad y(1) = 2</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> the right-hand side involves only <m>x</m>, so this is a job for <em>direct integration</em>.
+					</p>
+					<p>
+						Integrating both sides,
+						<me>y = \int \left(6x^2 - 4x + 1\right) dx = 2x^3 - 2x^2 + x + c</me>.
+					</p>
+					<p>
+						Applying <m>y(1) = 2</m>:
+						<me>2 = 2(1)^3 - 2(1)^2 + 1 + c = 1 + c \quad\implies\quad c = 1</me>.
+					</p>
+					<p>
+						The particular solution is <m>y = 2x^3 - 2x^2 + x + 1</m>.
+					</p>
+				</solution>
+				<answer>
+					<p>Direct integration; <m>y = 2x^3 - 2x^2 + x + 1</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="fo-review-mixed-2">
+				<statement>
+					<p>
+						<m>\dfrac{dy}{dx} = -\dfrac{x}{y}, \quad y(0) = 3</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> the right side factors as <m>(-x)\cdot\frac{1}{y}</m>, and the <m>\frac{1}{y}</m> factor makes the equation nonlinear—so <em>separation of variables</em> is the tool.
+					</p>
+					<p>
+						Separating and integrating,
+						<md>
+							<mrow>y\, dy \amp = -x\, dx</mrow>
+							<mrow>\frac{y^2}{2} \amp = -\frac{x^2}{2} + c</mrow>
+							<mrow>x^2 + y^2 \amp = C \qquad (C = 2c)</mrow>
+						</md>
+					</p>
+					<p>
+						Applying <m>y(0) = 3</m> gives <m>C = 9</m>, so the solution satisfies <m>x^2 + y^2 = 9</m>. Solving for <m>y</m> and choosing the branch through <m>(0, 3)</m>:
+						<me>y = \sqrt{9 - x^2}</me>.
+					</p>
+					<p>
+						The solution curve is the upper half of a circle of radius <m>3</m>, defined for <m>-3 \lt x \lt 3</m>.
+					</p>
+				</solution>
+				<answer>
+					<p>Separation of variables; <m>x^2 + y^2 = 9</m>, so <m>y = \sqrt{9 - x^2}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="fo-review-mixed-3">
+				<statement>
+					<p>
+						<m>y' + 2y = 4, \quad y(0) = 1</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> this equation passes <em>two</em> tests. It is first-order linear (standard form with <m>P = 2</m>, <m>Q = 4</m>), and isolating the derivative gives <m>y' = 4 - 2y = -2(y - 2)</m>, which is separable. Either method works; we show both.
+					</p>
+					<p>
+						<em>Integrating factor route:</em> <m>\mu = e^{\int 2\, dx} = e^{2x}</m>, so
+						<md>
+							<mrow>\frac{d}{dx}\left[e^{2x} y\right] \amp = 4e^{2x}</mrow>
+							<mrow>e^{2x} y \amp = 2e^{2x} + C</mrow>
+							<mrow>y \amp = 2 + Ce^{-2x}</mrow>
+						</md>
+					</p>
+					<p>
+						<em>Separation route:</em>
+						<md>
+							<mrow>\frac{dy}{y - 2} \amp = -2\, dx</mrow>
+							<mrow>\ln|y - 2| \amp = -2x + c</mrow>
+							<mrow>y \amp = 2 + Ce^{-2x}</mrow>
+						</md>
+						where <m>C = \pm e^{c}</m> absorbs the sign, as usual.
+					</p>
+					<p>
+						Both routes agree. Applying <m>y(0) = 1</m>: <m>1 = 2 + C</m>, so <m>C = -1</m> and
+						<me>y = 2 - e^{-2x}</me>.
+					</p>
+				</solution>
+				<answer>
+					<p>Both separation of variables and the integrating factor method apply; <m>y = 2 - e^{-2x}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="fo-review-mixed-4">
+				<statement>
+					<p>
+						<m>x y' + 2y = x^2, \quad x \gt 0</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> dividing by <m>x</m> gives the standard linear form <m>y' + \frac{2}{x}y = x</m>. The right side of <m>y' = x - \frac{2}{x}y</m> is a difference, not a product, so separation fails—this is an <em>integrating factor</em> problem.
+					</p>
+					<p>
+						The integrating factor is
+						<me>\mu(x) = e^{\int \frac{2}{x} dx} = e^{2\ln x} = x^2</me>.
+					</p>
+					<p>
+						Multiplying the standard form by <m>x^2</m> completes the product rule:
+						<md>
+							<mrow>x^2 y' + 2x y \amp = x^3</mrow>
+							<mrow>\frac{d}{dx}\left[x^2 y\right] \amp = x^3</mrow>
+							<mrow>x^2 y \amp = \frac{x^4}{4} + C</mrow>
+							<mrow>y \amp = \frac{x^2}{4} + \frac{C}{x^2}</mrow>
+						</md>
+					</p>
+				</solution>
+				<answer>
+					<p>Integrating factor (<m>\mu = x^2</m>); <m>y = \dfrac{x^2}{4} + \dfrac{C}{x^2}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="fo-review-mixed-5">
+				<statement>
+					<p>
+						<m>\dfrac{dy}{dx} = e^{\,x - y}</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> the exponent rule <m>e^{x-y} = e^x \cdot e^{-y}</m> reveals a product of an <m>x</m>-part and a <m>y</m>-part, so the equation is <em>separable</em>. (It is not linear: <m>y</m> sits inside an exponential.)
+					</p>
+					<p>
+						Separating and integrating,
+						<md>
+							<mrow>e^{y}\, dy \amp = e^{x}\, dx</mrow>
+							<mrow>e^{y} \amp = e^{x} + c</mrow>
+						</md>
+					</p>
+					<p>
+						Solving for <m>y</m> gives the general solution
+						<me>y = \ln\!\left(e^{x} + c\right)</me>.
+					</p>
+				</solution>
+				<answer>
+					<p>Separation of variables; <m>y = \ln\!\left(e^x + c\right)</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="fo-review-mixed-6">
+				<statement>
+					<p>
+						<m>e^x y' + e^x y = \cos x</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> before reaching for the integrating factor machinery, scan the left side: <m>e^x y' + e^x y</m> is exactly the expanded product rule for <m>\frac{d}{dx}\left[e^x y\right]</m>. The product rule is already complete, so <em>direct integration</em> finishes the job.
+					</p>
+					<p>
+						<md>
+							<mrow>\frac{d}{dx}\left[e^{x} y\right] \amp = \cos x</mrow>
+							<mrow>e^{x} y \amp = \sin x + C</mrow>
+							<mrow>y \amp = e^{-x}\left(\sin x + C\right)</mrow>
+						</md>
+					</p>
+					<p>
+						Had we not noticed, dividing by <m>e^x</m> would give standard form <m>y' + y = e^{-x}\cos x</m>, whose integrating factor <m>\mu = e^{x}</m> rebuilds the original equation—a longer road to the same place.
+					</p>
+				</solution>
+				<answer>
+					<p>Direct integration (the left side is <m>\frac{d}{dx}\left[e^x y\right]</m>); <m>y = e^{-x}\left(\sin x + C\right)</m>.</p>
+				</answer>
+			</exercise>
+		</exercisegroup>
+	</exercises>
+</section>

--- a/source/c5-if/review-first-order-methods.ptx
+++ b/source/c5-if/review-first-order-methods.ptx
@@ -22,19 +22,26 @@
 			The flowchart below organizes the decision. Each method has an entrance requirement: direct integration needs the equation to already be a single derivative, separation of variables needs the form <m>\frac{dy}{dx} = f(x)\cdot g(y)</m>, and the integrating factor method needs a first-order <em>linear</em> equation <m>y' + P(x)y = Q(x)</m>. Think of an equation you'd like to classify, then walk the chart by answering each highlighted question with the <c>Yes</c>/<c>No</c> buttons; press <c>Reset</c> to start over with a new equation.
 		</p>
 
-		<sidebyside width="90%" margins="5% 5%">
-			<interactive xml:id="method-flowchart"
-				platform="jsxgraph"
-				aspect="1.31:1"
-				dark-mode-enabled="yes"
-				source="code/jsxgraph/method-flowchart/method-flowchart.js"
-			>
-				<description>
-					Interactive decision-tree flowchart for choosing a first-order solution method. Starting from a given differential equation, it asks in order: Is the equation first order? If no, higher-order tools come in later chapters. Is it already a derivative of the form d/dx of something equals f of x? If yes, use direct integration. Is it separable? If yes, use separation of variables. Is it linear? If yes, use the integrating factor method; if no, use qualitative or numerical tools. Yes and No buttons advance the highlighted question and the chosen path is highlighted in green.
-				</description>
-				<slate xml:id="method-flowchart-plot1" surface="jsxboard" aspect="1.31:1" />
-			</interactive>
-		</sidebyside>
+		<figure xml:id="method-flowchart">
+			<caption>Particular solutions with different initial conditions.</caption>
+			<sidebyside width="90%">
+				<p>
+					<interactive xml:id="method-flowchart-interactive"
+						platform="jsxgraph"
+						aspect="1.3:1"
+						dark-mode-enabled="yes"
+						source="code/jsxgraph/method-flowchart/method-flowchart.js"
+					>
+						<slate xml:id="method-flowchart-plot1" surface="jsxboard" aspect="1.31:1" />
+						<instructions>
+							<p>
+								Interactive decision-tree flowchart for choosing a first-order solution method. Starting from a given differential equation, it asks in order: Is the equation first order? If no, higher-order tools come in later chapters. Is it already a derivative of the form d/dx of something equals f of x? If yes, use direct integration. Is it separable? If yes, use separation of variables. Is it linear? If yes, use the integrating factor method; if no, use qualitative or numerical tools. Yes and No buttons advance the highlighted question and the chosen path is highlighted in green.
+							</p>
+						</instructions>
+					</interactive>
+				</p>
+			</sidebyside>
+		</figure>
 
 		<p>
 			Two notes before you start practicing.
@@ -72,7 +79,7 @@
 				<title>Pick the Method</title>
 				<statement>
 					<p>
-						<me>\frac{dy}{dx} = x^2 e^{-x}</me>
+						<md>\frac{dy}{dx} = x^2 e^{-x}</md>
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -99,7 +106,7 @@
 				<title>Pick the Method</title>
 				<statement>
 					<p>
-						<me>\frac{dy}{dx} = x y^2</me>
+						<md>\frac{dy}{dx} = x y^2</md>
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -126,7 +133,7 @@
 				<title>Pick the Method</title>
 				<statement>
 					<p>
-						<me>y' + 3y = e^{2x}</me>
+						<md>y' + 3y = e^{2x}</md>
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -153,7 +160,7 @@
 				<title>Pick the Method</title>
 				<statement>
 					<p>
-						<me>x\, y' = y + x^2 \sin x</me>
+						<md>x\, y' = y + x^2 \sin x</md>
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -180,7 +187,7 @@
 				<title>Pick the Method</title>
 				<statement>
 					<p>
-						<me>\frac{dy}{dx} = \left(1 + y^2\right) e^{x}</me>
+						<md>\frac{dy}{dx} = \left(1 + y^2\right) e^{x}</md>
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -207,7 +214,7 @@
 				<title>More Than One Way</title>
 				<statement>
 					<p>
-						<me>\frac{dy}{dx} = 2y</me>
+						<md>\frac{dy}{dx} = 2y</md>
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -235,7 +242,7 @@
 				<statement>
 					<p>
 						This equation can be solved by more than one of our methods. Which observation gives the <em>fastest</em> route to the solution?
-						<me>x^2 y' + 2x y = 4x</me>
+						<md>x^2 y' + 2x y = 4x</md>
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -262,7 +269,7 @@
 				<title>Know When to Fold</title>
 				<statement>
 					<p>
-						<me>y' = y^2 + x</me>
+						<md>y' = y^2 + x</md>
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -311,11 +318,11 @@
 					</p>
 					<p>
 						Integrating both sides,
-						<me>y = \int \left(6x^2 - 4x + 1\right) dx = 2x^3 - 2x^2 + x + C</me>.
+						<md>y = \int \left(6x^2 - 4x + 1\right) dx = 2x^3 - 2x^2 + x + C</md>.
 					</p>
 					<p>
 						Applying <m>y(1) = 2</m>:
-						<me>2 = 2(1)^3 - 2(1)^2 + 1 + C = 1 + C \quad\implies\quad C = 1</me>.
+						<md>2 = 2(1)^3 - 2(1)^2 + 1 + C = 1 + C \quad\implies\quad C = 1</md>.
 					</p>
 					<p>
 						The particular solution is <m>y = 2x^3 - 2x^2 + x + 1</m>.
@@ -346,7 +353,7 @@
 					</p>
 					<p>
 						Applying <m>y(0) = 3</m> gives <m>C = 9</m>, so the solution satisfies <m>x^2 + y^2 = 9</m>. Solving for <m>y</m> and choosing the branch through <m>(0, 3)</m>:
-						<me>y = \sqrt{9 - x^2}</me>.
+						<md>y = \sqrt{9 - x^2}</md>.
 					</p>
 					<p>
 						The solution curve is the upper half of a circle of radius <m>3</m>, defined for <m>-3 \lt x \lt 3</m>.
@@ -386,7 +393,7 @@
 					</p>
 					<p>
 						Both routes agree. Applying <m>y(0) = 1</m>: <m>1 = 2 + C</m>, so <m>C = -1</m> and
-						<me>y = 2 - e^{-2x}</me>.
+						<md>y = 2 - e^{-2x}</md>.
 					</p>
 				</solution>
 				<answer>
@@ -406,7 +413,7 @@
 					</p>
 					<p>
 						The integrating factor is
-						<me>\mu(x) = e^{\int \frac{2}{x} dx} = e^{2\ln x} = x^2</me>.
+						<md>\mu(x) = e^{\int \frac{2}{x} dx} = e^{2\ln x} = x^2</md>.
 					</p>
 					<p>
 						Multiplying the standard form by <m>x^2</m> completes the product rule:
@@ -442,7 +449,7 @@
 					</p>
 					<p>
 						Solving for <m>y</m> gives the general solution
-						<me>y = \ln\!\left(e^{x} + C\right)</me>.
+						<md>y = \ln\!\left(e^{x} + C\right)</md>.
 					</p>
 				</solution>
 				<answer>

--- a/source/c5-if/review-first-order-methods.ptx
+++ b/source/c5-if/review-first-order-methods.ptx
@@ -311,11 +311,11 @@
 					</p>
 					<p>
 						Integrating both sides,
-						<me>y = \int \left(6x^2 - 4x + 1\right) dx = 2x^3 - 2x^2 + x + c</me>.
+						<me>y = \int \left(6x^2 - 4x + 1\right) dx = 2x^3 - 2x^2 + x + C</me>.
 					</p>
 					<p>
 						Applying <m>y(1) = 2</m>:
-						<me>2 = 2(1)^3 - 2(1)^2 + 1 + c = 1 + c \quad\implies\quad c = 1</me>.
+						<me>2 = 2(1)^3 - 2(1)^2 + 1 + C = 1 + C \quad\implies\quad C = 1</me>.
 					</p>
 					<p>
 						The particular solution is <m>y = 2x^3 - 2x^2 + x + 1</m>.
@@ -340,8 +340,8 @@
 						Separating and integrating,
 						<md>
 							<mrow>y\, dy \amp = -x\, dx</mrow>
-							<mrow>\frac{y^2}{2} \amp = -\frac{x^2}{2} + c</mrow>
-							<mrow>x^2 + y^2 \amp = C \qquad (C = 2c)</mrow>
+							<mrow>\frac{y^2}{2} \amp = -\frac{x^2}{2} + C_1</mrow>
+							<mrow>x^2 + y^2 \amp = C \qquad (C = 2C_1)</mrow>
 						</md>
 					</p>
 					<p>
@@ -379,10 +379,10 @@
 						<em>Separation route:</em>
 						<md>
 							<mrow>\frac{dy}{y - 2} \amp = -2\, dx</mrow>
-							<mrow>\ln|y - 2| \amp = -2x + c</mrow>
+							<mrow>\ln|y - 2| \amp = -2x + C_1</mrow>
 							<mrow>y \amp = 2 + Ce^{-2x}</mrow>
 						</md>
-						where <m>C = \pm e^{c}</m> absorbs the sign, as usual.
+						where <m>C = \pm e^{C_1}</m> absorbs the sign, as usual.
 					</p>
 					<p>
 						Both routes agree. Applying <m>y(0) = 1</m>: <m>1 = 2 + C</m>, so <m>C = -1</m> and
@@ -437,16 +437,16 @@
 						Separating and integrating,
 						<md>
 							<mrow>e^{y}\, dy \amp = e^{x}\, dx</mrow>
-							<mrow>e^{y} \amp = e^{x} + c</mrow>
+							<mrow>e^{y} \amp = e^{x} + C</mrow>
 						</md>
 					</p>
 					<p>
 						Solving for <m>y</m> gives the general solution
-						<me>y = \ln\!\left(e^{x} + c\right)</me>.
+						<me>y = \ln\!\left(e^{x} + C\right)</me>.
 					</p>
 				</solution>
 				<answer>
-					<p>Separation of variables; <m>y = \ln\!\left(e^x + c\right)</m>.</p>
+					<p>Separation of variables; <m>y = \ln\!\left(e^x + C\right)</m>.</p>
 				</answer>
 			</exercise>
 

--- a/source/c5-if/review-first-order-methods.ptx
+++ b/source/c5-if/review-first-order-methods.ptx
@@ -23,7 +23,7 @@
 		</p>
 
 		<figure xml:id="method-flowchart">
-			<caption>Particular solutions with different initial conditions.</caption>
+			<caption>The <q>Which Method?</q> flowchart. Answer each highlighted question with the <c>Yes</c>/<c>No</c> buttons to find the right tool; press <c>Reset</c> to start over with a new equation.</caption>
 			<sidebyside width="90%">
 				<p>
 					<interactive xml:id="method-flowchart-interactive"

--- a/source/c5-if/sec-completing-the-product-rule.ptx
+++ b/source/c5-if/sec-completing-the-product-rule.ptx
@@ -174,9 +174,9 @@
 			<statement>
 				<p>
 					Why do we multiply both sides of
-					<me>
+					<md>
 						\frac{dy}{dx} + 6y = -1
-					</me>
+					</md>
 					by <m>e^{6x}</m>?
 				</p>
 			</statement>
@@ -237,9 +237,9 @@
 			<statement>
 				<p>
 					Why do we say the differential equation
-					<me>
+					<md>
 						\frac{dy}{dx} + 6y = -1
-					</me>
+					</md>
 					contains an incomplete product rule?
 				</p>
 			</statement>
@@ -300,9 +300,9 @@
 			<statement>
 				<p>
 					The differential equation,
-					<me>
+					<md>
 						\frac{dQ}{dz}\ln z + \frac{Q}{z} = \tan\left(z^2\right)
-					</me>
+					</md>
 				</p>
 
 				<p>
@@ -358,9 +358,9 @@
 			<statement>
 				<p>
 					How does reversing the product rule help solve this equation?
-					<me>
+					<md>
 						\frac{dy}{dx} \cdot e^{5x^2} + 10x e^{5x^2} \cdot y = 3x
-					</me>.
+					</md>.
 				</p>
 			</statement>
 			<choices randomize="yes" multiple-correct="yes">
@@ -393,23 +393,23 @@
 			
 				<p>
 					Given that you can multiply the equation 
-					<me>
+					<md>
 						\frac{dy}{dx} + 6y = -1
-					</me>
+					</md>
 				</p>
 
 				<p>
 					by the function <m>e^{6x}</m> to transform it into
-					<me>
+					<md>
 						\frac{d}{dx}\left[e^{6x}y\right] = -e^{6x}
-					</me>
+					</md>
 				</p>
 
 				<p>
 					What function would you think to multiply the equation by
-					<me>
+					<md>
 						\frac{dy}{dx} - 8y = 3x
-					</me>
+					</md>
 				</p>
 
 				<p>

--- a/source/c5-if/sec-finding-the-integrating-factor.ptx
+++ b/source/c5-if/sec-finding-the-integrating-factor.ptx
@@ -20,24 +20,24 @@
 
 		<p>
 			For example, take the equation
-			<me>
+			<md>
 				\frac{dy}{dx} + 2y = 5.
-			</me>
+			</md>
 		</p>
 
 		<p>
 			It's not a <xref ref="gi-complete-product-rule" text="custom">complete product rule</xref>, but it can be if we multiply both sides by <m>e^{2x}</m>:
-			<me>
+			<md>
 				e^{2x} \frac{dy}{dx} + 2e^{2x} y = 5e^{2x}
-			</me>.
+			</md>.
 		</p>
 
 		<p>
 			<idx><h>integrating factor</h></idx>
 			Now, we can use the <xref ref="gi-reversed-product-rule" text="title"/> on the left, giving us
-			<me>
+			<md>
 				\frac{d}{dx} \left[ e^{2x} y \right] = 5e^{2x}
-			</me>,
+			</md>,
 			which is just one integration away from the solution. The function, <m>e^{2x}</m>, that we multiplied onto the equation is known as the <term>integrating factor</term>.
 		</p>
 
@@ -51,41 +51,41 @@
 
 		<p>
 			To figure out where <m>e^{2x}</m> came from, let's return to our example:
-			<me>
+			<md>
 				\frac{dy}{dx} + 2y = 5.
-			</me>
+			</md>
 		</p>
 
 		<p>
 			To complete the product rule, we need to multiply the equation by a function. We don't yet know what that function is, so let's call it <m>\mu(x)</m> and multiply both sides of the equation by it:
-			<me>
+			<md>
 				\mu(x)\ \frac{dy}{dx} + 2\mu(x)\ y = 5\mu(x)
-			</me>.
+			</md>.
 		</p>
 
 		<p>
 			If <m>\mu(x)</m> completes a product rule on the left, then it should match the form <m>fg'+f'g</m>. Setting the labels: <m>g = y</m>, so <m>g' = dy/dx</m>, and looking for functions <m>f</m> and <m>f'</m> that complete the pattern, we match as follows:
-			<me>
+			<md>
 				\underset{\Large f}{ \underset{\uparrow}{\ul{\mu(x)}}}\
 				\underset{\Large g'}{ \underset{\uparrow}{\ul{\vphantom{|}\frac{dy}{dx}}}} +
 				\underset{\Large f^\prime}{ \underset{\uparrow}{\ul{2\mu(x)}}}\
 				\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}y}}}
-			</me>.
+			</md>.
 		</p>
 
 		<p>
 			This suggests that
-			<me>
+			<md>
 				f = \mu(x) \quad\text{and}\quad f' = 2\mu(x)
-			</me>,
+			</md>,
 			and taking the derivative of the first of these means we also have <m>f' = \mu'(x)</m>.
 		</p>
 
 		<p>
 			Setting the two versions of <m>f'</m> equal, an interesting equation emerges:
-			<men xml:id="if-condition-equation">
+			<md xml:id="if-condition-equation">
 				\mu'(x) = 2\mu(x)
-			</men>.
+			</md>.
 		</p>
 
 		<p>
@@ -107,7 +107,7 @@
 
 		<p>
 			When selecting an integrating factor, we are free to choose any nonzero value for <m>c</m>. However, we usually choose <m>c = 1</m> to keep things simple, so, our integrating factor is:
-			<me>\mu(x) = e^{2x}.</me>
+			<md>\mu(x) = e^{2x}.</md>
 		</p>
 
 		<p>
@@ -122,20 +122,21 @@
 				<statement>
 					<p>
 						In the example above, we derived the integrating factor for the equation 
-						<me>
+						<md>
 							y' + 2y = 5
-						</me>.
+						</md>.
 						Based on this derivation, select the correct ending to the statement:
-						<blockquote>
-							<p>
-								Of the values in the equation, the integrating factor depends on <fillin characters="8" />.
-							</p>
-						</blockquote>
 					</p>
+
+					<blockquote>
+						<p>
+							Of the values in the equation, the integrating factor depends on <fillin characters="8" />.
+						</p>
+					</blockquote>
 				</statement>
 				<choices randomize="yes">
 					<choice correct="yes">
-						<statement> only the value <m>2</m>. </statement>
+						<statement><p>only the value <m>2</m>.</p></statement>
 						<feedback>
 							<p>
 								Correct! The integrating factor depends only on the coefficient of <m>y</m>, which is <m>2</m>.
@@ -143,7 +144,7 @@
 						</feedback>
 					</choice>
 					<choice>
-						<statement> only the value <m>5</m>. </statement>
+						<statement><p>only the value <m>5</m>.</p></statement>
 						<feedback>
 							<p>
 								Incorrect. The integrating factor does not depend on the free term <m>5</m>, but rather on the coefficient of <m>y</m>, which is <m>2</m>.
@@ -151,7 +152,7 @@
 						</feedback>
 					</choice>
 					<choice>
-						<statement> both <m>2</m> and <m>5</m>. </statement>
+						<statement><p> both <m>2</m> and <m>5</m>. </p></statement>
 						<feedback>
 							<p>
 								Incorrect. The integrating factor does not depend on the free term <m>5</m>, but rather only on the coefficient of <m>y</m>, which is <m>2</m>.
@@ -159,7 +160,7 @@
 						</feedback>
 					</choice>
 					<choice>
-						<statement> neither <m>2</m> nor <m>5</m>. </statement>
+						<statement><p> neither <m>2</m> nor <m>5</m>. </p></statement>
 						<feedback>
 							<p>
 								Incorrect. The integrating factor does depend on the coefficient of <m>y</m>, which is <m>2</m>.
@@ -174,32 +175,32 @@
 				<statement>
 					<p>
 						To solve the differential equation
-						<me>
+						<md>
 							y' + \frac{1}{x}y = x
-						</me>,
+						</md>,
 						you multiply both sides by the integrating factor, <m>\mu(x)</m>, to get
-						<me>
+						<md>
 							\mu(x) y' + \frac{\mu(x)}{x}y = \mu(x) x.
-						</me>
+						</md>
 						Which separable differential equation do you solve to find <m>\mu(x)</m>?
 					</p>
 				</statement>
 				<choices randomize="yes">
 					<choice correct="yes">
-						<statement><m>\quad\ds\mu'(x) = \frac{1}{x}\mu(x) </m></statement>
-						<feedback>Correct!</feedback>
+						<statement><p><m>\quad\ds\mu'(x) = \frac{1}{x}\mu(x) </m></p></statement>
+						<feedback><p>Correct!</p></feedback>
 					</choice>
 					<choice>
-						<statement><m>\quad\ds\mu'(x) = x\mu(x) </m></statement>
-						<feedback>Incorrect</feedback>
+						<statement><p><m>\quad\ds\mu'(x) = x\mu(x) </m></p></statement>
+						<feedback><p>Incorrect</p></feedback>
 					</choice>
 					<choice>
-						<statement><m>\quad\ds\mu'(x) + \frac{\mu(x)}{x} = x </m></statement>
-						<feedback>Incorrect. This is not a separable equation.</feedback>
+						<statement><p><m>\quad\ds\mu'(x) + \frac{\mu(x)}{x} = x </m></p></statement>
+						<feedback><p>Incorrect. This is not a separable equation.</p></feedback>
 					</choice>
 					<choice>
-						<statement><m>\quad\ds\mu'(x) = \frac{1}{x}y\mu(x) </m></statement>
-						<feedback>Incorrect. This equation has too many variables.</feedback>
+						<statement><p><m>\quad\ds\mu'(x) = \frac{1}{x}y\mu(x) </m></p></statement>
+						<feedback><p>Incorrect. This equation has too many variables.</p></feedback>
 					</choice>
 				</choices>
 			</task>
@@ -226,9 +227,9 @@
 				<p>
 					<idx><h>standard form (first-order linear)</h></idx>
 					A differential equation is said to be in <term>standard form</term> if it can be written as:
-					<me>
+					<md>
 						\frac{dy}{dx} + P(x)\,y = Q(x),
-					</me>
+					</md>
 					where <m>P(x)</m> and <m>Q(x)</m> are known functions of the independent variable <m>x</m>, and <m>y</m> is the unknown function (dependent variable) we want to find.
 				</p>
 			</statement>
@@ -240,15 +241,15 @@
 			<statement>
 				<p>
 					All first-order linear differential equations have a <m>y'</m>, <m>y</m>, and free term. Therefore, they can be written as
-					<me>
+					<md>
 						A(x)y' + B(x)y = C(x)
-					</me>.
+					</md>.
 					Dividing both sides by the leading coefficient, <m>A(x)</m>, and renaming the <m>y</m> and constant coefficients as <m>P</m> and <m>Q</m>, gives the standard form
-					<me>
+					<md>
 						y' + \us{P(x)}{\ub{\frac{B(x)}{A(x)}}}y	= \us{Q(x)}{\ub{\frac{C(x)}{A(x)}}}	
 						\quad \implies \quad
 						y' + P(x)y	= Q(x)
-					</me>.
+					</md>.
 				</p>
 			</statement>
 
@@ -263,9 +264,9 @@
 			<p>
 				<idx><h>integrating factor</h></idx>
 				For a first-order linear equation written in standard form
-				<me>
+				<md>
 					y' + P(x)\ y = Q(x)
-				</me>
+				</md>
 				the <term>integrating factor</term> is given by	
 				<m>
 					\ \ds\mu(x) = e\vphantom{\sum}^{{\Large\int} P(x)\ dx}
@@ -284,9 +285,9 @@
 
 				<p>
 					Just like before, we assume that multiplying by <m>\mu(x)</m> gives us something that matches the product rule. So we try:
-					<me>
+					<md>
 						\mu(x)\,\frac{dy}{dx} + \mu(x)\,P(x)\,y = \mu(x)\,Q(x).
-					</me>
+					</md>
 				</p>
 
 				<p>
@@ -295,19 +296,19 @@
 
 				<p>
 					As before, we set <m>g = y</m> and <m>g' = dy/dx</m>. Then the rest of the labels follow:
-					<me>
+					<md>
 						\underset{\Large f}{ \underset{\uparrow}{\ul{\mu(x)}}}\
 						\underset{\Large g'}{ \underset{\uparrow}{\ul{\vphantom{|}\frac{dy}{dx}}}} +
 						\underset{\Large f^\prime}{ \underset{\uparrow}{\ul{\mu(x)\,P(x)}}}\
 						\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}y}}}
-					</me>
+					</md>
 				</p>
 
 				<p>
 					Since <m>f = \mu(x)</m>, we also know <m>f' = \mu'(x)</m>. Setting these equal gives the condition:
-					<men xml:id="if-sov-eqn">
+					<md xml:id="if-sov-eqn">
 						\mu'(x) = P(x)\,\mu(x)
-					</men>
+					</md>
 				</p>
 
 				<p>
@@ -345,9 +346,9 @@
 			<solution>
 				<p>
 					The equation is in standard form and the coefficient of <m>y</m> is <m>4</m>, so <m>P(x) = 4</m> and the integrating factor is:
-					<me>
+					<md>
 						\mu(x) = e^{\large\int 4\ dx} = e^{4x}.
-					</me>
+					</md>
 				</p>
 			</solution>
 		</example>
@@ -358,16 +359,16 @@
 			<solution>
 				<p>
 					This equation is not in standard form because of <m>x</m> in the coefficient of <m>dy/dx</m>. Dividing through by <m>x</m> (since <m>x \neq 0</m>) puts it in standard form:
-					<me>
+					<md>
 						\frac{dy}{dx} + \frac{2}{x}y = x^3.
-					</me>
+					</md>
 				</p>
 
 				<p>
 					Now, we can easily see that <m>P(x) = 2/x</m>. Plugging this into the formula:
-					<me>
+					<md>
 						\mu(x) = e^{\large\int \frac{2}{x}\ dx} = e^{2\ln |x|} = e^{\ln x^2} = x^2.
-					</me>
+					</md>
 				</p>
 			</solution>
 		</example>
@@ -377,30 +378,30 @@
 			<solution>
 				<p>
 					The variables in this equation are <m>z</m> and <m>R</m>, so the formula adjusts accordingly:
-					<me>
+					<md>
 						\mu(z) = e^{\large\int P(z)\, dz}
-					</me>.
+					</md>.
 				</p>
 
 				<p>
 					Also, this equation is not in standard form, so move the <m>R</m> term to the left:
-					<me>
+					<md>
 						z^2\,\frac{dR}{dz} + (1 - 3z)R = \ln z
-					</me>.
+					</md>.
 				</p>
 
 				<p>
 					Then divide through by <m>z^2</m> and note <m>P(z)</m> as the coefficient of <m>R</m>:
-					<me>
+					<md>
 						\frac{dR}{dz} + \os{\large P(z)}{\boxed{\left(\frac{1 - 3z}{z^2}\right)}}\ R = \frac{\ln z}{z^2}
-					</me>
+					</md>
 				</p>
 
 				<p>
 					Using <m>P(z)</m>, calculate the integral of <m>P(z)</m> used in the formula:
-					<me>
+					<md>
 						\int P(z)\ dz = \int \frac{1 - 3z}{z^2}\ dz
-					</me>
+					</md>
 				</p>
 
 				<p>
@@ -418,9 +419,9 @@
 
 				<p>
 					Thus, the integrating factor is simplified and given as follows:
-					<me>
+					<md>
 						\mu(z) = e^{-\sfrac{1}{z} - 3\ln z} = e^{-\sfrac{1}{z}} \cdot e^{-3\ln z} = e^{-\sfrac{1}{z}} z^{-3}.
-					</me>
+					</md>
 				</p>
 			</solution>
 		</example>
@@ -433,15 +434,15 @@
 				<statement>
 					<p>
 						Suppose you want to compute the integrating factor for the differential equation
-						<me>
+						<md>
 							-4\frac{dy}{dx} + 6xy = 15.5
-						</me>.
+						</md>.
 						After rewriting it in standard form, which parts of the equation does the integrating factor depend on?
 					</p>
 				</statement>
 				<choices randomize="yes" multiple-correct="yes">
 					<choice correct="yes">
-						<statement><m>\quad 6x</m></statement>
+						<statement><p><m>\quad 6x</m></p></statement>
 						<feedback>
 							<p>
 								Correct! The integrating factor depends on the coefficient of <m>y</m>, which is <m>6x</m>.
@@ -449,7 +450,7 @@
 						</feedback>
 					</choice>
 					<choice correct="yes">
-						<statement><m>\quad -4</m></statement>
+						<statement><p><m>\quad -4</m></p></statement>
 						<feedback>
 							<p>
 								Correct! To put the equation in standard form, we divide by <m>-4</m>, so the integrating factor will depend on this coefficient.
@@ -457,7 +458,7 @@
 						</feedback>
 					</choice>
 					<choice>
-						<statement><m>\quad 15.5</m></statement>
+						<statement><p><m>\quad 15.5</m></p></statement>
 						<feedback>
 							<p>
 								Incorrect. The integrating factor does not depend on the free term.
@@ -465,7 +466,7 @@
 						</feedback>
 					</choice>
 					<choice>
-						<statement><m>\quad y</m></statement>
+						<statement><p><m>\quad y</m></p></statement>
 						<feedback>
 							<p>
 								Incorrect. The integrating factor does not depend on <m>y</m>, but it does depend on the coefficient of <m>y</m>.
@@ -480,9 +481,9 @@
 				<statement>
 					<p>
 						What is the integrating factor for the equation
-						<me>
+						<md>
 							y' + 3y = e^x
-						</me>?
+						</md>?
 					</p>
 				</statement>
 				<choices randomize="yes">
@@ -545,27 +546,25 @@
 					</p>
 
 					<p>
-						<me>
+						<md>
 							\frac{dy}{dx} + 3x^2y = \cos x
-						</me>
+						</md>
 					</p>
 
 					<p>
 						is given by the function <m>\quad\mu(x) = </m> <fillin name="mu_field" mode="math" ansobj="mu" />
 					</p>
-
-					<aside>
-						<title>Order of Operations</title>
-						<p>
-							Be wary of the order of operations and using parentheses when typing in your answer. For example, 
-							<ul>
-								<li><c>2^3^4</c> is equivalent to <m>(2^3)^4</m>, whereas</li>
-								<li><c>2^(3^4)</c> is equivalent to <m>2^{3^4}</m>.</li>
-							</ul>
-						</p>
-					</aside>
-
 				</statement>
+				<hint>
+					<title>Order of Operations</title>
+					<p>
+						Be wary of the order of operations and using parentheses when typing in your answer. For example, 
+						<ul>
+							<li><c>2^3^4</c> is equivalent to <m>(2^3)^4</m>, whereas</li>
+							<li><c>2^(3^4)</c> is equivalent to <m>2^{3^4}</m>.</li>
+						</ul>
+					</p>
+				</hint>
 				<setup>
 					<de-object name="mu" context="formula"><de-expression reduce="yes">	e^(x^3)	</de-expression></de-object>
 				</setup>
@@ -576,9 +575,9 @@
 							<feedback>
 								<p>
 									Correct! For this equation, <m>P(x) = 3x^2</m>, therefore the integrating factor is
-									<me>
+									<md>
 										\mu(x) = e^{\large\int 3x^2 dx} = e^{x^3}
-									</me>.
+									</md>.
 								</p>
 							</feedback>
 						</test>
@@ -594,16 +593,16 @@
 					</p>
 
 					<p>
-						<me>
+						<md>
 							-x y' = y + 2x + 1
-						</me>
+						</md>
 					</p>
 
 					<p>
 						in the standard first-order linear form
-						<me>
+						<md>
 							y' + P(x)y = Q(x)
-						</me>
+						</md>
 						and identify <m>P(x)</m>, <m>Q(x)</m> and the integrating factor, <m>\mu(x)</m>.
 						<ul marker="square">
 							<li>
@@ -637,9 +636,9 @@
 							<feedback>
 								<p>
 									Correct! The equation is rearranged as
-									<me>
+									<md>
 										y' + \frac{1}{x}y = 2 + \frac{1}{x}
-									</me>
+									</md>
 									showing that <m>P(x) = \frac{1}{x}</m>.
 								</p>
 							</feedback>
@@ -661,9 +660,9 @@
 							<feedback>
 								<p>
 									Correct! The integrating factor is
-									<me>
+									<md>
 										\mu(x) = e^{\large\int \frac{1}{x} dx} = e^{\ln x} = x
-									</me>.
+									</md>.
 								</p>
 							</feedback>
 						</test>
@@ -679,16 +678,16 @@
 					</p>
 
 					<p>
-						<me>
+						<md>
 							2y' = 4 - 4xy
-						</me>
+						</md>
 					</p>
 
 					<p>
 						in the standard first-order linear form
-						<me>
+						<md>
 							y' + P(x)y = Q(x)
-						</me>
+						</md>
 						and identify <m>P(x)</m>, <m>Q(x)</m> and the integrating factor, <m>\mu(x)</m>.
 						<ul marker="square">
 							<li>
@@ -721,9 +720,9 @@
 							<feedback>
 								<p>
 									Correct! The equation is rearranged as
-									<me>
+									<md>
 										y' + 2xy = 2
-									</me>
+									</md>
 									showing that <m>P(x) = 2x</m>.
 								</p>
 							</feedback>
@@ -745,9 +744,9 @@
 							<feedback>
 								<p>
 									Correct! The integrating factor is
-									<me>
+									<md>
 										\mu(x) = e^{\large\int 2x dx} = e^{x^2}
-									</me>.
+									</md>.
 								</p>
 							</feedback>
 						</test>

--- a/source/c5-if/sec-if-method.ptx
+++ b/source/c5-if/sec-if-method.ptx
@@ -49,17 +49,17 @@
 		<p>
 			<sidebyside valign="middle" widths="27% 33% 28%" margins="6% 6%">
 				<p>Standard Form:</p>
-				<p><me>\frac{dy}{dx} + 2 y = 5</me></p>
+				<p><md>\frac{dy}{dx} + 2 y = 5</md></p>
 				<p><m>\leftarrow</m> Find &amp; Multiply by <m>e^{2x}</m></p>
 			</sidebyside>
 			<sidebyside valign="middle" widths="27% 33% 28%" margins="6% 6%">
 				<p>Complete Product Rule:</p>
-				<p><me>e^{2x}\frac{dy}{dx}	+ 2e^{2x} y = 5e^{2x}</me></p>
+				<p><md>e^{2x}\frac{dy}{dx}	+ 2e^{2x} y = 5e^{2x}</md></p>
 				<p><m>\leftarrow</m> Reverse Product Rule</p>
 			</sidebyside>
 			<sidebyside valign="middle" widths="27% 33% 28%" margins="6% 6%">
 				<p>Grouped Derivative:</p>
-				<p><me>\frac{d}{dx} \left[e^{2x} y \right] = 5e^{2x}</me></p>
+				<p><md>\frac{d}{dx} \left[e^{2x} y \right] = 5e^{2x}</md></p>
 				<p><m>\leftarrow</m> Direct Integration</p>
 			</sidebyside>
 		</p>
@@ -72,47 +72,42 @@
 			<title>Integrating Factor (IF) Method</title>
 			<p>
 				Given a <xref ref="gi-first-order-linear-differential-equation" text="custom">first-order linear equation</xref> in standard form:
-				<men xml:id="if-steps-standard-form">
+				<md xml:id="if-steps-standard-form" number="yes">
 					y' + P(x) y = Q(x),
-				</men>
+				</md>
 			</p>
 
 			<p>
 				the general solution can be found through the following <em>three-step process</em>:
 				<dl width="narrow">
-					<li xml:id="if-step-1"><title>Step 1: Find the Integrating Factor</title>
-
-					<p>
-						Identify <m>P(x)</m> and compute the <em>integrating factor</em>:
-					</p>
-
-					<p>
-						<me>
-							\mu = e\vphantom{\large|}^{\textstyle\int P(x)\ dx}
-						</me>.
-					</p>
-					
+					<li xml:id="if-step-1">
+						<title>Step 1: Find the Integrating Factor</title>
+						<p>
+							Identify <m>P(x)</m> and compute the <em>integrating factor</em>:
+							<md>
+								\mu = e\vphantom{\large|}^{\textstyle\int P(x)\ dx}
+							</md>.
+						</p>
 					</li>
-					<li xml:id="if-step-2"><title>Step 2: Multiply by <m>\mu</m> to Complete the Product Rule</title>
-					<p>
-						Multiply both sides of the equation <xref ref="if-steps-standard-form"/> by <m>\mu</m> and reverse the product rule on the left side.
-					</p>
-
-					<p>
-						<mdn>
-							<mrow>	
-								\mu(x)\frac{dy}{dx} + P(x) \mu(x) y			\amp = Q(x)	\mu(x)
-							</mrow>
-							<mrow xml:id="if-method-reversed-product-rule">
-								\frac{d}{dx}\left[\mu(x) \cdot y\right]	\amp = Q(x) \mu(x)
-							</mrow>
-						</mdn>.
-					</p>
+					<li xml:id="if-step-2">
+						<title>Step 2: Multiply by <m>\mu</m> to Complete the Product Rule</title>
+						<p>
+							Multiply both sides of the equation <xref ref="if-steps-standard-form"/> by <m>\mu</m> and reverse the product rule on the left side.
+							<md>
+								<mrow>	
+									\mu(x)\frac{dy}{dx} + P(x) \mu(x) y			\amp = Q(x)	\mu(x)
+								</mrow>
+								<mrow xml:id="if-method-reversed-product-rule" number="yes">
+									\frac{d}{dx}\left[\mu(x) \cdot y\right]	\amp = Q(x) \mu(x)
+								</mrow>
+							</md>.
+						</p>
 					</li>
-					<li xml:id="if-step-3"><title>Step 3: Solve Using Direct Integration</title>
-					<p>
-						Integrate both sides of the equation <xref ref="if-method-reversed-product-rule"/> and solve for <m>y</m> to find the general solution.
-					</p>
+					<li xml:id="if-step-3">
+						<title>Step 3: Solve Using Direct Integration</title>
+						<p>
+							Integrate both sides of the equation <xref ref="if-method-reversed-product-rule"/> and solve for <m>y</m> to find the general solution.
+						</p>
 					</li>
 				</dl>
 			</p>
@@ -152,7 +147,7 @@
 				<statement>
 					<p>
 					Suppose you're given the equation:
-					<me>2xy' + 4x^2 y = \ln x</me>.
+					<md>2xy' + 4x^2 y = \ln x</md>.
 					What should you do before computing an integrating factor?
 					</p>
 				</statement>
@@ -196,9 +191,9 @@
 				<statement>
 					<p>
 						Consider multiplying this differential equation by its integrating factor.
-						<me>
+						<md>
 							y' + 2xy = 4x^2
-						</me>.
+						</md>.
 						Which of the following statements are true? (Select all that apply.)
 					</p>
 				</statement>
@@ -297,9 +292,9 @@
 					Find the general solution to the equation
 				</p>
 				<p>
-					<me>
+					<md>
 						y' + 6y = 1
-					</me>.
+					</md>.
 				</p>
 			</statement>
 			<solution>
@@ -314,9 +309,9 @@
 							Recall that we ignore the integration constant when computing the integrating factor.
 						</p>
 					</aside>
-					<me>
+					<md>
 						y' + \os{P}{\boxed{6}}\ y = 1\quad \rightarrow \quad \mu(x) = e^{\int 6\ dx} = e^{6x}
-					</me>
+					</md>
 				</p>
 
 				<p>
@@ -344,25 +339,23 @@
 			<statement>
 				<p>
 					Solve the equation
-				</p>
-				<p>
-					<me>x^2y' = 5x^3 + 2x^3y </me>.
+					<md>x^2y' = 5x^3 + 2x^3y </md>.
 				</p>
 			</statement>
 			<solution>
 				<p>
 					This equation is first-order and linear, but not in standard form, so we divide both sides by <m>x^2</m> and move the <m>y</m> to the same side as the <m>y'</m> term:
-					<me>
+					<md>
 						y' = 5x + 2x y \quad \Rightarrow \quad y' - 2x y = 5x
-					</me>.
+					</md>.
 					Now the IF method applies.
 				</p>
 
 				<p>
 					<xref ref="if-step-1" text="custom">Step 1</xref>. Identify <m>P(x)</m> and compute <m>\mu</m>:
-					<me>
+					<md>
 						y' + \os{P}{\boxed{-2x}} y = 5x \quad \rightarrow \quad \mu = e^{\int -2x\ dx} = e^{-x^2}
-					</me>.
+					</md>.
 				</p>
 
 				<p>
@@ -437,16 +430,16 @@
 			<statement>
 				<p>
 					Solve the equation:
-					<me> t^2 y' + 2ty = t^3 \ln t </me>.
+					<md> t^2 y' + 2ty = t^3 \ln t </md>.
 				</p>
 			</statement>
 			<solution>
 				<p>
 					Put the equation in standard form, identify <m>P(t)</m>, and compute <m>\mu</m>:
-					<me>
+					<md>
 						y' + \us{P}{\boxed{\frac{2}{t}}}\ y = t \ln t \quad \implies \quad
 						\mu(t) = e^{\large \int (\sfrac{2}{t})\, dt} = e^{2 \ln t} = t^2
-					</me>
+					</md>
 				</p>
 			
 				<p>
@@ -511,26 +504,26 @@
 			<statement>
 				<p>
 					Solve the initial value problem.
-					<me>
+					<md>
 						A = \sec\theta A' - \frac{\theta e^{\large\theta^2 + \sin\theta}}{\cos \theta}, \hspace{1cm} A(0) = -\frac{1}{2}
-					</me>.
+					</md>.
 				</p>
 			</statement>
 			<solution>
 				<p>
 					Put the equation in standard form by replacing <m>\sec\theta</m> with <m>\frac{1}{\cos\theta}</m> and moving the <m>A'</m> term to the left:
-					<me>
+					<md>
 						\frac{1}{\cos\theta} A' - A = \frac{\theta e^{\large\theta^2 + \sin\theta}}{\cos \theta}
-					</me>.
+					</md>.
 				</p>
 
 				<p>
 					Multiplying this by <m>\cos\theta</m> allows us to identify <m>P</m> and compute <m>\mu</m>:
-					<me>
+					<md>
 						A' + \us{P}{\boxed{- \cos\theta}}\ A = \theta e^{\large \theta^2 + \sin\theta}
 						\quad \implies \quad
 						\mu = e\vphantom{\large|}^{\large\int -\cos\theta d\theta} = e^{\large -\sin\theta}
-					</me>
+					</md>
 				</p>
 
 				<p>
@@ -585,7 +578,7 @@
 
 				<p>
 					We can then write the particular solution to the initial value problem.
-					<me>A(\theta) = \frac{1}{2}e^{\large\theta^2 + \sin\theta} - e^{\large\sin\theta}</me>
+					<md>A(\theta) = \frac{1}{2}e^{\large\theta^2 + \sin\theta} - e^{\large\sin\theta}</md>
 				</p>
 			</solution>
 		</example>

--- a/source/c5-if/sec-product-rule.ptx
+++ b/source/c5-if/sec-product-rule.ptx
@@ -25,9 +25,9 @@
 		<p>
 			<idx><h>product rule</h></idx>
 			In calculus, the <term>product rule</term> tells us how to take the derivative of two multiplied functions. If <m>f(x)</m> and <m>g(x)</m> are differentiable, then
-			<me>
+			<md>
 				\frac{d}{dx} \left[ f(x) \cdot g(x) \right] = f(x) \cdot g'(x) + f'(x) \cdot g(x)
-			</me>.
+			</md>.
 		</p>
 
 		<p>
@@ -40,9 +40,9 @@
 			<introduction>
 				<p>
 					Compute each of the derivatives below. Assume <m>y</m> is a function of <m>x</m>.
-					<me>
+					<md>
 						1. \quad \left[x^6 e^{3x}\right]' \hspace{5em} 2. \quad \frac{d}{dx}\left[e^{x^3} y\right]
-					</me>
+					</md>
 				</p>
 			</introduction>
 				
@@ -76,16 +76,16 @@
 					Using the product rule:
 					<ol>
 						<li>
-							<me>
+							<md>
 								\left[ x^6 e^{3x} \right]'
 									= x^6 \cdot 3e^{3x} + 6x^5 \cdot e^{3x}
-							</me>
+							</md>
 						</li>
 						<li>
-							<me>
+							<md>
 								\frac{d}{dx}\left[ e^{x^3} y(x) \right]
 									= e^{x^3} \cdot y'(x) + 3x^2 e^{x^3} \cdot y(x)
-							</me>
+							</md>
 						</li>
 					</ol>
 				</p>
@@ -104,16 +104,16 @@
 
 		<p>
 			Suppose you're given the expression:
-			<men xml:id="product-rule-in-reverse-eqn-1">
+			<md xml:id="product-rule-in-reverse-eqn-1">
 				\frac{1}{x} \sin x + \cos x \ln x
-			</men>.
+			</md>.
 		</p>
 
 		<p>
 			Can this be written as the derivative of a product? That is, can you find functions <m>f(x)</m> and <m>g(x)</m> so that
-			<me>
+			<md>
 				\frac{d}{dx} \left[ f(x) g(x) \right] = \frac{1}{x} \sin x + \cos x \ln x?
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -129,76 +129,76 @@
 			<statement>
 				<p>
 					Rewrite each expression as a derivative of a product:
-					<me>
+					<md>
 						1. \quad e^{x}\cos x + e^{x}\sin x \hspace{5em} 2. \quad \frac{e^{x^2}}{x} + 2 x \ln x e^{x^2}
-					</me>
+					</md>
 				</p>
 			</statement>
 
 			<solution>
 				<p>
 					First, select an <m>f</m> and <m>g</m> in different terms, like so
-					<me>
+					<md>
 						e^x \
 						\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}\cos x}}}
 						+
 						\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}e^x}}} \
 						\sin x
-					</me>.
+					</md>.
 				</p>
 			
 				<p>
 					For this to work, <m>f'</m> should be <m>\sin x</m>, next to our chosen <m>g</m>. However,
-					<me>
+					<md>
 						f' = [\cos x]' = -\sin x \ne \sin x \quad <e component="emoji">❌</e>
-					</me>
+					</md>
 				</p>
 			
 				<p>
 					So this labeling doesn't work, and we instead try the labels
-					<me>
+					<md>
 						\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}e^x}}} \
 						\cos x
 						+
 						e^x \
 						\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}\sin x}}}
-					</me>.
+					</md>.
 				</p>
 			
 				<p>
 					Noting that <m>f' = [e^x]' = e^x</m> is next to <m>g</m> and <m>g' = [\sin x]' = \cos x</m> is next to <m>f</m> confirms this is a valid product rule. Therefore, we can reverse the product rule as			
-					<me>
+					<md>
 						e^x \cos x + e^x \sin x = [e^x \sin x]'
-					</me>.
+					</md>.
 				</p>
 			
 				<p>
 					To make this easier, let's separate the terms as
-					<me>
+					<md>
 						\frac{1}{x} e^{x^2} + \ln x (2 x e^{x^2})
-					</me>.
+					</md>.
 				</p>
 			
 				<p>
 					So, as before, we first set <m>f</m> and <m>g</m>			
-					<me>
+					<md>
 						\frac{1}{x} \
 						\underset{\Large f}{ \underset{\uparrow}{\ul{\vphantom{|}e^{x^2}}}}
 						+
 						\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}\ln x}}} \
 						2 x e^{x^2}
-					</me>,
+					</md>,
 					then verify the derivatives of <m>f</m> and <m>g</m> are in the other terms,
-					<me>
+					<md>
 						f' = \left[e^{x^2}\right]' = 2 x e^{x^2} \quad <e component="emoji">✅</e> \qquad g' = \left[\ln x\right]' = \frac{1}{x} \quad <e component="emoji">✅</e>
-					</me>.
+					</md>.
 				</p>
 
 				<p>
 					Therefore,
-					<me>
+					<md>
 						\frac{e^{x^2}}{x} + 2 x \ln x e^{x^2} = \left[e^{x^2} \ln x\right]'
-					</me>.
+					</md>.
 				</p>
 			</solution>
 		</example>
@@ -212,58 +212,58 @@
 			<statement>
 				<p>
 					Rewrite each expression in the form <m>[f(x) y(x)]'</m>.
-					<me>
+					<md>
 						1. \quad e^{9x}\frac{dy}{dx} + 9y e^{9x} \hspace{5em} 2. \quad e^{1/x}y' - \frac{e^{1/x}}{x^2}y
-					</me>
+					</md>
 				</p>
 			</statement>
 
 			<solution>
 				<p>
 					Since <m>dy/dx</m> and <m>y</m> are in separate terms, setting <m>g</m> to <m>y</m> gives you <m>g'</m> and <m>f</m> for free since
-					<me>
+					<md>
 						\underset{\Large f}{ \underset{\uparrow}{\ul{e^{9x}}}} \
 						\underset{\Large g'}{ \underset{\uparrow}{\ul{\vphantom{|}\frac{dy}{dx}}}}
 						+
 						\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}y}}} \
 						(9 e^{9x})
-					</me>.
+					</md>.
 				</p>
 			
 				<p>
 					The only thing you need to check is
-					<me>
+					<md>
 						f' = [e^{9x}]' = 9e^{9x} \quad <e component="emoji">✅</e>
-					</me>
+					</md>
 					which is sitting right next to <m>g</m>. Therefore, we have
-					<me>
+					<md>
 						e^{9x}\frac{dy}{dx} + 9 e^{9x} y = \left[e^{9x} y\right]'
-					</me>.
+					</md>.
 				</p>
 			
 				<p>
 					Again, set <m>g</m> to <m>y</m> and the rest fall into place as
-					<me>
+					<md>
 						\underset{\Large f}{ \underset{\uparrow}{\ul{e^{1/x}}}} \
 						\underset{\Large g'}{ \underset{\uparrow}{\ul{\vphantom{|}y'}}}
 						+
 						\left(-\frac{e^{1/x}}{x^2}\right) \
 						\underset{\Large g}{ \underset{\uparrow}{\ul{\vphantom{|}y}}}
-					</me>.
+					</md>.
 				</p>
 			
 				<p>
 					The only thing left to do is verify the derivative of <m>f</m>:
-					<me>
+					<md>
 						f' = \left[e^{1/x}\right]' = e^{1/x}\left[\frac{1}{x}\right]^\prime = e^{1/x}\left(-\frac{1}{x^2}\right) = -\frac{e^{1/x}}{x^2} \quad <e component="emoji">✅</e>
-					</me>.
+					</md>.
 				</p>
 			
 				<p>
 					So, we can reverse the product rule as		
-					<me>
+					<md>
 						e^{1/x}y' - \frac{e^{1/x}}{x^2}y = \left[e^{1/x} y\right]'
-					</me>.
+					</md>.
 				</p>
 			</solution>
 		</example>

--- a/source/c6-qm/sec-equilibrium-solutions.ptx
+++ b/source/c6-qm/sec-equilibrium-solutions.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section label="equilibrium-solns"> 
+<section xml:id="equilibrium-solns"> 
 	<title>Equilibrium Solutions</title>
 
 	<introduction>
@@ -20,24 +20,23 @@
 		</p>
 	</introduction>
 
-	<subsection label="equilibrium-solns-behavior">
+	<subsection xml:id="equilibrium-solns-behavior">
 		<title>Flat Lines and Fixed Behavior</title>
 
 		<p>
 			Consider the slope field for the <xref ref="gi-autonomous-differential-equation" text="custom">autonomous equation</xref>:
+			<md>
+				\frac{dy}{dt} = 1 - y^2
+			</md>.
 		</p>
-
-		<md>
-			\frac{dy}{dt} = 1 - y^2
-		</md>.
 
 		<p>
 			Since this is autonomous, the slope depends only on <m>y</m>. At certain <m>y</m>-values, something special happens: the slope becomes exactly zero.
 		</p>
 
-		<sidebyside widths="50%" margin="10%" valign="middle">
-			<figure xml:id="slope-field-1-ysqrd">
-				<image width="50%">
+		<figure xml:id="slope-field-1-ysqrd">
+			<sidebyside widths="50%" margins="5% 5%" valign="middle">
+				<image width="100%">
 					<latex-image>
 						\begin{tikzpicture}[declare function={f(\x,\y) = 1 - \y*\y;}, scale=0.8]
 
@@ -107,10 +106,10 @@
 						\end{tikzpicture}
 					</latex-image>
 				</image>
-				<caption>Slope field for <m>y' = 1 - y^2</m></caption>
-			</figure>
-		</sidebyside>
-
+			</sidebyside>
+			<caption>Slope field for <m>y' = 1 - y^2</m></caption>
+		</figure>
+		
 		<p>
 			<idx><h>constant solution</h></idx>
 			In the slope field, those points appear as <em>rows of perfectly horizontal segments</em>. That's no accident—where <m>dy/dt = 0</m>, the solution curve doesn't move. If a solution starts there, it stays there forever. These flat lines are the <xref ref="gi-equilibrium-solution" text="custom">equilibrium solutions</xref>.
@@ -118,9 +117,9 @@
 
 		<p>
 			To find them, we set <m>\frac{dy}{dt}</m> (the slope) to zero and solve for <m>y</m>. In this example:
-			<me>
+			<md>
 				\us{\large =\ 0}{\boxed{\frac{dy}{dt}}} = 1 - y^2 \quad\rightarrow\quad 0 = 1 - y^2 \quad\Rightarrow\quad y = -1 \text{ or } y = 1.
-			</me>
+			</md>
 			So the equilibrium solutions are the constant functions <m>y(t) = -1</m> and <m>y(t) = 1</m>.
 		</p>
 
@@ -221,17 +220,17 @@
 
 		<p>
 			What about the <em>other</em> values of <m>y</m>? Between the equilibria at <m>y = -1</m> and <m>y = 1</m>, the slopes are positive. For example:
-			<me>
+			<md>
 				f(-0.5) = 1 - (-0.5)^2 = 0.75,
-			</me>
+			</md>
 			so the slope is positive and solutions rise. The slope field shows this: between <m>y=-1</m> and <m>y=1</m>, the little segments tilt upward.
 		</p>
 
 		<p>
 			Above <m>y = 1</m>, things flip. Try <m>y = 1.5</m>:
-			<me>
+			<md>
 				f(1.5) = 1 - (1.5)^2 = -1.25,
-			</me>
+			</md>
 			which is negative, so solutions decrease. The slope field confirms it—segments tilt downward. The same downward pull appears below <m>y = -1</m>.
 		</p>
 
@@ -247,24 +246,24 @@
 		</p>
 
 		<ol>
-			<li>Assuming <m>c</m> is constant and <m>y=c</m>, then <m>\frac{dy}{dt} = 0</m> and so: <me>\frac{dy}{dt} = f(y) \quad\rightarrow\quad 0 = f(c)</me>.</li>
+			<li>Assuming <m>c</m> is constant and <m>y=c</m>, then <m>\frac{dy}{dt} = 0</m> and so: <md>\frac{dy}{dt} = f(y) \quad\rightarrow\quad 0 = f(c)</md>.</li>
 			<li>The equation <m>f(c) = 0</m> is algebraic. Solve it for <m>c</m>. </li>
 			<li>For each <m>c</m> you found, <m>y(t) = c</m> is an equilibrium solution.</li>
 		</ol>
 
 		<p>
 			Let's do a quick example. Consider:
-			<me>
+			<md>
 				\frac{dy}{dt} = y^2 - 4y.
-			</me>
+			</md>
 			Assuming <m>y=c</m>, then this equation becomes:
-			<me>
+			<md>
 				0 = c^2 - 4c \quad\Rightarrow\quad c(c - 4) = 0.
-			</me>
+			</md>
 			So, <m>c=0, 4</m> and the equilibrium solutions are:
-			<me>
+			<md>
 				y(t) = 0 \quad \text{and} \quad y(t) = 4.
-			</me>
+			</md>
 		</p>
 
 		<p>
@@ -276,9 +275,9 @@
 			<statement>
 				<p>
 					Determine the equilibrium solutions for the equation:
-					<me>
+					<md>
 						\frac{dy}{dt} = y + \frac12y^2
-					</me>.
+					</md>.
 					Select all that apply.
 				</p>
 			</statement>

--- a/source/c9-uc/review-constant-coefficient.ptx
+++ b/source/c9-uc/review-constant-coefficient.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section xml:id="cc-mixed-review" label="cc-mixed-review">
+<section xml:id="cc-mixed-review">
 	<title>Mixed Review: Choosing Your Method</title>
 
 	<introduction>

--- a/source/c9-uc/review-constant-coefficient.ptx
+++ b/source/c9-uc/review-constant-coefficient.ptx
@@ -1,0 +1,459 @@
+<!-- LICENSING
+  This file is part of the textbook "Exploring Differential Equations, An Interactive, Student-Centered Approach" by Geoffrey Cox.
+  License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+  You are free to:
+    • Share — copy and redistribute the material in any medium or format.
+    • Adapt — remix, transform, and build upon the material for any purpose, even commercially.
+  Under the following terms:
+    • Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.
+    • ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license.
+  Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
+  Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
+-->
+<section xml:id="cc-mixed-review" label="cc-mixed-review">
+	<title>Mixed Review: Choosing Your Method</title>
+
+	<introduction>
+		<p>
+			The last two chapters more than doubled your toolkit. On top of the first-order methods—direct integration, separation of variables, and the integrating factor—you can now solve any <xref ref="def-lhcc-eqn" text="custom">LHCC equation</xref> with the characteristic equation, and any LNCC equation whose forcing function fits the <xref ref="uc-method-exploration" text="custom">Method of Undetermined Coefficients</xref>. With more tools comes a new burden: an exam problem won't tell you which one to pull out. This review practices making that call.
+		</p>
+
+		<p>
+			The decision comes down to three questions: <em>What is the order? Is the equation linear with constant coefficients? What does the forcing function look like?</em> The table below extends the <q>which method?</q> flowchart from the <xref ref="fo-mixed-review" text="custom">first-order mixed review</xref> to cover everything you know so far.
+		</p>
+
+		<tabular halign="left" top="minor" bottom="minor" left="minor" right="minor">
+			<col width="42%" />
+			<col width="58%" />
+			<row header="yes" bottom="medium">
+				<cell>If the equation is …</cell>
+				<cell>then …</cell>
+			</row>
+			<row>
+				<cell><p><em>first order</em></p></cell>
+				<cell><p>walk the <xref ref="fo-mixed-review" text="custom">first-order flowchart</xref>: direct integration <m>\rightarrow</m> separation of variables <m>\rightarrow</m> integrating factor.</p></cell>
+			</row>
+			<row>
+				<cell><p>linear, constant coefficients, forcing <m>= 0</m> (<em>LHCC</em>, any order)</p></cell>
+				<cell><p>solve the <xref ref="characteristic-equation" text="custom">characteristic equation</xref> and build the general solution from its roots.</p></cell>
+			</row>
+			<row>
+				<cell><p>linear, constant coefficients, forcing <m>f(x)</m> built from polynomials, exponentials, sines, and cosines (<em>LNCC</em>)</p></cell>
+				<cell><p>build <m>y = y_h + y_p</m>: characteristic equation for <m>y_h</m>, then <xref ref="uc-method-exploration" text="custom">undetermined coefficients</xref> for <m>y_p</m>.</p></cell>
+			</row>
+			<row>
+				<cell><p>anything else: variable coefficients, a nonlinear term, or a forcing function outside that family</p></cell>
+				<cell><p>none of our formula methods apply yet—reach for qualitative or numerical tools, and watch for the Laplace transform in <xref ref="chpt-laplace-transforms" text="custom">upcoming chapters</xref>.</p></cell>
+			</row>
+		</tabular>
+
+		<p>
+			One habit worth keeping: a first-order linear equation with constant coefficients, like <m>y' + 3y = 6</m>, belongs to <em>both</em> toolkits. The integrating factor method and <m>y_h + y_p</m> reasoning give the same answer—being able to see it both ways is a good sign you understand each method.
+		</p>
+	</introduction>
+
+	<exercises label="cc-review-quiz">
+		<title><e component="emoji">💡</e> Which Method? Quiz</title>
+
+		<introduction>
+			<p>
+				For each differential equation, choose the best plan of attack. <em>Do not solve any of the equations</em>—practice making the call the way you would on an exam.
+			</p>
+		</introduction>
+
+		<exercise label="cc-review-wm">
+
+			<task label="cc-review-wm-01">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>y'' - 5y' + 6y = 0</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Characteristic equation—this is an LHCC equation.</statement>
+						<feedback>Correct! Linear, constant coefficients, zero forcing. The characteristic equation <m>r^2 - 5r + 6 = 0</m> hands you the general solution.</feedback>
+					</choice>
+					<choice>
+						<statement>Undetermined coefficients, to find <m>y_p</m>.</statement>
+						<feedback>The forcing function is <m>0</m>, so there is no <m>y_p</m> to find—the homogeneous solution is the whole story.</feedback>
+					</choice>
+					<choice>
+						<statement>Integrating factor.</statement>
+						<feedback>The integrating factor method is a first-order tool; this equation is second order.</feedback>
+					</choice>
+					<choice>
+						<statement>Separation of variables.</statement>
+						<feedback>Separation of variables is a first-order tool; this equation is second order.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="cc-review-wm-02">
+				<title>Pick the Method</title>
+				<statement>
+					<p>
+						<me>y'' - 5y' + 6y = e^{x}</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Characteristic equation for <m>y_h</m>, then undetermined coefficients with guess <m>y_p = Ae^{x}</m>.</statement>
+						<feedback>Correct! This is an LNCC equation whose forcing function <m>e^x</m> is in the undetermined-coefficients family, and <m>e^x</m> does not overlap <m>y_h = c_1 e^{2x} + c_2 e^{3x}</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Characteristic equation alone—the general solution comes entirely from its roots.</statement>
+						<feedback>The roots only produce <m>y_h</m>. With a nonzero forcing function you also need a particular solution: <m>y = y_h + y_p</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Integrating factor with <m>\mu = e^{\int -5\, dx}</m>.</statement>
+						<feedback>The integrating factor method is a first-order tool; this equation is second order.</feedback>
+					</choice>
+					<choice>
+						<statement>None of our methods apply.</statement>
+						<feedback>Check the table: linear, constant coefficients, and <m>e^x</m> is squarely in the undetermined-coefficients family.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="cc-review-wm-03">
+				<title>Two Toolkits, One Equation</title>
+				<statement>
+					<p>
+						Which statement is true about the equation below?
+						<me>y' + 3y = 6</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Both the integrating factor method and <m>y_h + y_p</m> reasoning (undetermined coefficients) apply.</statement>
+						<feedback>Correct! It's first-order linear, so <m>\mu = e^{3x}</m> works—and it's also an LNCC equation with constant forcing, so <m>y_h = Ce^{-3x}</m> plus the constant guess <m>y_p = A</m> works too. Both give <m>y = 2 + Ce^{-3x}</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>Only the integrating factor method applies, because the equation is first order.</statement>
+						<feedback>First order doesn't disqualify the new machinery: this is a linear constant-coefficient equation with constant forcing, so <m>y_h + y_p</m> reasoning applies just as well.</feedback>
+					</choice>
+					<choice>
+						<statement>Only undetermined coefficients applies, because the forcing function is a constant.</statement>
+						<feedback>Undetermined coefficients works here, but so does the integrating factor method—the equation is first-order linear.</feedback>
+					</choice>
+					<choice>
+						<statement>Neither method applies.</statement>
+						<feedback>Quite the opposite—this equation belongs to both toolkits. Check the linearity and coefficient tests again.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="cc-review-wm-04">
+				<title>Know the Limits of the Guess</title>
+				<statement>
+					<p>
+						<me>y'' + 4y = \tan x</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>The characteristic equation gives <m>y_h</m>, but none of our methods produce <m>y_p</m>.</statement>
+						<feedback>Correct! The forcing function <m>\tan x</m> is not built from polynomials, exponentials, sines, and cosines, so undetermined coefficients has no form to guess. Equations like this need a method beyond our current toolkit (its name, for the curious: <em>variation of parameters</em>).</feedback>
+					</choice>
+					<choice>
+						<statement>Undetermined coefficients with guess <m>y_p = A\tan x + B\sec x</m>.</statement>
+						<feedback>Tempting, but derivatives of <m>\tan x</m> generate an endless stream of new function types—the guess never closes. Undetermined coefficients only works for forcing functions whose derivative families are finite: polynomials, exponentials, sines, and cosines.</feedback>
+					</choice>
+					<choice>
+						<statement>Separation of variables.</statement>
+						<feedback>Separation of variables is a first-order tool; this equation is second order.</feedback>
+					</choice>
+					<choice>
+						<statement>No method applies, not even for <m>y_h</m>.</statement>
+						<feedback>The homogeneous side is a perfectly good LHCC equation—<m>y_h = c_1\cos 2x + c_2 \sin 2x</m>. It's only the particular solution that's out of reach.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="cc-review-wm-05">
+				<title>Check the Fine Print</title>
+				<statement>
+					<p>
+						<me>y'' + y^2 = 0</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>None of our methods apply—the equation is nonlinear.</statement>
+						<feedback>Correct! The <m>y^2</m> term makes this nonlinear, and the characteristic equation shortcut is built on linearity. Substituting <m>y = e^{rx}</m> here would give <m>r^2 e^{rx} + e^{2rx} = 0</m>, which no constant <m>r</m> can satisfy.</feedback>
+					</choice>
+					<choice>
+						<statement>Characteristic equation: <m>r^2 + r^2 = 0</m>.</statement>
+						<feedback>Careful—<m>y^2</m> is the <em>square of the function</em>, not a second derivative. The equation is nonlinear, and the characteristic equation only applies to linear constant-coefficient equations.</feedback>
+					</choice>
+					<choice>
+						<statement>Undetermined coefficients.</statement>
+						<feedback>Undetermined coefficients builds particular solutions for <em>linear</em> equations with forcing; here the equation is nonlinear with no forcing at all.</feedback>
+					</choice>
+					<choice>
+						<statement>Direct integration, twice.</statement>
+						<feedback>Integrating twice would need the right side free of <m>y</m>; the <m>y^2</m> term blocks that.</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="cc-review-wm-06">
+				<title>Check the Fine Print</title>
+				<statement>
+					<p>
+						<me>x\, y'' + y' = 0</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>The characteristic-equation method does not apply—the coefficients are not constant.</statement>
+						<feedback>Correct! The leading coefficient is <m>x</m>, not a constant, so the exponential-guess machinery breaks down. (If you're curious: the substitution <m>v = y'</m> turns this into the separable first-order equation <m>x v' + v = 0</m>, leading to <m>y = C\ln x + D</m> for <m>x \gt 0</m>.)</feedback>
+					</choice>
+					<choice>
+						<statement>Characteristic equation: <m>xr^2 + r = 0</m>.</statement>
+						<feedback>A characteristic equation must have constant coefficients—an <m>x</m> inside means the method was never valid to begin with.</feedback>
+					</choice>
+					<choice>
+						<statement>Undetermined coefficients.</statement>
+						<feedback>Undetermined coefficients assumes constant coefficients and a nonzero forcing function; this equation has neither.</feedback>
+					</choice>
+					<choice>
+						<statement>Integrating factor, directly on <m>y''</m>.</statement>
+						<feedback>The integrating factor method as we know it handles <em>first-order</em> linear equations. (There is a first-order equation hiding here, though—what happens if you rename <m>y'</m> as a new unknown?)</feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="cc-review-wm-07">
+				<title>Any Order Welcome</title>
+				<statement>
+					<p>
+						<me>y''' - y' = 0</me>
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement>Characteristic equation—it works for LHCC equations of any order.</statement>
+						<feedback>Correct! <m>r^3 - r = r(r-1)(r+1) = 0</m> gives roots <m>0, 1, -1</m>, so <m>y = c_1 + c_2 e^{x} + c_3 e^{-x}</m>.</feedback>
+					</choice>
+					<choice>
+						<statement>No method applies—the characteristic equation only handles second-order equations.</statement>
+						<feedback>The characteristic equation scales to any order: an order-<m>n</m> LHCC equation gives a degree-<m>n</m> polynomial with <m>n</m> roots and <m>n</m> terms in the general solution.</feedback>
+					</choice>
+					<choice>
+						<statement>Direct integration, three times.</statement>
+						<feedback>After one integration you'd have <m>y'' - y = c</m>, which still involves <m>y</m>—direct integration can't finish the job.</feedback>
+					</choice>
+					<choice>
+						<statement>Undetermined coefficients.</statement>
+						<feedback>The forcing function is <m>0</m>, so there is no particular solution to build—the characteristic equation alone gives the general solution.</feedback>
+					</choice>
+				</choices>
+			</task>
+		</exercise>
+	</exercises>
+
+	<exercises label="cc-review-problems">
+		<title><e component="emoji">✍🏻</e> Mixed Problem Set</title>
+
+		<exercisegroup cols="2" label="cc-review-mixed">
+			<title>Choose, Then Solve</title>
+
+			<introduction>
+				<p>
+					Find the general solution of each equation (or the particular solution where initial conditions are given). No method is announced—begin each solution by naming the method you chose and the feature of the equation that told you it applies.
+				</p>
+			</introduction>
+
+			<exercise label="cc-review-mixed-1">
+				<statement>
+					<p>
+						<m>y'' - y' - 6y = 0</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> linear, constant coefficients, zero forcing—an LHCC equation, so we solve the characteristic equation.
+					</p>
+					<p>
+						<me>r^2 - r - 6 = (r - 3)(r + 2) = 0 \quad\implies\quad r = 3,\ -2</me>
+					</p>
+					<p>
+						Two distinct real roots contribute two exponentials:
+						<me>y = c_1 e^{3x} + c_2 e^{-2x}</me>.
+					</p>
+				</solution>
+				<answer>
+					<p>Characteristic equation; <m>y = c_1 e^{3x} + c_2 e^{-2x}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="cc-review-mixed-2">
+				<statement>
+					<p>
+						<m>y'' + 4y' + 13y = 0</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> LHCC equation, so we solve the characteristic equation.
+					</p>
+					<p>
+						<me>r^2 + 4r + 13 = 0 \quad\implies\quad r = \frac{-4 \pm \sqrt{16 - 52}}{2} = \frac{-4 \pm \sqrt{-36}}{2} = -2 \pm 3i</me>
+					</p>
+					<p>
+						Complex roots <m>\alpha \pm \beta i = -2 \pm 3i</m> contribute an exponential envelope times sines and cosines:
+						<me>y = e^{-2x}\left(c_1 \cos 3x + c_2 \sin 3x\right)</me>.
+					</p>
+				</solution>
+				<answer>
+					<p>Characteristic equation (complex roots); <m>y = e^{-2x}\left(c_1 \cos 3x + c_2 \sin 3x\right)</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="cc-review-mixed-3">
+				<statement>
+					<p>
+						<m>y'' + 6y' + 9y = 0</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> LHCC equation, so we solve the characteristic equation.
+					</p>
+					<p>
+						<me>r^2 + 6r + 9 = (r + 3)^2 = 0 \quad\implies\quad r = -3 \text{ (repeated)}</me>
+					</p>
+					<p>
+						A repeated root contributes <m>e^{rx}</m> and <m>xe^{rx}</m>:
+						<me>y = \left(c_1 + c_2 x\right) e^{-3x}</me>.
+					</p>
+				</solution>
+				<answer>
+					<p>Characteristic equation (repeated root); <m>y = \left(c_1 + c_2 x\right)e^{-3x}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="cc-review-mixed-4">
+				<statement>
+					<p>
+						<m>y'' - 3y' + 2y = 4x</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> linear with constant coefficients and polynomial forcing—an LNCC equation, so we build <m>y = y_h + y_p</m> using undetermined coefficients.
+					</p>
+					<p>
+						<em>Homogeneous part:</em> <m>r^2 - 3r + 2 = (r-1)(r-2) = 0</m>, so <m>y_h = c_1 e^{x} + c_2 e^{2x}</m>.
+					</p>
+					<p>
+						<em>Particular part:</em> the forcing <m>4x</m> is a first-degree polynomial, so guess <m>y_p = Ax + B</m>. Substituting (<m>y_p'' = 0</m>, <m>y_p' = A</m>):
+						<md>
+							<mrow>0 - 3A + 2(Ax + B) \amp = 4x</mrow>
+							<mrow>2A x + \left(2B - 3A\right) \amp = 4x</mrow>
+						</md>
+						Matching coefficients: <m>2A = 4</m> gives <m>A = 2</m>, and <m>2B - 3A = 0</m> gives <m>B = 3</m>.
+					</p>
+					<p>
+						<me>y = c_1 e^{x} + c_2 e^{2x} + 2x + 3</me>
+					</p>
+				</solution>
+				<answer>
+					<p>Undetermined coefficients; <m>y = c_1 e^{x} + c_2 e^{2x} + 2x + 3</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="cc-review-mixed-5">
+				<statement>
+					<p>
+						<m>y'' - 4y = 8e^{2x}</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> LNCC equation with exponential forcing—undetermined coefficients, but watch for overlap with <m>y_h</m>.
+					</p>
+					<p>
+						<em>Homogeneous part:</em> <m>r^2 - 4 = 0</m> gives <m>r = \pm 2</m>, so <m>y_h = c_1 e^{2x} + c_2 e^{-2x}</m>.
+					</p>
+					<p>
+						<em>Particular part:</em> the natural guess <m>Ae^{2x}</m> collides with the <m>c_1 e^{2x}</m> term of <m>y_h</m>, so multiply by <m>x</m>: guess <m>y_p = Axe^{2x}</m>. Then
+						<md>
+							<mrow>y_p' \amp = Ae^{2x}\left(1 + 2x\right)</mrow>
+							<mrow>y_p'' \amp = Ae^{2x}\left(4 + 4x\right)</mrow>
+						</md>
+						and substituting,
+						<me>y_p'' - 4y_p = Ae^{2x}\left(4 + 4x\right) - 4Axe^{2x} = 4Ae^{2x} = 8e^{2x} \quad\implies\quad A = 2</me>.
+					</p>
+					<p>
+						<me>y = c_1 e^{2x} + c_2 e^{-2x} + 2xe^{2x}</me>
+					</p>
+				</solution>
+				<answer>
+					<p>Undetermined coefficients with an overlap adjustment; <m>y = c_1 e^{2x} + c_2 e^{-2x} + 2xe^{2x}</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="cc-review-mixed-6">
+				<statement>
+					<p>
+						<m>y' - 2y = 4, \quad y(0) = 5</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> don't let two chapters of second-order machinery hide the obvious—this is a <em>first-order linear</em> equation. The integrating factor method applies (and so does <m>y_h + y_p</m> reasoning; we show both).
+					</p>
+					<p>
+						<em>Integrating factor route:</em> <m>\mu = e^{\int -2\, dx} = e^{-2x}</m>, so
+						<md>
+							<mrow>\frac{d}{dx}\left[e^{-2x} y\right] \amp = 4e^{-2x}</mrow>
+							<mrow>e^{-2x} y \amp = -2e^{-2x} + C</mrow>
+							<mrow>y \amp = -2 + Ce^{2x}</mrow>
+						</md>
+					</p>
+					<p>
+						<em>The <m>y_h + y_p</m> view:</em> the characteristic equation <m>r - 2 = 0</m> gives <m>y_h = Ce^{2x}</m>, and the constant guess <m>y_p = A</m> forces <m>-2A = 4</m>, so <m>y_p = -2</m>. Same general solution.
+					</p>
+					<p>
+						Applying <m>y(0) = 5</m>: <m>5 = -2 + C</m>, so <m>C = 7</m> and
+						<me>y = 7e^{2x} - 2</me>.
+					</p>
+				</solution>
+				<answer>
+					<p>Integrating factor (or first-order <m>y_h + y_p</m>); <m>y = 7e^{2x} - 2</m>.</p>
+				</answer>
+			</exercise>
+
+			<exercise label="cc-review-mixed-7">
+				<statement>
+					<p>
+						<m>y'' + y = 5\sin 2x</m>
+					</p>
+				</statement>
+				<solution>
+					<p>
+						<em>Method selection:</em> LNCC equation with sinusoidal forcing—undetermined coefficients. The forcing frequency (<m>2</m>) differs from the natural frequency in <m>y_h</m> (<m>1</m>), so no overlap adjustment is needed.
+					</p>
+					<p>
+						<em>Homogeneous part:</em> <m>r^2 + 1 = 0</m> gives <m>r = \pm i</m>, so <m>y_h = c_1 \cos x + c_2 \sin x</m>.
+					</p>
+					<p>
+						<em>Particular part:</em> guess <m>y_p = A\sin 2x + B\cos 2x</m>. Then <m>y_p'' = -4A\sin 2x - 4B\cos 2x</m>, and
+						<me>y_p'' + y_p = -3A\sin 2x - 3B\cos 2x = 5\sin 2x</me>
+						forces <m>A = -\frac{5}{3}</m> and <m>B = 0</m>.
+					</p>
+					<p>
+						<me>y = c_1 \cos x + c_2 \sin x - \frac{5}{3}\sin 2x</me>
+					</p>
+				</solution>
+				<answer>
+					<p>Undetermined coefficients; <m>y = c_1 \cos x + c_2 \sin x - \dfrac{5}{3}\sin 2x</m>.</p>
+				</answer>
+			</exercise>
+		</exercisegroup>
+	</exercises>
+</section>

--- a/source/c9-uc/review-constant-coefficient.ptx
+++ b/source/c9-uc/review-constant-coefficient.ptx
@@ -100,7 +100,7 @@
 				<choices randomize="yes">
 					<choice correct="yes">
 						<statement>Characteristic equation for <m>y_h</m>, then undetermined coefficients with guess <m>y_p = Ae^{x}</m>.</statement>
-						<feedback>Correct! This is an LNCC equation whose forcing function <m>e^x</m> is in the undetermined-coefficients family, and <m>e^x</m> does not overlap <m>y_h = c_1 e^{2x} + c_2 e^{3x}</m>.</feedback>
+						<feedback>Correct! This is an LNCC equation whose forcing function <m>e^x</m> is in the undetermined-coefficients family, and <m>e^x</m> does not overlap <m>y_h = C_1 e^{2x} + C_2 e^{3x}</m>.</feedback>
 					</choice>
 					<choice>
 						<statement>Characteristic equation alone—the general solution comes entirely from its roots.</statement>
@@ -167,7 +167,7 @@
 					</choice>
 					<choice>
 						<statement>No method applies, not even for <m>y_h</m>.</statement>
-						<feedback>The homogeneous side is a perfectly good LHCC equation—<m>y_h = c_1\cos 2x + c_2 \sin 2x</m>. It's only the particular solution that's out of reach.</feedback>
+						<feedback>The homogeneous side is a perfectly good LHCC equation—<m>y_h = C_1\cos 2x + C_2 \sin 2x</m>. It's only the particular solution that's out of reach.</feedback>
 					</choice>
 				</choices>
 			</task>
@@ -236,7 +236,7 @@
 				<choices randomize="yes">
 					<choice correct="yes">
 						<statement>Characteristic equation—it works for LHCC equations of any order.</statement>
-						<feedback>Correct! <m>r^3 - r = r(r-1)(r+1) = 0</m> gives roots <m>0, 1, -1</m>, so <m>y = c_1 + c_2 e^{x} + c_3 e^{-x}</m>.</feedback>
+						<feedback>Correct! <m>r^3 - r = r(r-1)(r+1) = 0</m> gives roots <m>0, 1, -1</m>, so <m>y = C_1 + C_2 e^{x} + C_3 e^{-x}</m>.</feedback>
 					</choice>
 					<choice>
 						<statement>No method applies—the characteristic equation only handles second-order equations.</statement>
@@ -244,7 +244,7 @@
 					</choice>
 					<choice>
 						<statement>Direct integration, three times.</statement>
-						<feedback>After one integration you'd have <m>y'' - y = c</m>, which still involves <m>y</m>—direct integration can't finish the job.</feedback>
+						<feedback>After one integration you'd have <m>y'' - y = C</m>, which still involves <m>y</m>—direct integration can't finish the job.</feedback>
 					</choice>
 					<choice>
 						<statement>Undetermined coefficients.</statement>
@@ -282,11 +282,11 @@
 					</p>
 					<p>
 						Two distinct real roots contribute two exponentials:
-						<me>y = c_1 e^{3x} + c_2 e^{-2x}</me>.
+						<me>y = C_1 e^{3x} + C_2 e^{-2x}</me>.
 					</p>
 				</solution>
 				<answer>
-					<p>Characteristic equation; <m>y = c_1 e^{3x} + c_2 e^{-2x}</m>.</p>
+					<p>Characteristic equation; <m>y = C_1 e^{3x} + C_2 e^{-2x}</m>.</p>
 				</answer>
 			</exercise>
 
@@ -305,11 +305,11 @@
 					</p>
 					<p>
 						Complex roots <m>\alpha \pm \beta i = -2 \pm 3i</m> contribute an exponential envelope times sines and cosines:
-						<me>y = e^{-2x}\left(c_1 \cos 3x + c_2 \sin 3x\right)</me>.
+						<me>y = e^{-2x}\left(C_1 \cos 3x + C_2 \sin 3x\right)</me>.
 					</p>
 				</solution>
 				<answer>
-					<p>Characteristic equation (complex roots); <m>y = e^{-2x}\left(c_1 \cos 3x + c_2 \sin 3x\right)</m>.</p>
+					<p>Characteristic equation (complex roots); <m>y = e^{-2x}\left(C_1 \cos 3x + C_2 \sin 3x\right)</m>.</p>
 				</answer>
 			</exercise>
 
@@ -328,11 +328,11 @@
 					</p>
 					<p>
 						A repeated root contributes <m>e^{rx}</m> and <m>xe^{rx}</m>:
-						<me>y = \left(c_1 + c_2 x\right) e^{-3x}</me>.
+						<me>y = \left(C_1 + C_2 x\right) e^{-3x}</me>.
 					</p>
 				</solution>
 				<answer>
-					<p>Characteristic equation (repeated root); <m>y = \left(c_1 + c_2 x\right)e^{-3x}</m>.</p>
+					<p>Characteristic equation (repeated root); <m>y = \left(C_1 + C_2 x\right)e^{-3x}</m>.</p>
 				</answer>
 			</exercise>
 
@@ -347,7 +347,7 @@
 						<em>Method selection:</em> linear with constant coefficients and polynomial forcing—an LNCC equation, so we build <m>y = y_h + y_p</m> using undetermined coefficients.
 					</p>
 					<p>
-						<em>Homogeneous part:</em> <m>r^2 - 3r + 2 = (r-1)(r-2) = 0</m>, so <m>y_h = c_1 e^{x} + c_2 e^{2x}</m>.
+						<em>Homogeneous part:</em> <m>r^2 - 3r + 2 = (r-1)(r-2) = 0</m>, so <m>y_h = C_1 e^{x} + C_2 e^{2x}</m>.
 					</p>
 					<p>
 						<em>Particular part:</em> the forcing <m>4x</m> is a first-degree polynomial, so guess <m>y_p = Ax + B</m>. Substituting (<m>y_p'' = 0</m>, <m>y_p' = A</m>):
@@ -358,11 +358,11 @@
 						Matching coefficients: <m>2A = 4</m> gives <m>A = 2</m>, and <m>2B - 3A = 0</m> gives <m>B = 3</m>.
 					</p>
 					<p>
-						<me>y = c_1 e^{x} + c_2 e^{2x} + 2x + 3</me>
+						<me>y = C_1 e^{x} + C_2 e^{2x} + 2x + 3</me>
 					</p>
 				</solution>
 				<answer>
-					<p>Undetermined coefficients; <m>y = c_1 e^{x} + c_2 e^{2x} + 2x + 3</m>.</p>
+					<p>Undetermined coefficients; <m>y = C_1 e^{x} + C_2 e^{2x} + 2x + 3</m>.</p>
 				</answer>
 			</exercise>
 
@@ -377,10 +377,10 @@
 						<em>Method selection:</em> LNCC equation with exponential forcing—undetermined coefficients, but watch for overlap with <m>y_h</m>.
 					</p>
 					<p>
-						<em>Homogeneous part:</em> <m>r^2 - 4 = 0</m> gives <m>r = \pm 2</m>, so <m>y_h = c_1 e^{2x} + c_2 e^{-2x}</m>.
+						<em>Homogeneous part:</em> <m>r^2 - 4 = 0</m> gives <m>r = \pm 2</m>, so <m>y_h = C_1 e^{2x} + C_2 e^{-2x}</m>.
 					</p>
 					<p>
-						<em>Particular part:</em> the natural guess <m>Ae^{2x}</m> collides with the <m>c_1 e^{2x}</m> term of <m>y_h</m>, so multiply by <m>x</m>: guess <m>y_p = Axe^{2x}</m>. Then
+						<em>Particular part:</em> the natural guess <m>Ae^{2x}</m> collides with the <m>C_1 e^{2x}</m> term of <m>y_h</m>, so multiply by <m>x</m>: guess <m>y_p = Axe^{2x}</m>. Then
 						<md>
 							<mrow>y_p' \amp = Ae^{2x}\left(1 + 2x\right)</mrow>
 							<mrow>y_p'' \amp = Ae^{2x}\left(4 + 4x\right)</mrow>
@@ -389,11 +389,11 @@
 						<me>y_p'' - 4y_p = Ae^{2x}\left(4 + 4x\right) - 4Axe^{2x} = 4Ae^{2x} = 8e^{2x} \quad\implies\quad A = 2</me>.
 					</p>
 					<p>
-						<me>y = c_1 e^{2x} + c_2 e^{-2x} + 2xe^{2x}</me>
+						<me>y = C_1 e^{2x} + C_2 e^{-2x} + 2xe^{2x}</me>
 					</p>
 				</solution>
 				<answer>
-					<p>Undetermined coefficients with an overlap adjustment; <m>y = c_1 e^{2x} + c_2 e^{-2x} + 2xe^{2x}</m>.</p>
+					<p>Undetermined coefficients with an overlap adjustment; <m>y = C_1 e^{2x} + C_2 e^{-2x} + 2xe^{2x}</m>.</p>
 				</answer>
 			</exercise>
 
@@ -439,7 +439,7 @@
 						<em>Method selection:</em> LNCC equation with sinusoidal forcing—undetermined coefficients. The forcing frequency (<m>2</m>) differs from the natural frequency in <m>y_h</m> (<m>1</m>), so no overlap adjustment is needed.
 					</p>
 					<p>
-						<em>Homogeneous part:</em> <m>r^2 + 1 = 0</m> gives <m>r = \pm i</m>, so <m>y_h = c_1 \cos x + c_2 \sin x</m>.
+						<em>Homogeneous part:</em> <m>r^2 + 1 = 0</m> gives <m>r = \pm i</m>, so <m>y_h = C_1 \cos x + C_2 \sin x</m>.
 					</p>
 					<p>
 						<em>Particular part:</em> guess <m>y_p = A\sin 2x + B\cos 2x</m>. Then <m>y_p'' = -4A\sin 2x - 4B\cos 2x</m>, and
@@ -447,11 +447,11 @@
 						forces <m>A = -\frac{5}{3}</m> and <m>B = 0</m>.
 					</p>
 					<p>
-						<me>y = c_1 \cos x + c_2 \sin x - \frac{5}{3}\sin 2x</me>
+						<me>y = C_1 \cos x + C_2 \sin x - \frac{5}{3}\sin 2x</me>
 					</p>
 				</solution>
 				<answer>
-					<p>Undetermined coefficients; <m>y = c_1 \cos x + c_2 \sin x - \dfrac{5}{3}\sin 2x</m>.</p>
+					<p>Undetermined coefficients; <m>y = C_1 \cos x + C_2 \sin x - \dfrac{5}{3}\sin 2x</m>.</p>
 				</answer>
 			</exercise>
 		</exercisegroup>

--- a/source/main-dev.ptx
+++ b/source/main-dev.ptx
@@ -38,13 +38,14 @@
 				</p>
 			</introduction>
 
-			<!-- <xi:include href="c0-whats-a-de/sec-connection-to-alg-calc.ptx" /> -->
-			<!-- <xi:include href="c0-whats-a-de/sec-de-defn.ptx" /> -->
-			<!-- <xi:include href="c0-whats-a-de/sec-variables.ptx" /> -->
+			<xi:include href="c0-whats-a-de/sec-connection-to-alg-calc.ptx" />
+			<xi:include href="c0-whats-a-de/sec-de-defn.ptx" />
+			<xi:include href="c0-whats-a-de/sec-variables.ptx" />
 			<xi:include href="c0-whats-a-de/sec-terms-coeffs.ptx" />
+			<!-- <xi:include href="c0-whats-a-de/wad-model.ptx" /> -->
 			<!-- <xi:include href="c0-whats-a-de/exercises-wad.ptx" /> -->
 
-			<outcomes label="what-is-a-de-takeaways">
+			<!-- <outcomes label="what-is-a-de-takeaways">
 				<ul marker="square">
 					<li><p>A differential equation involves <ul><li>an unknown function and at least one of its derivatives, and</li><li>an equal sign (to be considered an equation).</li></ul></p></li>
 					<li>Every differential equation involves two variables: a <term>dependent variable</term> (the unknown function we're solving for) and an <term>independent variable</term> (the variable it depends on).</li>
@@ -52,13 +53,13 @@
 					<li>A <term>free term</term> is any term that doesn't involve the dependent variable or its derivatives, even a hidden <m>0</m> on one side of the equation counts.</li>
 					<li>A <term>coefficient</term> is a constant or function of the independent variable that multiplies the dependent variable or its derivatives.</li>
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
 		</chapter>
 		
-		<!-- <chapter label="chpt-classification">
+		<chapter label="chpt-classification">
 			<title>Classification</title>
-		
+
 			<introduction>
 				<aside component="web">
 					<title><e component="emoji">🎧</e> Listen</title>
@@ -77,6 +78,7 @@
 			<xi:include href="c1-classification/sec-order.ptx" />
 			<xi:include href="c1-classification/sec-linear-terms.ptx" />
 			<xi:include href="c1-classification/sec-linearity.ptx" />
+			<!-- <xi:include href="c1-classification/class-model.ptx" /> -->
 			<xi:include href="c1-classification/exercises-class.ptx" />
 
 			<outcomes label="classification-takeaways">
@@ -90,11 +92,11 @@
 				</ul>
 			</outcomes>
 
-		</chapter> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-solns">
+		<chapter label="chpt-solns">
 			<title>Solutions</title>
-		
+
 			<introduction>
 				<aside component="web">
 					<title><e component="emoji">🎧</e> Listen</title>
@@ -126,6 +128,7 @@
 			<xi:include href="c2-solns/sec-general-particular-solns.ptx" />
 			<xi:include href="c2-solns/sec-initial-valued-problems.ptx" />
 			<xi:include href="c2-solns/sec-visualizing-solns.ptx" />
+			<!-- <xi:include href="c2-solns/solns-model.ptx" /> -->
 			<xi:include href="c2-solns/exercises-solns.ptx" />
 
 			<outcomes label="solns-takeaways">
@@ -142,11 +145,11 @@
 				</ul>
 			</outcomes>
 
-		</chapter> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-direct-integration">
+		<chapter label="chpt-direct-integration">
 			<title>Direct Integration</title>
-			
+
 			<introduction>
 				<aside component="web">
 					<title><e component="emoji">🎧</e> Listen</title>
@@ -164,26 +167,45 @@
 
 			<xi:include href="c3-di/sec-antiderivatives.ptx" />
 			<xi:include href="c3-di/sec-di-method.ptx" />
+			<!-- <xi:include href="c3-di/di-model.ptx" /> -->
 			<xi:include href="c3-di/exercises-di.ptx" />
 
 			<outcomes label="di-takeaways">
 				<ul marker="square">
-					<li><p>The general solution to the differential equation <me>\frac{dy}{dx} = f(x)</me> is given by
-							<me>y(x) = F(x) + c</me> where <m>F(x)</m> is any antiderivative of <m>f(x)</m> and <m>c</m> is any constant.</p>
+					<li>
+						<p>
+							The general solution to the differential equation
+							<md>
+								\frac{dy}{dx} = f(x)
+							</md>
+							is given by
+							<md>
+								y(x) = F(x) + c
+							</md>
+							where <m>F(x)</m> is any antiderivative of <m>f(x)</m> and <m>c</m> is any constant.
+						</p>
 					</li>
-					<li><p>If the differential equation can be expressed as <me>\frac{d}{dx}[\ ... ] = f(x)</me> then the general solution can be found by <em>direct integration</em>.
-							For example, integrating both sides of the equations
-							<me> \frac{dy}{dx} = \cos x \quad\text{or}\quad \frac{d}{dx}\left[x^2\cos(y)\right] = x + e^x </me>.
-							removes the derivative, allowing you to isolate the unknown, <m>y</m>.</p>
+					<li>
+						<p>
+							If the differential equation can be expressed as
+							<md>
+								\frac{d}{dx}[\ ... ] = f(x)
+							</md>
+							then the general solution can be found by <em>direct integration</em>. For example, integrating both sides of the equations
+							<md>
+								\frac{dy}{dx} = \cos x \quad\text{or}\quad \frac{d}{dx}\left[x^2\cos(y)\right] = x + e^x
+							</md>.
+							removes the derivative, allowing you to isolate the unknown, <m>y</m>.
+						</p>
 					</li>
 				</ul>
 			</outcomes>
 
-		</chapter> -->
+		</chapter>
 		
-		<!-- <chapter label="chpt-separable-variables">
+		<chapter label="chpt-separable-variables">
 			<title>Separation of Variables</title>
-			
+
 			<introduction>
 				<aside component="web">
 					<title><e component="emoji">🎧</e> Listen</title>
@@ -214,12 +236,13 @@
 			<xi:include href="c4-sov/sec-showing-separability.ptx" />
 			<xi:include href="c4-sov/sec-sov-method.ptx" />
 			<xi:include href="c4-sov/sec-sov-implicit-solns.ptx" />
+			<!-- <xi:include href="c4-sov/sov-model.ptx" /> -->
 			<xi:include href="c4-sov/exercises-sov.ptx" />
 
 			<outcomes label="separable-variables-takeaways">
 				<ul marker="square">
 					<li>A first-order differential equation is <em>Separable</em> when the right-hand side is a product of an <m>x</m>-only part and a <m>y</m>-only part:
-							<me>\dfrac{dy}{dx}=f(x)\cdot g(y)</me>.
+							<md>\dfrac{dy}{dx}=f(x)\cdot g(y)</md>.
 					</li>
 					<li>The separation of variables (SOV) method applies only to <m>\textit{first-order, separable}</m> differential equations.</li>
 					<li>
@@ -244,10 +267,9 @@
 					</li>
 				</ul>
 			</outcomes>
+		</chapter>
 
-		</chapter> -->
-
-		<!-- <chapter label="chpt-integrating-factor">
+		<chapter label="chpt-integrating-factor">
 			<title>Integrating Factor</title>
 
 			<introduction>
@@ -262,11 +284,11 @@
 
 				<p>
 					Here's the intuition: Every equation of the form
-					<me>\frac{dy}{dx} + P(x)y = Q(x)</me>
+					<md>\frac{dy}{dx} + P(x)y = Q(x)</md>
 					can be multiplied by a special factor to give you
-					<me>\boxed{\phantom{M}}\cdot \frac{dy}{dx} + \ \boxed{\phantom{M}}\cdot P(x)y = \ \boxed{\phantom{M}}\cdot Q(x)</me>
+					<md>\boxed{\phantom{M}}\cdot \frac{dy}{dx} + \ \boxed{\phantom{M}}\cdot P(x)y = \ \boxed{\phantom{M}}\cdot Q(x)</md>
 					and the whole left side becomes a single derivative:
-					<me>\frac{d}{dx}\big[\ \boxed{\phantom{M}}\cdot y\big] =\ \boxed{\phantom{M}}\cdot Q(x).</me>
+					<md>\frac{d}{dx}\big[\ \boxed{\phantom{M}}\cdot y\big] =\ \boxed{\phantom{M}}\cdot Q(x).</md>
 					From here, the equation is solved with <xref ref="di-method" text="custom">direct integration</xref>.
 				</p>
 
@@ -279,18 +301,20 @@
 			<xi:include href="c5-if/sec-completing-the-product-rule.ptx" />
 			<xi:include href="c5-if/sec-finding-the-integrating-factor.ptx" />
 			<xi:include href="c5-if/sec-if-method.ptx" />
+			<!-- <xi:include href="c5-if/if-model.ptx" /> -->
 			<xi:include href="c5-if/exercises-if.ptx" />
+			<xi:include href="c5-if/review-first-order-methods.ptx" />
 
 			<outcomes label="integrating-factor-takeaways">
 				<ul marker="square">
-					<li><p>The integrating factor method solves <em>any</em> first-order linear differential equations of the <em>standard form</em> <me>y' + P(x)y = Q(x)</me>.</p></li>
+					<li><p>The integrating factor method solves <em>any</em> first-order linear differential equations of the <em>standard form</em> <md>y' + P(x)y = Q(x)</md>.</p></li>
 					<li>The integrating factor, <m>\mu(x)</m>, is the function we multiply onto the <em>standard form</em> to <q>complete the product rule</q> (on the left).</li>
 					<li>Completing the product rule is conceptually similar to completing the square; both introduce a missing piece that makes the equation easier to solve.</li>
 					<li>Multiplying by the integrating factor allows the left-hand side to be written as a single derivative, which can be easily solved by integration.</li>
 					<li><p>Once in standard form, <m>\ y' + P(x)y = Q(x)\ </m>, the method involves: 
 							<ol marker="(1)">
 								<li>Computing the integrating factor <m>\mu = e^{\int P(x)\, dx}</m>,</li>
-								<li>Multiplying the standard form by <m>\mu</m> to rewrite it as <me>\frac{d}{dx}\left[\mu\cdot y\right] = \mu\cdot Q(x),\quad \text{and}</me></li>
+								<li>Multiplying the standard form by <m>\mu</m> to rewrite it as <md>\frac{d}{dx}\left[\mu\cdot y\right] = \mu\cdot Q(x),\quad \text{and}</md></li>
 								<li>Applying direct integration.</li>
 							</ol>
 							</p>
@@ -298,9 +322,9 @@
 				</ul>
 			</outcomes>
 
-		</chapter> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-qualitative">
+		<chapter xml:id="chpt-qualitative" label="chpt-qualitative">
 			<title>Qualitative Methods</title>
 
 			<introduction>
@@ -326,19 +350,20 @@
 				</p>
 			</introduction>
 
-			<xi:include href="c6-qm/sec-slope-fields.ptx" />
-			<xi:include href="c6-qm/sec-autonomous-equations.ptx" />
+			<!-- <xi:include href="c6-qm/sec-slope-fields.ptx" /> -->
+			<!-- <xi:include href="c6-qm/sec-autonomous-equations.ptx" /> -->
 			<xi:include href="c6-qm/sec-equilibrium-solutions.ptx" />
-			<xi:include href="c6-qm/sec-classifying-equilibrium-solutions.ptx" />
-			<xi:include href="c6-qm/sec-parameter-analysis.ptx" />
-			<xi:include href="c6-qm/sec-logistical-models.ptx" />
-			<xi:include href="c6-qm/exercises-qm.ptx" />
+			<!-- <xi:include href="c6-qm/sec-classifying-equilibrium-solutions.ptx" /> -->
+			<!-- <xi:include href="c6-qm/sec-parameter-analysis.ptx" /> -->
+			<!-- <xi:include href="c6-qm/sec-logistical-models.ptx" /> -->
+			<!-- <xi:include href="c6-qm/qm-model.ptx" /> -->
+			<!-- <xi:include href="c6-qm/exercises-qm.ptx" /> -->
 
-			<outcomes label="qualitative-takeaways">
+			<!-- <outcomes label="qualitative-takeaways">
 				<ul marker="square">
-					<li><p>For first-order differential equations of the form <me>\frac{dy}{dt} = f(t,y)</me>, <m>f(t,y)</m> acts as a slope formula for <m>y(t)</m> at any point <m>(t,y)</m>.</p></li>
+					<li><p>For first-order differential equations of the form <md>\frac{dy}{dt} = f(t,y)</md>, <m>f(t,y)</m> acts as a slope formula for <m>y(t)</m> at any point <m>(t,y)</m>.</p></li>
 					<li>Slope fields are visual tools that plot the slopes found by <m>f(t,y)</m> to show the flow that any solution curve must follow.</li>
-					<li><p>First-order <term>autonomous equations</term> have the form <me>\frac{dy}{dt} = f(y)</me> and their solutions have the following properties:
+					<li><p>First-order <term>autonomous equations</term> have the form <md>\frac{dy}{dt} = f(y)</md> and their solutions have the following properties:
 							<ul>
 								<li>Since the slopes of the solutions don't depend on <m>t</m>, the slope field forms horizontal <q>stripes</q> of parallel line segments.</li>
 								<li>Solutions show horizontal shift symmetry: if <m>y(t)</m> is a solution, so is <m>y(t+c)</m> for any constant <m>c</m>.</li>
@@ -359,36 +384,36 @@
 					<li><term>Parameters</term> can change equilibria and their stability.</li>
 					<li><term>Bifurcation diagrams</term> show where those changes occur and summarize the system's response to parameter variation.</li>
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
-		</chapter> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-eulers-method">
+		<chapter xml:id="chpt-eulers-method" label="chpt-eulers-method">
 			<title>Euler's Method</title>
-
-			<introduction>
+<section><title>fuxck</title><p>No</p></section>
+			<!-- <introduction>
 				<p>
 					Not every differential equation gives up its secrets to pencil-and-paper methods. Some are too complicated to solve exactly; others have solutions so messy they're practically useless. That's where <em>numerical methods</em> come in—techniques for building approximate solutions when analytic ones aren't possible.
 				</p>
 
 				<p>
 					To give you an idea of how easily solutions get out of hand, meet the Riccati equation:
-					<men xml:id="riccati-eqn">
+					<md xml:id="riccati-eqn" number="yes">
 						y' = y^2 - x
-					</men>.
+					</md>.
 					It appears relatively tame, but the nonlinear term <m>y^2</m> makes solving it substantially more challenging. An exact solution to <xref ref="riccati-eqn"/> exists, but it ain't pretty, as you can see below.
 				</p>
 
 				<proof component="web"><title>🫣 Solution to the Riccati Equation</title>
 					<p>
 						The solution to <xref ref="riccati-eqn"/> is described by
-						<me component="web">
+						<md component="web">
 							😱\quad y = \frac{ 3 x \left(c_1 J_{-\frac{4}{3}} \left( x \right) - c_1 J_{\frac{2}{3}}\left( x \right) + 2 J_{-\frac{2}{3}}\left( x \right) \right) + 2 c_1 J_{-\frac{1}{3}}\left( x \right) }{ (12 x)^{2/3} \left(c_1 J_{-\frac{1}{3}} \left( x \right) + J_{\frac{1}{3}} \left(x \right) \right)}  
-						</me>
+						</md>
 						where <m>J_n(x)</m> denotes a Bessel function defined as
-						<me>
+						<md>
 							J_n( x ) = \sum_{m=0}^{\infty} \frac{(-1)^m}{m! \ \Gamma(m + n + 1)}\left( \frac{i}{3} x^{\frac{3}{2}} \right)^{2m + n}
-						</me>
+						</md>
 					</p>
 				</proof>
  
@@ -399,31 +424,32 @@
 				<p>
 					Along the way, we'll confront an important truth: many differential equations simply cannot be expressed in neat <q>closed form.</q> But we're not helpless—we can <q>trade</q> the exact solution for an approximate one that's good enough for analysis, prediction, and real-world applications. By the end of this chapter, you'll understand the thinking behind numerical methods and be ready to start building these approximations yourself.
 				</p>
-			</introduction>
+			</introduction> -->
 
-			<xi:include href="c7-em/sec-what-is-a-numerical-solution.ptx" />
-			<xi:include href="c7-em/sec-euler-intro-thinking-in-steps.ptx" />
-			<xi:include href="c7-em/sec-euler-method.ptx" />
-			<xi:include href="c7-em/exercises-em.ptx" />
+			<!-- <xi:include href="c7-em/sec-what-is-a-numerical-solution.ptx" /> -->
+			<!-- <xi:include href="c7-em/sec-euler-intro-thinking-in-steps.ptx" /> -->
+			<!-- <xi:include href="c7-em/sec-euler-method.ptx" /> -->
+			<!-- <xi:include href="c7-em/em-model.ptx" /> -->
+			<!-- <xi:include href="c7-em/exercises-em.ptx" /> -->
 
-			<outcomes label="eulers-method-takeaways">
+			<!-- <outcomes label="eulers-method-takeaways">
 				<ul marker="square">
 					<li>Analytic solutions are exact; numerical solutions are approximate.</li>
 					<li>Numerical solutions are essential when analytic solutions are too complicated or don't exist.</li>
 					<li>Euler's method approximates solutions by following the slope given by the differential equation, taking small steps from one point to the next.</li>
 					<li>Euler's one-step task is <q>move from where you are in the direction of the slope.</q></li>
 					<li>Choosing a step size <m>h</m> sets the <q>run</q> = <m>h</m> and <q>rise</q> = slope <m>\times\ h</m>.</li>
-					<li><p>Euler's method is based on the movement rule <me>(t_{\text{new}}, y_{\text{new}}) = (t_{\text{cur}} + h,\ y_{\text{cur}} + h \times \text{slope})</me>, so each step is given by: <m>y_{k+1} = y_k + h f(t_k, y_k)</m>.</p></li>
+					<li><p>Euler's method is based on the movement rule <md>(t_{\text{new}}, y_{\text{new}}) = (t_{\text{cur}} + h,\ y_{\text{cur}} + h \times \text{slope})</md>, so each step is given by: <m>y_{k+1} = y_k + h f(t_k, y_k)</m>.</p></li>
 					<li>Smaller step sizes usually mean better accuracy — but more steps.</li>
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
-		</chapter> -->
+		</chapter>
 
 		<chapter label="chpt-homogeneous-eqns">
 			<title>Homogeneous Equations (LHCC)</title>
-
-			<introduction>
+<section><title>fuxck</title><p>No</p></section>
+			<!-- <introduction>
 				<p>
 					Stepping beyond first-order problems, we turn to equations involving higher derivatives—especially the important class of linear equations with constant coefficients. This chapter explains why these equations are so useful and how systematic methods yield powerful, general solutions.
 				</p>
@@ -439,16 +465,17 @@
 				<p>
 					By the end, you'll have a clear strategy for solving LHCC equations of any order—a foundation that will carry directly into the next chapter, where we'll look at what happens when these equations are no longer homogeneous.
 				</p>
-			</introduction>
+			</introduction> -->
 
 			<!-- <xi:include href="c8-lhcc/sec-lhcc-eqn.ptx" /> -->
 			<!-- <xi:include href="c8-lhcc/sec-exponential-solns.ptx" /> -->
 			<!-- <xi:include href="c8-lhcc/sec-second-order-lhcc-eqns.ptx" /> -->
-			<xi:include href="c8-lhcc/sec-higher-order-lhcc-eqns.ptx" />
-			<xi:include href="c8-lhcc/sec-solving-higher-order-lhcc-eqns.ptx" />
+			<!-- <xi:include href="c8-lhcc/sec-higher-order-lhcc-eqns.ptx" /> -->
+			<!-- <xi:include href="c8-lhcc/sec-solving-higher-order-lhcc-eqns.ptx" /> -->
+			<!-- <xi:include href="c8-lhcc/lhcc-model.ptx" /> -->
 			<!-- <xi:include href="c8-lhcc/exercises-lhcc.ptx" /> -->
 
-			<outcomes label="homogeneous-eqns-takeaways">
+			<!-- <outcomes label="homogeneous-eqns-takeaways">
 				<ul>
 					<li>An <m>\DLO \text{LHCC}</m> equation is a <m>\DLO \text{L}</m>inear <m>\DLO \text{H}</m>omogeneous <m>\DLO \text{C}</m>onstant <m>\DLO \text{C}</m>oefficient equation.</li>
 					<li>The forcing function is the collection of all terms not multiplied by the dependent variable, typically written on the right-side.</li>
@@ -475,14 +502,14 @@
 					<li>When factoring is hard or impossible by hand, use a factoring tool or numerical solver to find the roots.</li>
 					<li>Once the roots are known, constructing the full general solution is mechanical and follows a predictable structure.</li>
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
 		</chapter>
 
-		<!-- <chapter label="chpt-undetermined-coefficients">
+		<chapter label="chpt-undetermined-coefficients">
 			<title>Nonhomogeneous Equations (LNCC)</title>
-
-			<introduction>
+<section><title>fuxck</title><p>No</p></section>
+			<!-- <introduction>
 				<p>
 					In the last chapter, we studied <em>linear homogeneous constant coefficient</em> (LHCC) equations—problems where the right-hand side was always zero. Their solutions were obtained entirely from exponential functions determined by the characteristic equation.
 				</p>
@@ -498,14 +525,16 @@
 				<p>
 					In this chapter, we'll learn how to recognize that structure and then develop a powerful tool—the <em>Method of Undetermined Coefficients</em>—to systematically build the particular solution. This will open the door to solving a huge range of real-world problems.
 				</p>
-			</introduction>
+			</introduction> -->
 
-			<xi:include href="c9-uc/sec-lncc-eqns.ptx" />
-			<xi:include href="c9-uc/sec-selecting-the-particular-soln.ptx" />
-			<xi:include href="c9-uc/sec-uc-method.ptx" />
-			<xi:include href="c9-uc/exercises-uc.ptx" />
+			<!-- <xi:include href="c9-uc/sec-lncc-eqns.ptx" /> -->
+			<!-- <xi:include href="c9-uc/sec-selecting-the-particular-soln.ptx" /> -->
+			<!-- <xi:include href="c9-uc/sec-uc-method.ptx" /> -->
+			<!-- <xi:include href="c9-uc/uc-model.ptx" /> -->
+			<!-- <xi:include href="c9-uc/exercises-uc.ptx" /> -->
+			<!-- <xi:include href="c9-uc/review-constant-coefficient.ptx" /> -->
 
-			<outcomes label="undetermined-coefficients-takeaways">
+			<!-- <outcomes label="undetermined-coefficients-takeaways">
 				<ul marker="square">
 					<li>A linear differential equation is <em>nonhomogeneous</em> if the right-hand side is not zero—it includes a <term>forcing function</term>, <m>f(x)</m>.</li>
 					<li>You can often guess a particular solution, <m>y_p</m>, that matches the structural forms of the forcing function.</li>
@@ -517,14 +546,14 @@
 					<li>For sums like <m>f(x) = x + e^x</m>, build <m>y_p</m> as the sum of matching forms.</li>
 					<li>For products like <m>f(x) = x^2 e^x</m>, multiply the forms, but look out for redundant constants.</li>
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
-		</chapter> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-laplace-transforms">
+		<chapter xml:id="chpt-laplace-transforms" label="chpt-laplace-transforms">
 			<title>Laplace Transforms</title>
-
-			<introduction>
+<section><title>fuxck</title><p>No</p></section>
+			<!-- <introduction>
 				<p>
 					The Laplace transform opens a new path for solving differential equations: it turns calculus problems into algebra problems, handles initial conditions seamlessly, and works beautifully with inputs that turn on, off, or switch over time. This part builds the method step by step.
 				</p>
@@ -540,21 +569,22 @@
 				<p>
 					This chapter lays the foundation for all Laplace-related material. We'll define the Laplace transform from scratch, explore why it works, and build a library of key transforms and properties. With those tools in hand, we'll be ready to use the Laplace method to solve differential equations in the chapters ahead.
 				</p>
-			</introduction>
+			</introduction> -->
 
-			<xi:include href="c10-lt/sec-lt-derivative-transfer.ptx" />
-			<xi:include href="c10-lt/sec-lt-definition.ptx" />
-			<xi:include href="c10-lt/sec-common-transforms.ptx" />
-			<xi:include href="c10-lt/sec-lt-properties.ptx" />
-			<xi:include href="c10-lt/sec-lt-library.ptx" />
-			<xi:include href="c10-lt/exercises-lt.ptx" />
+			<!-- <xi:include href="c10-lt/sec-lt-derivative-transfer.ptx" /> -->
+			<!-- <xi:include href="c10-lt/sec-lt-definition.ptx" /> -->
+			<!-- <xi:include href="c10-lt/sec-common-transforms.ptx" /> -->
+			<!-- <xi:include href="c10-lt/sec-lt-properties.ptx" /> -->
+			<!-- <xi:include href="c10-lt/sec-lt-library.ptx" /> -->
+			<!-- <xi:include href="c10-lt/lt-model.ptx" /> -->
+			<!-- <xi:include href="c10-lt/exercises-lt.ptx" /> -->
 
-			<outcomes label="laplace-transforms-takeaways">
+			<!-- <outcomes label="laplace-transforms-takeaways">
 				<ul marker="square">
 					<li>Integration by parts lets you shift derivatives from one function to another within an integral.</li>
 					<li>Choosing <m>u(t) = e^{-st}</m> causes derivatives on <m>y(t)</m> to transfer onto the exponential, producing a simple factor of <m>s</m>.</li>
 					<li>Understanding this transfer mechanism explains where the variable <m>s</m> comes from and why it appears in Laplace transform formulas.</li>
-					<li>The Laplace transform converts a function of <m>t</m> into a function of <m>s</m> using <me>\lap{f(t)} = \int_0^\infty e^{-st} f(t)\, dt.</me></li>
+					<li>The Laplace transform converts a function of <m>t</m> into a function of <m>s</m> using <md>\lap{f(t)} = \int_0^\infty e^{-st} f(t)\, dt.</md></li>
 					<li>The result is a function of <m>s</m> and exists only when the integral converges.</li>
 					<li>The definition is used to derive the Laplace transforms of common functions encountered in differential equations.</li>
 					<li>Linearity allows us to separate sums and pull out constants.</li>
@@ -562,14 +592,14 @@
 					<li>A derivative in <m>t</m> becomes multiplication by <m>s</m> in the transform (minus an initial condition).</li>
 					<li>Multiplying by <m>t^n</m> corresponds to differentiating the transform <m>n</m> times with respect to <m>s</m>.</li>
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
-		</chapter> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-laplace-transform-method">
+		<chapter label="chpt-laplace-transform-method">
 			<title>Laplace Transform Method</title>
-
-			<introduction>
+<section><title>fuxck</title><p>No</p></section>
+			<!-- <introduction>
 				<p>
 					Imagine turning a differential equation into an algebra problem instead. That's exactly what the <em>Laplace transform method</em> does. It unfolds in the same three steps:
 				</p>
@@ -599,15 +629,16 @@
 						</row>
 					</tabular>
 				</figure>
-			</introduction>
+			</introduction> -->
 
-			<xi:include href="c11-ltm/sec-into-the-laplace-domain.ptx" />
-			<xi:include href="c11-ltm/sec-solving-the-laplace-domain-eqn.ptx" />
-			<xi:include href="c11-ltm/sec-leaving-the-laplace-domain.ptx" />
-			<xi:include href="c11-ltm/sec-laplace-transform-method.ptx" />
-			<xi:include href="c11-ltm/exercises-ltm.ptx" />
+			<!-- <xi:include href="c11-ltm/sec-into-the-laplace-domain.ptx" /> -->
+			<!-- <xi:include href="c11-ltm/sec-solving-the-laplace-domain-eqn.ptx" /> -->
+			<!-- <xi:include href="c11-ltm/sec-leaving-the-laplace-domain.ptx" /> -->
+			<!-- <xi:include href="c11-ltm/sec-laplace-transform-method.ptx" /> -->
+			<!-- <xi:include href="c11-ltm/ltm-model.ptx" /> -->
+			<!-- <xi:include href="c11-ltm/exercises-ltm.ptx" /> -->
 
-			<outcomes label="laplace-transform-method-takeaways">
+			<!-- <outcomes label="laplace-transform-method-takeaways">
 				<ul marker="square">
 					<li>The three-step Laplace roadmap never changes, and most of the variety comes from the algebra you need in the Laplace domain.
 							<tabular halign="center">
@@ -637,14 +668,14 @@
 					<li>Once <m>Y(s)</m> is ready, apply the inverse by matching its terms to the middle column of the <xref ref="lt-table-common" text="custom">transforms table</xref>.</li>
 					<li>Always look at the denominator when matching forms in the table; they provide the best way to identify the correct form to match.</li>
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
-		</chapter> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-piecewise-forcing-functions">
+		<chapter label="chpt-piecewise-forcing-functions">
 			<title>Piecewise Forcing Functions</title>
-
-			<introduction>
+<section><title>fuxck</title><p>No</p></section>
+			<!-- <introduction>
 				<p>
 					Real-world systems rarely behave with smooth, unbroken motion. Machines switch on, circuits reset, and forces might act for only a moment before stopping. These situations call for <em>piecewise functions</em>—functions defined by different rules over different time intervals.
 				</p>
@@ -656,21 +687,23 @@
 				<p>
 					In this chapter, you'll learn how to express any piecewise function using unit step notation, how to handle different types of switches (turning on, turning off, or staying on for just a window of time), and how to apply special Laplace transform rules for step functions. By the end, you'll be able to solve differential equations with inputs that start, stop, and change just like the systems they model.
 				</p>
-			</introduction>
+			</introduction> -->
 
-			<xi:include href="c12-ltp/sec-unit-step-functions.ptx" />
-			<xi:include href="c12-ltp/sec-unit-step-variants.ptx" />
-			<xi:include href="c12-ltp/sec-piecewise-functions.ptx" />
-			<xi:include href="c12-ltp/sec-piecewise-transform-rules.ptx" />
-			<xi:include href="c12-ltp/sec-transforming-piecewise-functions.ptx" />
-			<xi:include href="c12-ltp/sec-laplace-piecewise-method.ptx" />
-			<xi:include href="c12-ltp/exercises-ltp.ptx" />
+			<!-- <xi:include href="c12-ltp/sec-unit-step-functions.ptx" /> -->
+			<!-- <xi:include href="c12-ltp/sec-unit-step-variants.ptx" /> -->
+			<!-- <xi:include href="c12-ltp/sec-piecewise-functions.ptx" /> -->
+			<!-- <xi:include href="c12-ltp/sec-piecewise-transform-rules.ptx" /> -->
+			<!-- <xi:include href="c12-ltp/sec-transforming-piecewise-functions.ptx" /> -->
+			<!-- <xi:include href="c12-ltp/sec-laplace-piecewise-method.ptx" /> -->
+			<!-- <xi:include href="c12-ltp/ltp-model.ptx" /> -->
+			<!-- <xi:include href="c12-ltp/exercises-ltp.ptx" /> -->
+			<!-- <xi:include href="c12-ltp/review-choosing-a-method.ptx" /> -->
 
-			<outcomes label="piecewise-forcing-functions-takeaways">
+			<!-- <outcomes label="piecewise-forcing-functions-takeaways">
 				<ul marker="square">
 					<li>Step functions are mathematical ON/OFF switches that let you control when a function is active.</li>
 					<li><p>The unit step function <m>u(t)</m> is given by
-							<me>
+							<md>
 								u(t) =
 									\left\{
 									\begin{array}{ll}
@@ -678,13 +711,13 @@
 										0, \amp t \lt 0
 									\end{array}
 									\right.
-							</me>
+							</md>
 							jumps from <m>0</m> to <m>1</m> at <m>t=0</m>. We say it activates at <m>t=0</m>.
 							</p>
 					</li>
 					<li>To active a function at <m>t=0</m>, multiply it by <m>u(t)</m>.</li>
 					<li><p>You can change the activation point by shifting <m>u(t)</m> horizontally:
-							<me>
+							<md>
 								u_c(t) = u(t-c) =
 									\left\{
 									\begin{array}{ll}
@@ -692,15 +725,15 @@
 										1, \amp t \ge c
 									\end{array}
 									\right.
-							</me>
+							</md>
 							</p>
 					</li>
 					<li><p>Multiplying by <m>u_c(t)</m> activates a function at <m>t = c</m>: 
-							<me>f(t)\,u_c(t) = \begin{cases}0,&amp; t \lt c\\ f(t),&amp; t \ge c\end{cases}</me>.
+							<md>f(t)\,u_c(t) = \begin{cases}0,&amp; t \lt c\\ f(t),&amp; t \ge c\end{cases}</md>.
 							</p>
 					</li>
 					<li><p>By default, <m>u_c(t)</m> is an OFF-ON switch, but you can turn it into an ON-OFF switch with:
-							<me>
+							<md>
 								1-u_c(t) =
 									\left\{
 									\begin{array}{ll}
@@ -708,15 +741,15 @@
 										0, \amp t \ge c
 									\end{array}
 									\right.
-							</me>
+							</md>
 							</p>
 					</li>
 					<li><p>So multiplying by <m>1-u_c(t)</m> deactivates an active function at <m>t = c</m>:
-								<me>f(t)\,(1 - u_c(t)) = \begin{cases}f(t),&amp; t \lt c\\ 0,&amp; t \ge c\end{cases}</me>.
+								<md>f(t)\,(1 - u_c(t)) = \begin{cases}f(t),&amp; t \lt c\\ 0,&amp; t \ge c\end{cases}</md>.
 							</p>
 					</li>
 					<li><p>To activate a function only on a window, multiply:
-								<me>f(t)\,(u_c(t) - u_d(t)) = \begin{cases}f(t),&amp; c \le t \lt d\\ 0,&amp; \text{otherwise}\end{cases}</me>.
+								<md>f(t)\,(u_c(t) - u_d(t)) = \begin{cases}f(t),&amp; c \le t \lt d\\ 0,&amp; \text{otherwise}\end{cases}</md>.
 							</p>
 					</li>
 					<li>When a differential equation has a piecewise forcing term, start the Laplace method process by rewriting it using step functions.</li>
@@ -724,14 +757,14 @@
 					<li>After rewriting the forcing function, apply the same three Laplace steps you already know: forward transform, solve for <m>Y(s)</m>, and invert.</li>
 
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
-		</chapter> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-1st-order-linear-systems">
+		<chapter label="chpt-1st-order-linear-systems">
 			<title>First-Order Linear Systems</title>
-
-			<introduction>
+<section><title>fuxck</title><p>No</p></section>
+			<!-- <introduction>
 
 				<p>
 					Many real-world problems involve several quantities changing together. This section introduces systems of differential equations, starting with linear systems and progressing to nonlinear ones, providing tools to understand and analyze how multiple variables interact dynamically.
@@ -748,18 +781,19 @@
 				<p>
 					In this chapter, we'll build the foundations for working with systems. We'll start by looking at simple cases, then move into coupled systems and see how tools like the <em>phase plane</em> help us visualize the relationships between variables. By the end, you'll have the groundwork needed to understand and solve first-order linear systems.
 				</p>
-			</introduction>
+			</introduction> -->
 
-			<xi:include href="c13-linsys/sec-introduction-to-systems.ptx" />
-			<xi:include href="c13-linsys/sec-variable-interactions.ptx" />
-			<xi:include href="c13-linsys/sec-linear-systems.ptx" />
-			<xi:include href="c13-linsys/sec-solving-linear-systems.ptx" />
-			<xi:include href="c13-linsys/sec-second-order-to-system.ptx" />
-			<xi:include href="c13-linsys/sec-eulers-method-systems.ptx" />
-			<xi:include href="c13-linsys/sec-qualitative-methods-systems.ptx" />
-			<xi:include href="c13-linsys/exercises-linsys.ptx" />
+			<!-- <xi:include href="c13-linsys/sec-introduction-to-systems.ptx" /> -->
+			<!-- <xi:include href="c13-linsys/sec-variable-interactions.ptx" /> -->
+			<!-- <xi:include href="c13-linsys/sec-linear-systems.ptx" /> -->
+			<!-- <xi:include href="c13-linsys/sec-solving-linear-systems.ptx" /> -->
+			<!-- <xi:include href="c13-linsys/sec-second-order-to-system.ptx" /> -->
+			<!-- <xi:include href="c13-linsys/sec-eulers-method-systems.ptx" /> -->
+			<!-- <xi:include href="c13-linsys/sec-qualitative-methods-systems.ptx" /> -->
+			<!-- <xi:include href="c13-linsys/linsys-model.ptx" /> -->
+			<!-- <xi:include href="c13-linsys/exercises-linsys.ptx" /> -->
 
-			<outcomes label="1st-order-linear-systems-takeaways">
+			<!-- <outcomes label="1st-order-linear-systems-takeaways">
 				<ul marker="square">
 					<li><p>In <em>uncoupled systems</em>, 
 							<ul>
@@ -785,7 +819,7 @@
 						</p>
 					</li>
 					<li><p>A system is <em>linear</em> if its unknowns appear without products, powers, or nonlinear functions. Such systems can be written in vector form:
-								<me>\dfrac{d\vec{X}}{dt} = A\vec{X}</me>
+								<md>\dfrac{d\vec{X}}{dt} = A\vec{X}</md>
 								where <m>A</m> is the constant coefficient matrix.
 							</p>
 					</li>
@@ -794,13 +828,13 @@
 					<li>Phase plane diagrams reveal whether a system's solutions decay, grow, or spiral.</li>
 					<li>You can often tell what will happen by the shape of the arrows — even without solving equations.</li>
 				</ul>
-			</outcomes>
-		</chapter> -->
+			</outcomes> -->
+		</chapter>
 
-		<!-- <chapter label="chpt-nonlinear-systems">
+		<chapter label="chpt-nonlinear-systems">
 			<title>Nonlinear Systems</title>
-
-			<introduction>
+<section><title>fuxck</title><p>No</p></section>
+			<!-- <introduction>
 				<p>
 					<xref provisional="FUTURE-WORK"/>
 				</p>
@@ -816,20 +850,20 @@
 				<p>
 					This chapter introduces the core ideas you'll need to begin exploring nonlinear systems. While the techniques are more limited and the solutions less tidy, the insights they reveal are essential for understanding the complex, interconnected systems that define much of the world around us.
 				</p>
-			</introduction>
+			</introduction> -->
 
-			<xi:include href="c14-nlinsys/sec-nonlinear-systems.ptx" />
+			<!-- <xi:include href="c14-nlinsys/sec-nonlinear-systems.ptx" /> -->
 
-			<outcomes label="nonlinear-systems-takeaways">
+			<!-- <outcomes label="nonlinear-systems-takeaways">
 				<ul marker="square">
 					<li><p>Nonlinear systems can exhibit complex behaviors that linear systems cannot, such as chaos, oscillations, and bifurcations.</p></li>
 					<li><p>Qualitative methods are essential for understanding the behavior of nonlinear systems when exact solutions are not available.</p></li>
 					<li><p>Phase plane analysis helps visualize the dynamics of nonlinear systems and identify equilibrium points and their stability.</p></li>
 					<li><p>Numerical methods are often necessary to approximate solutions to nonlinear systems.</p></li>
 				</ul>
-			</outcomes>
+			</outcomes> -->
 
-		</chapter> -->
+		</chapter>
 
 		<xi:include href="aa-bookends/back-matter.ptx" />
 	</book>

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -307,7 +307,7 @@
 
 		</chapter>
 
-		<chapter xml:id="chpt-qualitative" label="chpt-qualitative">
+		<chapter xml:id="chpt-qualitative">
 			<title>Qualitative Methods</title>
 
 			<introduction>
@@ -371,7 +371,7 @@
 
 		</chapter>
 
-		<chapter xml:id="chpt-eulers-method" label="chpt-eulers-method">
+		<chapter xml:id="chpt-eulers-method">
 			<title>Euler's Method</title>
 
 			<introduction>
@@ -533,7 +533,7 @@
 
 		</chapter>
 
-		<chapter xml:id="chpt-laplace-transforms" label="chpt-laplace-transforms">
+		<chapter xml:id="chpt-laplace-transforms">
 			<title>Laplace Transforms</title>
 
 			<introduction>

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -286,6 +286,7 @@
 			<xi:include href="c5-if/sec-if-method.ptx" />
 			<!-- <xi:include href="c5-if/if-model.ptx" /> -->
 			<xi:include href="c5-if/exercises-if.ptx" />
+			<xi:include href="c5-if/review-first-order-methods.ptx" />
 
 			<outcomes label="integrating-factor-takeaways">
 				<ul marker="square">
@@ -306,7 +307,7 @@
 
 		</chapter>
 
-		<chapter label="chpt-qualitative">
+		<chapter xml:id="chpt-qualitative" label="chpt-qualitative">
 			<title>Qualitative Methods</title>
 
 			<introduction>
@@ -370,7 +371,7 @@
 
 		</chapter>
 
-		<chapter label="chpt-eulers-method">
+		<chapter xml:id="chpt-eulers-method" label="chpt-eulers-method">
 			<title>Euler's Method</title>
 
 			<introduction>
@@ -514,6 +515,7 @@
 			<xi:include href="c9-uc/sec-uc-method.ptx" />
 			<!-- <xi:include href="c9-uc/uc-model.ptx" /> -->
 			<xi:include href="c9-uc/exercises-uc.ptx" />
+			<xi:include href="c9-uc/review-constant-coefficient.ptx" />
 
 			<outcomes label="undetermined-coefficients-takeaways">
 				<ul marker="square">
@@ -531,7 +533,7 @@
 
 		</chapter>
 
-		<chapter label="chpt-laplace-transforms">
+		<chapter xml:id="chpt-laplace-transforms" label="chpt-laplace-transforms">
 			<title>Laplace Transforms</title>
 
 			<introduction>
@@ -678,6 +680,7 @@
 			<xi:include href="c12-ltp/sec-laplace-piecewise-method.ptx" />
 			<!-- <xi:include href="c12-ltp/ltp-model.ptx" /> -->
 			<xi:include href="c12-ltp/exercises-ltp.ptx" />
+			<xi:include href="c12-ltp/review-choosing-a-method.ptx" />
 
 			<outcomes label="piecewise-forcing-functions-takeaways">
 				<ul marker="square">


### PR DESCRIPTION
Implements audit task **H9** — the book previously had no cumulative or mixed review anywhere, so students never practiced *choosing* a method, which is the skill exams actually test.

## What this adds

**Three "Mixed Review: Choosing Your Method" sections** at the natural seams, each centered on method *selection* rather than a single technique:

- **After ch. 5** (`c5-if/review-first-order-methods.ptx`) — direct integration vs. separation of variables vs. integrating factor
- **After ch. 9** (`c9-uc/review-constant-coefficient.ptx`) — LHCC characteristic equation vs. LNCC undetermined coefficients, plus the "don't overthink a first-order equation" traps
- **After ch. 12** (`c12-ltp/review-choosing-a-method.ptx`) — Laplace vs. the earlier toolkit, with a whole-book decision map

Each section pairs a **💡 "Which Method?" quiz** (per-choice feedback explaining *why* each wrong tool fails) with a **✍🏻 mixed problem set** whose solutions lead with the method choice and the equation feature that motivated it. Deliberate "more than one method applies" and "none of our methods apply yet" cases are included.

**An interactive decision-tree flowchart** (`assets/code/jsxgraph/method-flowchart/method-flowchart.js`): first order? → already a derivative? → separable? → linear? → which tool. It reuses the existing `if-drill-which-method` group as its companion, as the audit suggested.

## Verification

- **Every printed answer is CAS-verified.** 26 new SymPy checks appended to the `verify-worked-math` registry (the H3 regression gate); the full registry is **89/89 passing**. No answer went in unverified.
- **Flowchart driven end-to-end in headless Chromium** on the book's pinned JSXGraph 1.8.0 — the decision logic walks every branch and highlights the correct terminal node.
- **Rendered through a real `pretext build`** — a self-contained mini-book of the three sections built to HTML with zero errors, confirming structure, math markup, decision-map tables, and the interactive all compile.
- **Both CI gates pass**: `validate-source` (138/138 well-formed, 0 duplicate IDs, placeholder baseline held) and `verify-worked-math`.

## Supporting edits

- `main.ptx`: three `xi:include`s wiring in the new sections.
- Added `xml:id` targets to the divisions the new cross-references point at (three chapters, two Laplace sections, and the `if-drill-which-method` group), matching the book's existing convention of using `xml:id` as xref targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vhHaJjo1fdpi2TBj7VMCc

---
_Generated by [Claude Code](https://claude.ai/code/session_018vhHaJjo1fdpi2TBj7VMCc)_