### PR TITLE
H10: De-duplicate exercise pools and re-tier difficulty

### DIFF
--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -745,6 +745,18 @@ REGISTRY += [
 ]
 
 
+# ----------------------------------------------------------------------
+# H10 — de-duplication pass: a copy-paste answer error corrected in c11
+# ----------------------------------------------------------------------
+REGISTRY += [
+    Check(
+        "c11 composite drill: L{ e^(2t) sin 4t } = 4/((s-2)^2+16) (fixed copy-paste answer)",
+        "source/c11-ltm/exercises-ltm.ptx",
+        lambda: laplace_matches(exp(2 * t) * sin(4 * t), 4 / ((s - 2) ** 2 + 16)),
+    ),
+]
+
+
 def main() -> int:
     failures = 0
     for check in REGISTRY:

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -754,6 +754,14 @@ REGISTRY += [
         "source/c11-ltm/exercises-ltm.ptx",
         lambda: laplace_matches(exp(2 * t) * sin(4 * t), 4 / ((s - 2) ** 2 + 16)),
     ),
+    Check(
+        "c11 composite drill: combined y(t)=e^(2t)sin4t+(1/12)t^4 e^(-7t) -> Y(s)",
+        "source/c11-ltm/exercises-ltm.ptx",
+        lambda: laplace_matches(
+            exp(2 * t) * sin(4 * t) + R(1, 12) * t**4 * exp(-7 * t),
+            4 / ((s - 2) ** 2 + 16) + 2 / (s + 7) ** 5,
+        ),
+    ),
     # New first-order direct-integration drills added to c3 (replacing the
     # out-of-scope second-order drills that were re-homed to c2).
     Check(

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -746,13 +746,45 @@ REGISTRY += [
 
 
 # ----------------------------------------------------------------------
-# H10 — de-duplication pass: a copy-paste answer error corrected in c11
+# H10 — de-duplication pass: corrected/added answers
 # ----------------------------------------------------------------------
 REGISTRY += [
     Check(
         "c11 composite drill: L{ e^(2t) sin 4t } = 4/((s-2)^2+16) (fixed copy-paste answer)",
         "source/c11-ltm/exercises-ltm.ptx",
         lambda: laplace_matches(exp(2 * t) * sin(4 * t), 4 / ((s - 2) ** 2 + 16)),
+    ),
+    # New first-order direct-integration drills added to c3 (replacing the
+    # out-of-scope second-order drills that were re-homed to c2).
+    Check(
+        "c3 drill A1: y=2x^3+C solves dy/dx=6x^2",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff(2 * x**3 + C1, x) - 6 * x**2),
+    ),
+    Check(
+        "c3 drill A2: y=(1/4)e^{4x}+C solves dy/dx=e^{4x}",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff(R(1, 4) * exp(4 * x) + C1, x) - exp(4 * x)),
+    ),
+    Check(
+        "c3 drill A3: y=-(1/3)cos(3x)+C solves dy/dx=sin(3x)",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff(-R(1, 3) * cos(3 * x) + C1, x) - sin(3 * x)),
+    ),
+    Check(
+        "c3 drill A4: y=ln|x|+C solves dy/dx=1/x",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff(log(x) + C1, x) - 1 / x),
+    ),
+    Check(
+        "c3 drill B5: y=2x^2+C/x^2 solves d/dx[x^2 y]=8x^3",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff(x**2 * (2 * x**2 + C1 / x**2), x) - 8 * x**3),
+    ),
+    Check(
+        "c3 drill B6: y=1+Ce^{-x} solves d/dx[e^x y]=e^x",
+        "source/c3-di/exercises-di.ptx",
+        lambda: is_zero(diff(exp(x) * (1 + C1 * exp(-x)), x) - exp(x)),
     ),
 ]
 

--- a/source/c0-whats-a-de/exercises-wad.ptx
+++ b/source/c0-whats-a-de/exercises-wad.ptx
@@ -39,19 +39,19 @@
 				</task>
 
 				<task label="wad-ex-01-tf-task-02">
-					<statement><p>The expression <m>z^{(18)}</m> is the same as <m>z</m> to the power of 18.</p></statement>
+					<statement><p>The expression <m>y^{(4)}</m> is another way to write the fourth derivative of <m>y</m>, not <m>y</m> raised to the fourth power.</p></statement>
 					<choices>
-						<choice>
-							<statement><p>True</p></statement>
-							<feedback><p>Incorrect. Please read the note on derivative notation.</p></feedback>
-						</choice>
 						<choice correct="yes">
+							<statement><p>True</p></statement>
+							<feedback><p>Correct! A parenthesized superscript denotes a derivative, so <m>y^{(4)}</m> is the fourth derivative of <m>y</m>.</p></feedback>
+						</choice>
+						<choice>
 							<statement><p>False</p></statement>
-							<feedback><p>Correct!</p></feedback>
+							<feedback><p>Incorrect. Please read the note on derivative notation.</p></feedback>
 						</choice>
 					</choices>
 					<feedback>
-						<p>The correct response is False: <m>z^{(18)}</m> denotes the 18th derivative, not a power.</p>
+						<p>The correct response is True: the parentheses distinguish the derivative <m>y^{(4)}</m> from the power <m>y^4</m>.</p>
 					</feedback>
 				</task>
 
@@ -100,13 +100,13 @@
 				<solution>
 					<ol>
 						<li>False. These are called differential equations.</li>
-						<li>False. <m>z^{(18)}</m> denotes the 18th derivative.</li>
+						<li>True. <m>y^{(4)}</m> denotes the fourth derivative, not a power.</li>
 						<li>True. A differential equation includes a derivative of the dependent variable.</li>
 						<li>True statements: the dependent variable depends on the independent variable, and an ODE has one independent variable.</li>
 					</ol>
 				</solution>
 				<answer>
-					<p>1) False. 2) False. 3) True. 4) True statements: dependent variable depends on independent variable; ODE has one independent variable.</p>
+					<p>1) False. 2) True. 3) True. 4) True statements: dependent variable depends on independent variable; ODE has one independent variable.</p>
 				</answer>
 			</exercise>
 
@@ -218,35 +218,35 @@
 						<p>
 							Which variable in the differential equation,
 							<me>
-								\dfrac{dP}{ds} + \dfrac{P}{s^2} = 17s
+								\dfrac{dQ}{dr} + rQ = e^r
 							</me>,
 							represents the unknown function we would like to find?
 						</p>
 					</statement>
-					
+
 					<choices randomize="yes">
 
 						<choice>
-							<statement><p>dependent variable, <m>s</m></p></statement>
-							<feedback><p>Incorrect. <m>s</m> is neither the dependent variable nor what we are solving for.</p></feedback>
+							<statement><p>dependent variable, <m>r</m></p></statement>
+							<feedback><p>Incorrect. <m>r</m> is neither the dependent variable nor what we are solving for.</p></feedback>
 						</choice>
 						<choice>
-							<statement><p>independent variable, <m>s</m></p></statement>
-							<feedback><p>Incorrect! <m>s</m> is the independent variable, but it is not what we are solving for.</p></feedback>
+							<statement><p>independent variable, <m>r</m></p></statement>
+							<feedback><p>Incorrect! <m>r</m> is the independent variable, but it is not what we are solving for.</p></feedback>
 						</choice>
 						<choice correct="yes">
-							<statement><p>dependent variable, <m>P</m></p></statement>
-							<feedback><p>Yes! We are solving for the unknown <m>P</m>, the dependent variable in this equation.</p></feedback>
+							<statement><p>dependent variable, <m>Q</m></p></statement>
+							<feedback><p>Yes! We are solving for the unknown <m>Q</m>, the dependent variable in this equation.</p></feedback>
 						</choice>
 						<choice>
-							<statement><p>independent variable, <m>P</m></p></statement>
-							<feedback><p>Incorrect. We are solving for <m>P</m>, but it is not the independent variable.</p></feedback>
+							<statement><p>independent variable, <m>Q</m></p></statement>
+							<feedback><p>Incorrect. We are solving for <m>Q</m>, but it is not the independent variable.</p></feedback>
 						</choice>
 
 					</choices>
 
 					<feedback>
-						<p>The correct choice is the dependent variable <m>P</m>, which represents the unknown function.</p>
+						<p>The correct choice is the dependent variable <m>Q</m>, which represents the unknown function.</p>
 					</feedback>
 				</task>
 
@@ -255,34 +255,34 @@
 						<p>
 							Which variable, in the differential equation below, does the solution of this equation depend on?
 							<me>
-								\dfrac{dP}{ds} + \dfrac{P}{s^2} = 17s
+								\dfrac{dQ}{dr} + rQ = e^r
 							</me>
 						</p>
 					</statement>
-					
+
 					<choices randomize="yes">
 
 						<choice>
-							<statement><p>The solution, <m>P</m>, depends on the dependent variable, <m>s</m></p></statement>
-							<feedback><p>Incorrect. The solution depends on <m>s</m>, but <m>s</m> is not a dependent variable.</p></feedback>
+							<statement><p>The solution, <m>Q</m>, depends on the dependent variable, <m>r</m></p></statement>
+							<feedback><p>Incorrect. The solution depends on <m>r</m>, but <m>r</m> is not a dependent variable.</p></feedback>
 						</choice>
 						<choice correct="yes">
-							<statement><p>The solution, <m>P</m>, depends on the independent variable, <m>s</m></p></statement>
-							<feedback><p>Yes! The solution, <m>P</m>, depends on the independent variable <m>s</m>.</p></feedback>
+							<statement><p>The solution, <m>Q</m>, depends on the independent variable, <m>r</m></p></statement>
+							<feedback><p>Yes! The solution, <m>Q</m>, depends on the independent variable <m>r</m>.</p></feedback>
 						</choice>
 						<choice>
-							<statement><p>The solution, <m>s</m>, depends on the dependent variable, <m>P</m></p></statement>
-							<feedback><p>Incorrect. <m>P</m> is the solution, so it does not depend on <m>P</m>.</p></feedback>
+							<statement><p>The solution, <m>r</m>, depends on the dependent variable, <m>Q</m></p></statement>
+							<feedback><p>Incorrect. <m>Q</m> is the solution, so it does not depend on <m>Q</m>.</p></feedback>
 						</choice>
 						<choice>
-							<statement><p>The solution, <m>s</m>, depends on the independent variable, <m>P</m></p></statement>
-							<feedback><p>Incorrect. The variable <m>P</m> is not the independent variable.</p></feedback>
+							<statement><p>The solution, <m>r</m>, depends on the independent variable, <m>Q</m></p></statement>
+							<feedback><p>Incorrect. The variable <m>Q</m> is not the independent variable.</p></feedback>
 						</choice>
 
 					</choices>
 
 					<feedback>
-						<p>The correct choice is that <m>P</m> depends on the independent variable <m>s</m>.</p>
+						<p>The correct choice is that <m>Q</m> depends on the independent variable <m>r</m>.</p>
 					</feedback>
 				</task>
 
@@ -326,13 +326,13 @@
 						<li>The number of variables the unknown function depends on.</li>
 						<li>They involve derivatives of an unknown function.</li>
 						<li>An <m>x</m>-variable is not required.</li>
-						<li>Dependent variable <m>P</m>.</li>
-						<li>The solution <m>P</m> depends on <m>s</m>.</li>
+						<li>Dependent variable <m>Q</m>.</li>
+						<li>The solution <m>Q</m> depends on <m>r</m>.</li>
 						<li>The free term is <m>0</m>.</li>
 					</ol>
 				</solution>
 				<answer>
-					<p>1) derivatives. 2) number of variables in the unknown function. 3) involves derivatives. 4) <m>x</m>-variable not required. 5) <m>P</m>. 6) depends on <m>s</m>. 7) <m>0</m>.</p>
+					<p>1) derivatives. 2) number of variables in the unknown function. 3) involves derivatives. 4) <m>x</m>-variable not required. 5) <m>Q</m>. 6) depends on <m>r</m>. 7) <m>0</m>.</p>
 				</answer>
 			</exercise>
 
@@ -605,28 +605,28 @@
 				<title>Identify the Coefficients</title>
 
 				<task label="wad-ex-05-mc-task-01">
-					<statement>	
+					<statement>
 						<p>
-							Identify the coefficient of <m>y'</m> in the differential equation
-							<me>5y'' + 2\cos(t)y' - y = 7</me>
-						</p>	
+							Identify the coefficient of <m>y''</m> in the differential equation
+							<me>3t\,y'' + e^t\,y' - 4y = t^2</me>
+						</p>
 					</statement>
 					<choices randomize="yes">
-						<choice>
-							<statement><p><m>\quad \cos(t)</m></p></statement>
-							<feedback><p>Incorrect. <m>\cos(t)</m> is only part of the coefficient of <m>y'</m>.</p></feedback>
-						</choice>
 						<choice correct="yes">
-							<statement><p><m>\quad 2\cos(t)</m></p></statement>
-							<feedback><p>Correct! <m>2\cos(t)</m> is the coefficient of the term involving <m>y'</m>.</p></feedback>
+							<statement><p><m>\quad 3t</m></p></statement>
+							<feedback><p>Correct! <m>3t</m> is the coefficient of the term involving <m>y''</m>.</p></feedback>
 						</choice>
 						<choice>
-							<statement><p><m>\quad 2</m></p></statement>
-							<feedback><p>Incorrect. <m>2</m> is only part of the coefficient of <m>y'</m>.</p></feedback>
+							<statement><p><m>\quad t</m></p></statement>
+							<feedback><p>Incorrect. <m>t</m> is only part of the coefficient of <m>y''</m>.</p></feedback>
 						</choice>
 						<choice>
-							<statement><p><m>\quad 7</m></p></statement>
-							<feedback><p>Incorrect. <m>7</m> is the constant on the right-hand side of the equation.</p></feedback>
+							<statement><p><m>\quad e^t</m></p></statement>
+							<feedback><p>Incorrect. <m>e^t</m> is the coefficient of <m>y'</m>, not <m>y''</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>\quad -4</m></p></statement>
+							<feedback><p>Incorrect. <m>-4</m> is the coefficient of <m>y</m>.</p></feedback>
 						</choice>
 					</choices>
 				</task>
@@ -661,12 +661,12 @@
 
 				<solution>
 					<ol>
-						<li>The coefficient of <m>y'</m> is <m>2\cos(t)</m>.</li>
+						<li>The coefficient of <m>y''</m> is <m>3t</m>.</li>
 						<li>The coefficients are <m>t</m>, <m>t^2</m>, <m>4</m>, and <m>t</m> for the terms involving <m>y''</m>, <m>y^2</m>, <m>y'</m>, and <m>y^{-1}</m>.</li>
 					</ol>
 				</solution>
 				<answer>
-					<p>1) <m>2\cos(t)</m>. 2) Coefficients: <m>t</m>, <m>t^2</m>, <m>4</m>, and <m>t</m>.</p>
+					<p>1) <m>3t</m>. 2) Coefficients: <m>t</m>, <m>t^2</m>, <m>4</m>, and <m>t</m>.</p>
 				</answer>
 			</exercise>
 

--- a/source/c1-classification/exercises-class.ptx
+++ b/source/c1-classification/exercises-class.ptx
@@ -71,27 +71,27 @@
 				<title>Multiple Choice</title>
 
 				<task label="class-ex-02-mc-task-01">
-					<statement><p>Which of the following equations is a third-order differential equation?</p></statement>
+					<statement><p>Which of the following equations is a fourth-order differential equation?</p></statement>
 					<choices randomize="yes">
 						<choice correct="yes">
-							<statement><p><m>\quad \dfrac{d^3y}{dx^3} + x^2y = 0</m></p></statement>
-							<feedback><p>Correct! The highest derivative here is the third derivative, making it a third-order differential equation.</p></feedback>
+							<statement><p><m>\quad \dfrac{d^4y}{dx^4} - y = e^x</m></p></statement>
+							<feedback><p>Correct! The highest derivative here is the fourth derivative, making it a fourth-order differential equation.</p></feedback>
 						</choice>
 						<choice>
-							<statement><p><m>\quad \dfrac{d^2y}{dx^2} + y' = \sin x</m></p></statement>
+							<statement><p><m>\quad y''' + 2y = 0</m></p></statement>
+							<feedback><p>Incorrect. This is a third-order differential equation.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>\quad \dfrac{d^2y}{dx^2} + 3y' = x</m></p></statement>
 							<feedback><p>Incorrect. This is a second-order differential equation.</p></feedback>
 						</choice>
 						<choice>
-							<statement><p><m>\quad y'' + y' + y = 0</m></p></statement>
-							<feedback><p>Incorrect. This is a second-order differential equation.</p></feedback>
-						</choice>
-						<choice>
-							<statement><p><m>\quad y' + y = x</m></p></statement>
+							<statement><p><m>\quad y' - 5y = e^x</m></p></statement>
 							<feedback><p>Incorrect. This is a first-order differential equation.</p></feedback>
 						</choice>
 					</choices>
 					<feedback>
-						<p>The correct choice is the equation with the third derivative <m>\dfrac{d^3y}{dx^3}</m>.</p>
+						<p>The correct choice is the equation with the fourth derivative <m>\dfrac{d^4y}{dx^4}</m>.</p>
 					</feedback>
 				</task>
 
@@ -168,14 +168,14 @@
 				</task>
 				<solution>
 					<ol>
-						<li><m>\dfrac{d^3y}{dx^3} + x^2y = 0</m></li>
+						<li><m>\dfrac{d^4y}{dx^4} - y = e^x</m></li>
 						<li><m>y^2</m></li>
 						<li><m>y^2</m></li>
 						<li>A dependent variable inside another function.</li>
 					</ol>
 				</solution>
 				<answer>
-					<p>1) Equation with <m>\dfrac{d^3y}{dx^3}</m>. 2) <m>y^2</m>. 3) <m>y^2</m>. 4) Dependent variable inside another function.</p>
+					<p>1) Equation with <m>\dfrac{d^4y}{dx^4}</m>. 2) <m>y^2</m>. 3) <m>y^2</m>. 4) Dependent variable inside another function.</p>
 				</answer>
 			</exercise>
 
@@ -597,21 +597,21 @@
 						<tabular>
 							<row><cell><m/></cell></row>
 							<row>
-								<cell><area correct="yes">	<m> \dfrac{dx}{ds} = x^2 - 4						</m></area></cell>
-								<cell><area correct="no">	<m> \dfrac{d^2u}{dz^2} - 5 \dfrac{du}{dz} + 6u = 0	</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dp}{d\tau} + \sin(p) = \tau^2			</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dx}{dt} = x^2 + t					</m></area></cell>
+								<cell><area correct="no">	<m> \dfrac{dy}{dt} + t^2 y = e^t				</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{du}{ds} = \cos(u)					</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 							<row>
-								<cell><area correct="no">	<m> \dfrac{dw}{dv} + 2vw = \cos(v)				</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dr}{d\theta} + r^3 = \theta			</m></area></cell>
-								<cell><area correct="no">	<m> \dfrac{dN}{dt} = -N							</m></area></cell>
+								<cell><area correct="no">	<m> \dfrac{d^2w}{dr^2} + 4w = 0				</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dp}{dq} = p^2 q					</m></area></cell>
+								<cell><area correct="no">	<m> \dfrac{dv}{dz} + v = z^3					</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 							<row>
-								<cell><area correct="yes">	<m> \dfrac{dm}{dq} = m^3 - q^2					</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dz}{dt} + z\dfrac{dz}{dt} = t^3			</m></area></cell>
-								<cell><area correct="yes">	<m> \dfrac{dy}{dx} = y \ln(y)						</m></area></cell>
+								<cell><area correct="yes">	<m> \dfrac{dh}{dx} = \sqrt{h}				</m></area></cell>
+								<cell><area correct="no">	<m> \dfrac{dT}{dt} + 3T = 20					</m></area></cell>
+								<cell><area correct="yes">	<m> y' + (y')^2 = x							</m></area></cell>
 							</row>
 							<row><cell><m/></cell></row>
 						</tabular>
@@ -631,11 +631,11 @@
 						<li>Nonlinear.</li>
 						<li><m>y'' + y' + y = 0</m>.</li>
 						<li>Linear equations: <m>y'' + \dfrac{y'}{t^2} + y = 17t</m>, <m>y'' + 3y' + 2y = 0</m>, <m>y'' + \dfrac{y'}{t} + y = 17t</m>, <m>y = y'</m>.</li>
-						<li>Nonlinear equations: <m>\dfrac{dx}{ds} = x^2 - 4</m>, <m>\dfrac{dp}{d\tau} + \sin(p) = \tau^2</m>, <m>\dfrac{dr}{d\theta} + r^3 = \theta</m>, <m>\dfrac{dm}{dq} = m^3 - q^2</m>, <m>\dfrac{dz}{dt} + z\dfrac{dz}{dt} = t^3</m>, <m>\dfrac{dy}{dx} = y \ln(y)</m>.</li>
+						<li>Nonlinear equations: <m>\dfrac{dx}{dt} = x^2 + t</m>, <m>\dfrac{du}{ds} = \cos(u)</m>, <m>\dfrac{dp}{dq} = p^2 q</m>, <m>\dfrac{dh}{dx} = \sqrt{h}</m>, <m>y' + (y')^2 = x</m>.</li>
 					</ol>
 				</solution>
 				<answer>
-					<p>1) Nonlinear. 2) Linear. 3) Linear. 4) Nonlinear. 5) <m>y'' + y' + y = 0</m>. 6) Linear: <m>y'' + \dfrac{y'}{t^2} + y = 17t</m>, <m>y'' + 3y' + 2y = 0</m>, <m>y'' + \dfrac{y'}{t} + y = 17t</m>, <m>y = y'</m>. 7) Nonlinear: <m>\dfrac{dx}{ds} = x^2 - 4</m>, <m>\dfrac{dp}{d\tau} + \sin(p) = \tau^2</m>, <m>\dfrac{dr}{d\theta} + r^3 = \theta</m>, <m>\dfrac{dm}{dq} = m^3 - q^2</m>, <m>\dfrac{dz}{dt} + z\dfrac{dz}{dt} = t^3</m>, <m>\dfrac{dy}{dx} = y \ln(y)</m>.</p>
+					<p>1) Nonlinear. 2) Linear. 3) Linear. 4) Nonlinear. 5) <m>y'' + y' + y = 0</m>. 6) Linear: <m>y'' + \dfrac{y'}{t^2} + y = 17t</m>, <m>y'' + 3y' + 2y = 0</m>, <m>y'' + \dfrac{y'}{t} + y = 17t</m>, <m>y = y'</m>. 7) Nonlinear: <m>\dfrac{dx}{dt} = x^2 + t</m>, <m>\dfrac{du}{ds} = \cos(u)</m>, <m>\dfrac{dp}{dq} = p^2 q</m>, <m>\dfrac{dh}{dx} = \sqrt{h}</m>, <m>y' + (y')^2 = x</m>.</p>
 				</answer>
 			</exercise>
 

--- a/source/c11-ltm/exercises-ltm.ptx
+++ b/source/c11-ltm/exercises-ltm.ptx
@@ -350,7 +350,7 @@
 			</task>
 
 			<task label="ltm-drill-03">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Shifted Sine</title>
 				<statement>
 					<p><m>\quad \ilap{\dfrac{10}{(s - 2)^2 + 25}} = </m> <fillin characters="15"/></p>
 				</statement>
@@ -383,7 +383,7 @@
 			</task>
 
 			<task label="ltm-drill-04">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Power of s</title>
 				<statement>
 					<me>Y(s) = \dfrac{7}{s^2} \quad\Rightarrow\quad y(t) = <fillin characters="15"/></me>
 				</statement>
@@ -424,7 +424,7 @@
 			</task>
 
 			<task label="ltm-drill-05">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Sum of Terms</title>
 				<statement>
 					<p><m>\ilap{\dfrac{1}{s - 1} - \dfrac{1}{s + 1} + \dfrac{4s + 3}{s^2 + 1}} = <fillin characters="10" /></m></p>
 				</statement>
@@ -457,7 +457,7 @@
 			</task>
 
 			<task label="ltm-drill-06">
-				<title>Select the Inverse</title>
+				<title>Select the Forward Transform</title>
 				<statement>
 					<p>What is the Laplace transform of <m>e^{3t}</m>?</p>
 				</statement>
@@ -478,7 +478,7 @@
 			</task>
 
 			<task label="ltm-drill-07">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Sine</title>
 				<statement>
 					<p><m>\quad \ilap{\dfrac{3}{s^2 + 9}} = <fillin characters="6" /></m></p>
 				</statement>
@@ -511,7 +511,7 @@
 			</task>
 
 			<task label="ltm-drill-08">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Decaying Exponential</title>
 				<statement>
 					<p><m>\quad \ilap{\dfrac{1}{s+3}} = <fillin characters="6" /></m></p>
 				</statement>
@@ -544,7 +544,7 @@
 			</task>
 			
 			<task label="ltm-drill-09">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Higher Power</title>
 				<statement>
 					<p><m>\quad \ilap{\dfrac{24}{s^5}} = <fillin characters="6" /></m></p>
 				</statement>
@@ -577,7 +577,7 @@
 			</task>
 			
 			<task label="ltm-drill-10">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Sine Wave</title>
 				<statement>
 					<p><m>\quad \ilap{\dfrac{2}{s^2 + 4}} = <fillin characters="6" /></m></p>
 				</statement>
@@ -610,7 +610,7 @@
 			</task>
 			
 			<task label="ltm-drill-11">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Growing Exponential</title>
 				<statement>
 					<p><m>\quad \ilap{\dfrac{1}{s - 5}} = <fillin characters="6" /></m></p>
 				</statement>
@@ -643,7 +643,7 @@
 			</task>
 			
 			<task label="ltm-drill-12">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Repeated Factor</title>
 				<statement>
 					<p><m>\quad \ilap{\dfrac{1}{(s+4)^2}} = <fillin characters="6" /></m></p>
 				</statement>
@@ -676,7 +676,7 @@
 			</task>
 
 			<task label="ltm-drill-13">
-				<title>Select the Inverse</title>
+				<title>Inverse of a Shifted Cosine</title>
 				<statement>
 					<p><m>\ilap{\dfrac{s-1}{(s-1)^2 + 4}} = <fillin characters="6"/></m></p>
 				</statement>
@@ -980,12 +980,10 @@
 				<statement><p><m>Y(s) = \dfrac{4}{(s - 2)^2 + 16} + \dfrac{2}{(s+7)^5}</m></p></statement>
 				<answer>
 					<p>
-						The form of this denominator is <m>\ul{(s \pm \text{shift})^{2} + \text{number}}</m> and has no <m>s</m> in the numerator. Therefore,
+						The form of the first denominator is <m>\ul{(s \pm \text{shift})^{2} + \text{number}}</m> and has no <m>s</m> in the numerator. Here the numerator already matches <m>b</m>, so
 						<md>
-							<mrow> \ilap{\dfrac{10}{(s - 3)^2 + 11}} \amp\ \quad <xref ref="lt-L7-table" text="custom"><m>L_7</m></xref> (a=3,\ b=\sqrt{11})</mrow>
-							<mrow>	\amp = 10\ \ilap{\dfrac{\sqrt{11}}{\sqrt{11}}\dfrac{1}{(s - 3)^2 + 11}}</mrow>
-							<mrow>	\amp = \dfrac{10}{\sqrt{11}} \ilap{\dfrac{\sqrt{11}}{(s - 3)^2 + 11}}</mrow>
-							<mrow>	\amp = \dfrac{10}{\sqrt{11}} e^{3t} \sin(\sqrt{11}t)</mrow>
+							<mrow> \ilap{\dfrac{4}{(s - 2)^2 + 16}} \amp\ \quad <xref ref="lt-L7-table" text="custom"><m>L_7</m></xref> (a=2,\ b=4)</mrow>
+							<mrow>	\amp = e^{2t} \sin(4t)</mrow>
 						</md>
 
 					</p>

--- a/source/c11-ltm/exercises-ltm.ptx
+++ b/source/c11-ltm/exercises-ltm.ptx
@@ -959,6 +959,10 @@
 						</mrow>
 						</md>
 					</p>
+					<p>
+						Adding the two terms gives the full inverse transform:
+						<me>y(t) = e^{2t}\sin(4t) + \dfrac{1}{12}t^4 e^{-7t}</me>.
+					</p>
 				</answer>
 			</exercise>
 

--- a/source/c2-solns/exercises-solns.ptx
+++ b/source/c2-solns/exercises-solns.ptx
@@ -757,7 +757,7 @@
 
 	</subsection>
 
-	<!-- <subsection label="solns-practice-drills">
+	<subsection label="solns-practice-drills">
 		<title><e component="emoji">🏋️‍♂️</e> Practice Drills</title>
 
 		<exercises label="solns-drills">
@@ -827,6 +827,22 @@
 							</sidebyside>
 						</p>
 					</areas>
+					<solution>
+						<p>
+							To verify if a function is a solution, we need to compute <m>y''</m> and check if <m>y'' - 9y = 0</m>.
+							<ul>
+								<li><p><m>y = 3</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 27 = -27 \neq 0</m>. <term>Not a solution.</term></p></li>
+								<li><p><m>y = 0</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 0 = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = e^{3x}</m>: <m>y'' = 9e^{3x}</m>, so <m>y'' - 9y = 9e^{3x} - 9e^{3x} = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = 3x</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 27x = -27x \neq 0</m>. <term>Not a solution.</term></p></li>
+								<li><p><m>y = 9e^x</m>: <m>y'' = 9e^x</m>, so <m>y'' - 9y = 9e^x - 81e^x = -72e^x \neq 0</m>. <term>Not a solution.</term></p></li>
+								<li><p><m>y = x^9</m>: <m>y'' = 72x^7</m>, so <m>y'' - 9y = 72x^7 - 9x^9 \neq 0</m>. <term>Not a solution.</term></p></li>
+								<li><p><m>y = 4e^{3x}</m>: <m>y'' = 36e^{3x}</m>, so <m>y'' - 9y = 36e^{3x} - 36e^{3x} = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = e^{-3x}</m>: <m>y'' = 9e^{-3x}</m>, so <m>y'' - 9y = 9e^{-3x} - 9e^{-3x} = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = e^{3x} - 2e^{-3x}</m>: <m>y'' = 9e^{3x} - 18e^{-3x}</m>, so <m>y'' - 9y = (9e^{3x} - 18e^{-3x}) - 9(e^{3x} - 2e^{-3x}) = 0</m>. <term>Solution.</term></p></li>
+							</ul>
+						</p>
+					</solution>
 					<answer>
 						<p>
 							<sidebyside width="30%">
@@ -874,6 +890,22 @@
 							</sidebyside>
 						</p>
 					</areas>
+					<solution>
+						<p>
+							To verify if a function is a solution, we need to compute <m>y'</m> and <m>y''</m> and check if <m>y'' - 10y' + 25y = 0</m>.
+							<ul>
+								<li><p><m>y = 0</m>: <m>y' = 0</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 0 + 0 = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = x^2e^{5x}</m>: <m>y' = 2xe^{5x} + 5x^2e^{5x}</m>, <m>y'' = 2e^{5x} + 10xe^{5x} + 10xe^{5x} + 25x^2e^{5x} = (2 + 20x + 25x^2)e^{5x}</m>. Then <m>y'' - 10y' + 25y = (2 + 20x + 25x^2)e^{5x} - 10(2x + 5x^2)e^{5x} + 25x^2e^{5x} = 2e^{5x} \neq 0</m>. <term>Not a solution.</term></p></li>
+								<li><p><m>y = e^{5x}</m>: <m>y' = 5e^{5x}</m>, <m>y'' = 25e^{5x}</m>, so <m>y'' - 10y' + 25y = 25e^{5x} - 50e^{5x} + 25e^{5x} = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = 5x</m>: <m>y' = 5</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 50 + 125x \neq 0</m>. <term>Not a solution.</term></p></li>
+								<li><p><m>y = xe^{5x}</m>: <m>y' = e^{5x} + 5xe^{5x}</m>, <m>y'' = 5e^{5x} + 5e^{5x} + 25xe^{5x} = (10 + 25x)e^{5x}</m>, so <m>y'' - 10y' + 25y = (10 + 25x)e^{5x} - 10(1 + 5x)e^{5x} + 25xe^{5x} = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = 5e^{5x}</m>: <m>y' = 25e^{5x}</m>, <m>y'' = 125e^{5x}</m>, so <m>y'' - 10y' + 25y = 125e^{5x} - 250e^{5x} + 125e^{5x} = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = 1/25</m>: <m>y' = 0</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 0 + 1 = 1 \neq 0</m>. <term>Not a solution.</term></p></li>
+								<li><p><m>y = e^{-5x}</m>: <m>y' = -5e^{-5x}</m>, <m>y'' = 25e^{-5x}</m>, so <m>y'' - 10y' + 25y = 25e^{-5x} + 50e^{-5x} + 25e^{-5x} = 100e^{-5x} \neq 0</m>. <term>Not a solution.</term></p></li>
+								<li><p><m>y = (1+x)e^{5x}</m>: <m>y' = e^{5x} + 5(1+x)e^{5x} = (1 + 5 + 5x)e^{5x} = (6 + 5x)e^{5x}</m>, <m>y'' = 5e^{5x} + 5(6 + 5x)e^{5x} = (5 + 30 + 25x)e^{5x} = (35 + 25x)e^{5x}</m>. Then <m>y'' - 10y' + 25y = (35 + 25x)e^{5x} - 10(6 + 5x)e^{5x} + 25(1+x)e^{5x} = 0</m>. <term>Solution.</term></p></li>
+							</ul>
+						</p>
+					</solution>
 					<answer>
 						<sidebyside width="30%">
 							<p>
@@ -920,6 +952,35 @@
 						</pg-code>
 						<statement><p><m>y'' - y' - 12y =</m> <var name="$rhs" width="10" /></p></statement>
 					</webwork>
+					<solution>
+						<p>
+							Find <m>y'</m> and <m>y''</m>:
+							<md>
+								<mrow>	y	\amp = 2e^{-3t} </mrow>
+								<mrow>	y' 	\amp = 2e^{-3t} \cdot (-3) = -6e^{-3t} </mrow>
+								<mrow>	y'' \amp = -6e^{-3t} \cdot (-3) = 18e^{-3t} </mrow>
+							</md>
+							and plug them in:
+							<md>
+								<mrow> 												
+									y'' - y' - 12y
+									\amp = 18e^{-3t} - (-6e^{-3t}) - 12(2e^{-3t})
+								</mrow>
+								<mrow>
+									\amp = 18e^{-3t} + 6e^{-3t} - 24e^{-3t}
+								</mrow>
+								<mrow>
+									\amp = 0
+								</mrow>
+							</md>
+							Therefore, the differential equation must be <m>y'' - y' - 12y = 0</m>.
+						</p>
+					</solution>
+					<answer>
+						<p>
+							<m>0</m>
+						</p>
+					</answer>
 				</exercise>
 
 				<exercise label="solns-drills-05">
@@ -967,7 +1028,7 @@
 				</exercise>
 			</exercisegroup>
 		</exercises>
-	</subsection> -->
+	</subsection>
 
 	<!-- <subsection label="solns-problems-main">
 		<title><e component="emoji">✍🏻</e> Problems </title>
@@ -1617,60 +1678,6 @@
 						<p>
 							Since <m>y = 3x^2 - 2x + 1</m> satisfies both the differential equation and the initial condition, it is a particular solution to the initial-value problem.
 						</p>
-					</solution>
-				</exercise>
-
-				<exercise label="solns-ex-ivp-04">
-					<statement>
-						<p>
-							Show <m>y = -3e^{x^2} + 3</m> is a particular solution to
-							<md>
-								\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0
-							</md>.
-						</p>
-					</statement>
-					<answer><p>Yes.</p></answer>
-					<solution>
-						<p>
-							To verify that the function <m>y = -3e^{x^2} + 3</m> is a particular solution to the initial-value problem <md>\frac{dy}{dx} = 2xy - 6x, \qquad y(0) = 0</md>, we must show the following two things:
-						</p>
-
-						<p>
-							<ul marker="square">
-								<li>
-									<p>
-										<m>y = -3e^{x^2} + 3</m> satisfies the differential equation.
-									</p>
-								</li>
-								<li>
-									<p>
-										<m>y = -3e^{x^2} + 3</m> satisfies the initial condition.
-									</p>
-								</li>
-							</ul>
-						</p>
-
-						<p>
-							Let's start by showing that the function <m>y = -3e^{x^2} + 3</m> satisfies the differential equation.
-							<md>
-								<mrow>							\frac{dy}{dx}	\amp = 2xy - 6x					</mrow>
-								<mrow>	\frac{d}{dx}\left[-3e^{x^2} + 3\right]	\amp = 2x(-3e^{x^2} + 3) - 6x	</mrow>
-								<mrow>	-3\frac{d}{dx}\left[e^{x^2}\right]+ 0	\amp = -6xe^{x^2} + 6x - 6x		</mrow>
-								<mrow>			-3\left(e^{x^2} \cdot 2x\right)	\amp = -6xe^{x^2}				</mrow>
-								<mrow>								-6xe^{x^2}	\amp = -6xe^{x^2}\quad <e component="emoji">✅</e>		  </mrow>
-							</md>
-						</p>
-						
-						<p>
-							Now, let's show that the function satisfies the initial condition <m>y(0) = 0</m>.
-							<md>
-								<mrow>	y(0)	\amp = -3e^{0^2} + 3	</mrow>
-								<mrow>		0	\amp = -3e^0 + 3		</mrow>
-								<mrow>		0	\amp = -3 + 3			</mrow>
-								<mrow>		0	\amp = 0\quad <e component="emoji">✅</e>		  </mrow>
-							</md>
-						</p>
-
 					</solution>
 				</exercise>
 

--- a/source/c2-solns/exercises-solns.ptx
+++ b/source/c2-solns/exercises-solns.ptx
@@ -831,15 +831,15 @@
 						<p>
 							To verify if a function is a solution, we need to compute <m>y''</m> and check if <m>y'' - 9y = 0</m>.
 							<ul>
-								<li><p><m>y = 3</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 27 = -27 \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = 0</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 0 = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = e^{3x}</m>: <m>y'' = 9e^{3x}</m>, so <m>y'' - 9y = 9e^{3x} - 9e^{3x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = 3x</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 27x = -27x \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = 9e^x</m>: <m>y'' = 9e^x</m>, so <m>y'' - 9y = 9e^x - 81e^x = -72e^x \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = x^9</m>: <m>y'' = 72x^7</m>, so <m>y'' - 9y = 72x^7 - 9x^9 \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = 4e^{3x}</m>: <m>y'' = 36e^{3x}</m>, so <m>y'' - 9y = 36e^{3x} - 36e^{3x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = e^{-3x}</m>: <m>y'' = 9e^{-3x}</m>, so <m>y'' - 9y = 9e^{-3x} - 9e^{-3x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = e^{3x} - 2e^{-3x}</m>: <m>y'' = 9e^{3x} - 18e^{-3x}</m>, so <m>y'' - 9y = (9e^{3x} - 18e^{-3x}) - 9(e^{3x} - 2e^{-3x}) = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = 3</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 27 = -27 \neq 0</m>. <em>Not a solution.</em></p></li>
+								<li><p><m>y = 0</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 0 = 0</m>. <em>Solution.</em></p></li>
+								<li><p><m>y = e^{3x}</m>: <m>y'' = 9e^{3x}</m>, so <m>y'' - 9y = 9e^{3x} - 9e^{3x} = 0</m>. <em>Solution.</em></p></li>
+								<li><p><m>y = 3x</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 27x = -27x \neq 0</m>. <em>Not a solution.</em></p></li>
+								<li><p><m>y = 9e^x</m>: <m>y'' = 9e^x</m>, so <m>y'' - 9y = 9e^x - 81e^x = -72e^x \neq 0</m>. <em>Not a solution.</em></p></li>
+								<li><p><m>y = x^9</m>: <m>y'' = 72x^7</m>, so <m>y'' - 9y = 72x^7 - 9x^9 \neq 0</m>. <em>Not a solution.</em></p></li>
+								<li><p><m>y = 4e^{3x}</m>: <m>y'' = 36e^{3x}</m>, so <m>y'' - 9y = 36e^{3x} - 36e^{3x} = 0</m>. <em>Solution.</em></p></li>
+								<li><p><m>y = e^{-3x}</m>: <m>y'' = 9e^{-3x}</m>, so <m>y'' - 9y = 9e^{-3x} - 9e^{-3x} = 0</m>. <em>Solution.</em></p></li>
+								<li><p><m>y = e^{3x} - 2e^{-3x}</m>: <m>y'' = 9e^{3x} - 18e^{-3x}</m>, so <m>y'' - 9y = (9e^{3x} - 18e^{-3x}) - 9(e^{3x} - 2e^{-3x}) = 0</m>. <em>Solution.</em></p></li>
 							</ul>
 						</p>
 					</solution>
@@ -894,15 +894,15 @@
 						<p>
 							To verify if a function is a solution, we need to compute <m>y'</m> and <m>y''</m> and check if <m>y'' - 10y' + 25y = 0</m>.
 							<ul>
-								<li><p><m>y = 0</m>: <m>y' = 0</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 0 + 0 = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = x^2e^{5x}</m>: <m>y' = 2xe^{5x} + 5x^2e^{5x}</m>, <m>y'' = 2e^{5x} + 10xe^{5x} + 10xe^{5x} + 25x^2e^{5x} = (2 + 20x + 25x^2)e^{5x}</m>. Then <m>y'' - 10y' + 25y = (2 + 20x + 25x^2)e^{5x} - 10(2x + 5x^2)e^{5x} + 25x^2e^{5x} = 2e^{5x} \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = e^{5x}</m>: <m>y' = 5e^{5x}</m>, <m>y'' = 25e^{5x}</m>, so <m>y'' - 10y' + 25y = 25e^{5x} - 50e^{5x} + 25e^{5x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = 5x</m>: <m>y' = 5</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 50 + 125x \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = xe^{5x}</m>: <m>y' = e^{5x} + 5xe^{5x}</m>, <m>y'' = 5e^{5x} + 5e^{5x} + 25xe^{5x} = (10 + 25x)e^{5x}</m>, so <m>y'' - 10y' + 25y = (10 + 25x)e^{5x} - 10(1 + 5x)e^{5x} + 25xe^{5x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = 5e^{5x}</m>: <m>y' = 25e^{5x}</m>, <m>y'' = 125e^{5x}</m>, so <m>y'' - 10y' + 25y = 125e^{5x} - 250e^{5x} + 125e^{5x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = 1/25</m>: <m>y' = 0</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 0 + 1 = 1 \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = e^{-5x}</m>: <m>y' = -5e^{-5x}</m>, <m>y'' = 25e^{-5x}</m>, so <m>y'' - 10y' + 25y = 25e^{-5x} + 50e^{-5x} + 25e^{-5x} = 100e^{-5x} \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = (1+x)e^{5x}</m>: <m>y' = e^{5x} + 5(1+x)e^{5x} = (1 + 5 + 5x)e^{5x} = (6 + 5x)e^{5x}</m>, <m>y'' = 5e^{5x} + 5(6 + 5x)e^{5x} = (5 + 30 + 25x)e^{5x} = (35 + 25x)e^{5x}</m>. Then <m>y'' - 10y' + 25y = (35 + 25x)e^{5x} - 10(6 + 5x)e^{5x} + 25(1+x)e^{5x} = 0</m>. <term>Solution.</term></p></li>
+								<li><p><m>y = 0</m>: <m>y' = 0</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 0 + 0 = 0</m>. <em>Solution.</em></p></li>
+								<li><p><m>y = x^2e^{5x}</m>: <m>y' = 2xe^{5x} + 5x^2e^{5x}</m>, <m>y'' = 2e^{5x} + 10xe^{5x} + 10xe^{5x} + 25x^2e^{5x} = (2 + 20x + 25x^2)e^{5x}</m>. Then <m>y'' - 10y' + 25y = (2 + 20x + 25x^2)e^{5x} - 10(2x + 5x^2)e^{5x} + 25x^2e^{5x} = 2e^{5x} \neq 0</m>. <em>Not a solution.</em></p></li>
+								<li><p><m>y = e^{5x}</m>: <m>y' = 5e^{5x}</m>, <m>y'' = 25e^{5x}</m>, so <m>y'' - 10y' + 25y = 25e^{5x} - 50e^{5x} + 25e^{5x} = 0</m>. <em>Solution.</em></p></li>
+								<li><p><m>y = 5x</m>: <m>y' = 5</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 50 + 125x \neq 0</m>. <em>Not a solution.</em></p></li>
+								<li><p><m>y = xe^{5x}</m>: <m>y' = e^{5x} + 5xe^{5x}</m>, <m>y'' = 5e^{5x} + 5e^{5x} + 25xe^{5x} = (10 + 25x)e^{5x}</m>, so <m>y'' - 10y' + 25y = (10 + 25x)e^{5x} - 10(1 + 5x)e^{5x} + 25xe^{5x} = 0</m>. <em>Solution.</em></p></li>
+								<li><p><m>y = 5e^{5x}</m>: <m>y' = 25e^{5x}</m>, <m>y'' = 125e^{5x}</m>, so <m>y'' - 10y' + 25y = 125e^{5x} - 250e^{5x} + 125e^{5x} = 0</m>. <em>Solution.</em></p></li>
+								<li><p><m>y = 1/25</m>: <m>y' = 0</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 0 + 1 = 1 \neq 0</m>. <em>Not a solution.</em></p></li>
+								<li><p><m>y = e^{-5x}</m>: <m>y' = -5e^{-5x}</m>, <m>y'' = 25e^{-5x}</m>, so <m>y'' - 10y' + 25y = 25e^{-5x} + 50e^{-5x} + 25e^{-5x} = 100e^{-5x} \neq 0</m>. <em>Not a solution.</em></p></li>
+								<li><p><m>y = (1+x)e^{5x}</m>: <m>y' = e^{5x} + 5(1+x)e^{5x} = (1 + 5 + 5x)e^{5x} = (6 + 5x)e^{5x}</m>, <m>y'' = 5e^{5x} + 5(6 + 5x)e^{5x} = (5 + 30 + 25x)e^{5x} = (35 + 25x)e^{5x}</m>. Then <m>y'' - 10y' + 25y = (35 + 25x)e^{5x} - 10(6 + 5x)e^{5x} + 25(1+x)e^{5x} = 0</m>. <em>Solution.</em></p></li>
 							</ul>
 						</p>
 					</solution>

--- a/source/c3-di/exercises-di.ptx
+++ b/source/c3-di/exercises-di.ptx
@@ -511,240 +511,150 @@
 		<exercises label="di-drills">
 
 			<exercisegroup>
-				<title>Select the Solutions</title>
+				<title>Select the General Solution</title>
 
 				<introduction>
 					<p>
-						For each differential equation, select the functions that are solutions to that equation.
+						Each equation is already in the form <m>\dfrac{dy}{dx} = f(x)</m>, so it can be solved by direct integration. Select its general solution&#8212;and don't forget the constant of integration.
 					</p>
 				</introduction>
 
-				<exercise label="di-warm-ups-click-01"><title><m> y''-9y = 0</m></title>
-					<statement/>
-					<areas>
-						<p>
-							<sidebyside width="30%">
-								<p>
-									<line><area correct="no">	a. <m>\ \ y = 3</m>		</area></line>
-									<line><area correct="yes">	b. <m>\ \ y = 0</m>		</area></line>
-									<line><area correct="yes">	c. <m>\ \ y = e^{3x}</m>	</area></line>
-								</p>
-								<p>
-									<line><area correct="no">	d. <m>\ \ y = 3x</m>	</area></line>
-									<line><area correct="no">	e. <m>\ \ y = 9e^x</m>	</area></line>
-									<line><area correct="no">	f. <m>\ \ y = x^9</m>	</area></line>
-								</p>
-								<p>
-									<line><area correct="yes">	g. <m>\ \ y = 4e^{3x}</m>				</area></line>
-									<line><area correct="yes">	h. <m>\ \ y = e^{-3x}</m>				</area></line>
-									<line><area correct="yes">	i. <m>\ \ y = e^{3x} - 2e^{-3x}</m>	</area></line>
-								</p>
-							</sidebyside>
-						</p>
-					</areas>
-					<solution>
-						<p>
-							To verify if a function is a solution, we need to compute <m>y''</m> and check if <m>y'' - 9y = 0</m>.
-							<ul>
-								<li><p><m>y = 3</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 27 = -27 \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = 0</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 0 = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = e^{3x}</m>: <m>y'' = 9e^{3x}</m>, so <m>y'' - 9y = 9e^{3x} - 9e^{3x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = 3x</m>: <m>y'' = 0</m>, so <m>y'' - 9y = 0 - 27x = -27x \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = 9e^x</m>: <m>y'' = 9e^x</m>, so <m>y'' - 9y = 9e^x - 81e^x = -72e^x \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = x^9</m>: <m>y'' = 72x^7</m>, so <m>y'' - 9y = 72x^7 - 9x^9 \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = 4e^{3x}</m>: <m>y'' = 36e^{3x}</m>, so <m>y'' - 9y = 36e^{3x} - 36e^{3x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = e^{-3x}</m>: <m>y'' = 9e^{-3x}</m>, so <m>y'' - 9y = 9e^{-3x} - 9e^{-3x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = e^{3x} - 2e^{-3x}</m>: <m>y'' = 9e^{3x} - 18e^{-3x}</m>, so <m>y'' - 9y = (9e^{3x} - 18e^{-3x}) - 9(e^{3x} - 2e^{-3x}) = 0</m>. <term>Solution.</term></p></li>
-							</ul>
-						</p>
-					</solution>
-					<answer>
-						<p>
-							<sidebyside width="30%">
-							<p>
-								<line> a. No </line>
-								<line> b. Yes </line>
-								<line> c. Yes </line>
-							</p>
-							<p>
-								<line> d. No </line>
-								<line> e. No </line>
-								<line> f. No </line>
-							</p>
-							<p>
-								<line> g. Yes </line>
-								<line> h. Yes </line>
-								<line> i. Yes </line>
-							</p>
-						</sidebyside>
-						</p>
-					</answer>
+				<exercise>
+					<title><m>\dfrac{dy}{dx} = 6x^2</m></title>
+					<statement>
+						<p><m>\dfrac{dy}{dx} = 6x^2</m></p>
+					</statement>
+					<choices randomize="yes">
+						<choice correct="yes">
+							<statement><p><m>y = 2x^3 + C</m></p></statement>
+							<feedback><p>Correct! <m>\int 6x^2\,dx = 6\cdot\dfrac{x^3}{3} + C = 2x^3 + C</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = 6x^3 + C</m></p></statement>
+							<feedback><p>Check the power rule: <m>\int 6x^2\,dx = 6\cdot\dfrac{x^3}{3} = 2x^3</m>, not <m>6x^3</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = 2x^3</m></p></statement>
+							<feedback><p>The antiderivative is right, but every general solution needs an arbitrary constant <m>+\,C</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = 12x + C</m></p></statement>
+							<feedback><p>That is the <em>derivative</em> of <m>6x^2</m>. Direct integration asks for the antiderivative.</p></feedback>
+						</choice>
+					</choices>
 				</exercise>
-				
-				<exercise label="di-warm-ups-click-02"><title><m>y'' - 10y' + 25y = 0</m></title>
-					<statement/>
-					<areas>
-						<p>
-							<sidebyside width="30%">
-								<p>
-									<line><area correct="yes">	a. <m>\ \ y = 0</m>			</area></line>
-									<line><area correct="no">	b. <m>\ \ y = x^2e^{5x}</m>	</area></line>
-									<line><area correct="yes">	c. <m>\ \ y = e^{5x}</m>		</area></line>
-								</p>
-								<p>
-									<line><area correct="no">	d. <m>\ \ y = 5x</m>		</area></line>
-									<line><area correct="yes">	e. <m>\ \ y = xe^{5x}</m>	</area></line>
-									<line><area correct="yes">	f. <m>\ \ y = 5e^{5x}</m>	</area></line>
-								</p>
-								<p>
-									<line><area correct="no">	g. <m>\ \ y = 1/25</m>			</area></line>
-									<line><area correct="no">	h. <m>\ \ y = e^{-5x}</m>		</area></line>
-									<line><area correct="yes">	i. <m>\ \ y = (1+x)e^{5x}</m>	</area></line>
-								</p>
-							</sidebyside>
-						</p>
-					</areas>
-					<solution>
-						<p>
-							To verify if a function is a solution, we need to compute <m>y'</m> and <m>y''</m> and check if <m>y'' - 10y' + 25y = 0</m>.
-							<ul>
-								<li><p><m>y = 0</m>: <m>y' = 0</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 0 + 0 = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = x^2e^{5x}</m>: <m>y' = 2xe^{5x} + 5x^2e^{5x}</m>, <m>y'' = 2e^{5x} + 10xe^{5x} + 10xe^{5x} + 25x^2e^{5x} = (2 + 20x + 25x^2)e^{5x}</m>. Then <m>y'' - 10y' + 25y = (2 + 20x + 25x^2)e^{5x} - 10(2x + 5x^2)e^{5x} + 25x^2e^{5x} = 2e^{5x} \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = e^{5x}</m>: <m>y' = 5e^{5x}</m>, <m>y'' = 25e^{5x}</m>, so <m>y'' - 10y' + 25y = 25e^{5x} - 50e^{5x} + 25e^{5x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = 5x</m>: <m>y' = 5</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 50 + 125x \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = xe^{5x}</m>: <m>y' = e^{5x} + 5xe^{5x}</m>, <m>y'' = 5e^{5x} + 5e^{5x} + 25xe^{5x} = (10 + 25x)e^{5x}</m>, so <m>y'' - 10y' + 25y = (10 + 25x)e^{5x} - 10(1 + 5x)e^{5x} + 25xe^{5x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = 5e^{5x}</m>: <m>y' = 25e^{5x}</m>, <m>y'' = 125e^{5x}</m>, so <m>y'' - 10y' + 25y = 125e^{5x} - 250e^{5x} + 125e^{5x} = 0</m>. <term>Solution.</term></p></li>
-								<li><p><m>y = 1/25</m>: <m>y' = 0</m>, <m>y'' = 0</m>, so <m>y'' - 10y' + 25y = 0 - 0 + 1 = 1 \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = e^{-5x}</m>: <m>y' = -5e^{-5x}</m>, <m>y'' = 25e^{-5x}</m>, so <m>y'' - 10y' + 25y = 25e^{-5x} + 50e^{-5x} + 25e^{-5x} = 100e^{-5x} \neq 0</m>. <term>Not a solution.</term></p></li>
-								<li><p><m>y = (1+x)e^{5x}</m>: <m>y' = e^{5x} + 5(1+x)e^{5x} = (1 + 5 + 5x)e^{5x} = (6 + 5x)e^{5x}</m>, <m>y'' = 5e^{5x} + 5(6 + 5x)e^{5x} = (5 + 30 + 25x)e^{5x} = (35 + 25x)e^{5x}</m>. Then <m>y'' - 10y' + 25y = (35 + 25x)e^{5x} - 10(6 + 5x)e^{5x} + 25(1+x)e^{5x} = 0</m>. <term>Solution.</term></p></li>
-							</ul>
-						</p>
-					</solution>
-					<answer>
-						<p>
-							<p>
-							<sidebyside width="30%">
-								<p>
-									<line> a. Yes </line>
-									<line> b. No </line>
-									<line> c. Yes </line>
-								</p>
-								<p>
-									<line> d. No </line>
-									<line> e. Yes </line>
-									<line> f. Yes </line>
-								</p>
-								<p>
-									<line> g. No </line>
-									<line> h. No </line>
-									<line> i. Yes </line>
-								</p>
-							</sidebyside>
-						</p>
-						</p>
-					</answer>
+
+				<exercise>
+					<title><m>\dfrac{dy}{dx} = e^{4x}</m></title>
+					<statement>
+						<p><m>\dfrac{dy}{dx} = e^{4x}</m></p>
+					</statement>
+					<choices randomize="yes">
+						<choice correct="yes">
+							<statement><p><m>y = \dfrac{1}{4}e^{4x} + C</m></p></statement>
+							<feedback><p>Correct! <m>\int e^{4x}\,dx = \dfrac{1}{4}e^{4x} + C</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = e^{4x} + C</m></p></statement>
+							<feedback><p>Almost&#8212;differentiating <m>e^{4x}</m> brings down a factor of <m>4</m>, so integrating divides by <m>4</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = 4e^{4x} + C</m></p></statement>
+							<feedback><p>Integrating <m>e^{4x}</m> divides by <m>4</m>; it does not multiply by <m>4</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = \dfrac{1}{4}e^{4x}</m></p></statement>
+							<feedback><p>Right form, but don't forget the <m>+\,C</m>.</p></feedback>
+						</choice>
+					</choices>
+				</exercise>
+
+				<exercise>
+					<title><m>\dfrac{dy}{dx} = \sin(3x)</m></title>
+					<statement>
+						<p><m>\dfrac{dy}{dx} = \sin(3x)</m></p>
+					</statement>
+					<choices randomize="yes">
+						<choice correct="yes">
+							<statement><p><m>y = -\dfrac{1}{3}\cos(3x) + C</m></p></statement>
+							<feedback><p>Correct! <m>\int \sin(3x)\,dx = -\dfrac{1}{3}\cos(3x) + C</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = \dfrac{1}{3}\cos(3x) + C</m></p></statement>
+							<feedback><p>Sign slip: <m>\int \sin u\,du = -\cos u</m>, so the answer is <m>-\dfrac{1}{3}\cos(3x) + C</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = -3\cos(3x) + C</m></p></statement>
+							<feedback><p>The inner factor of <m>3</m> means you divide by <m>3</m>, not multiply.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = -\dfrac{1}{3}\cos(3x)</m></p></statement>
+							<feedback><p>Right form, but include the <m>+\,C</m>.</p></feedback>
+						</choice>
+					</choices>
+				</exercise>
+
+				<exercise>
+					<title><m>\dfrac{dy}{dx} = \dfrac{1}{x}</m></title>
+					<statement>
+						<p><m>\dfrac{dy}{dx} = \dfrac{1}{x}</m></p>
+					</statement>
+					<choices randomize="yes">
+						<choice correct="yes">
+							<statement><p><m>y = \ln|x| + C</m></p></statement>
+							<feedback><p>Correct! <m>\int \dfrac{1}{x}\,dx = \ln|x| + C</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = -\dfrac{1}{x^2} + C</m></p></statement>
+							<feedback><p>The antiderivative of <m>\frac{1}{x}</m> is a logarithm, not a power&#8212;the power rule does not apply when the exponent is <m>-1</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = x\ln|x| + C</m></p></statement>
+							<feedback><p>That is not the antiderivative of <m>\frac{1}{x}</m>; <m>\int \frac{1}{x}\,dx = \ln|x| + C</m>.</p></feedback>
+						</choice>
+						<choice>
+							<statement><p><m>y = \ln|x|</m></p></statement>
+							<feedback><p>Right function, but don't drop the <m>+\,C</m>.</p></feedback>
+						</choice>
+					</choices>
 				</exercise>
 			</exercisegroup>
 
 			<exercisegroup>
-				<title>Find the Hidden Right-Hand Side</title>
+				<title>Integrate a Completed Derivative</title>
 
 				<introduction>
 					<p>
-						For each given <m>y(t)</m>, assume it is a solution to the differential equation with a hidden right side. Give the function that must be on the right for <m>y</m> to be a solution to the equation.
+						In each equation the left side is already written as a single derivative. Integrate both sides, then solve for <m>y</m>.
 					</p>
 				</introduction>
-			
-				<exercise label="di-warm-ups-ww-01">
-					<title>🕸️ <m>\ y(t) = 2e^{-3t}</m></title>
-					<webwork xml:id="di-warm-ups-ww-1-id">		
-						<description>Find the hidden right-hand side.</description>
-						<pg-code>
-							Context()->variables->add(y => 'Real');
-							Context()->variables->add(t => 'Real');
-							$y = Formula("2*e^(-3*t)");
-							#$yp = $y->D('t');
-							#$ypp = $yp->D('t');
-							#$rhs = Formula("$ypp - $yp - 12*$y");
-							$rhs = Formula("0");
-						</pg-code>
-						<statement><p><m>y'' - y' - 12y =</m> <var name="$rhs" width="10" /></p></statement>
-					</webwork>
+
+				<exercise>
+					<statement><p><m>\dfrac{d}{dx}\left[x^2 y\right] = 8x^3</m></p></statement>
 					<solution>
 						<p>
-							Find <m>y'</m> and <m>y''</m>:
+							Integrate both sides with respect to <m>x</m>:
 							<md>
-								<mrow>	y	\amp = 2e^{-3t} </mrow>
-								<mrow>	y' 	\amp = 2e^{-3t} \cdot (-3) = -6e^{-3t} </mrow>
-								<mrow>	y'' \amp = -6e^{-3t} \cdot (-3) = 18e^{-3t} </mrow>
+								<mrow>x^2 y \amp = \int 8x^3\,dx = 2x^4 + C</mrow>
+								<mrow>y \amp = 2x^2 + \dfrac{C}{x^2}</mrow>
 							</md>
-							and plug them in:
-							<md>
-								<mrow> 												
-									y'' - y' - 12y
-									\amp = 18e^{-3t} - (-6e^{-3t}) - 12(2e^{-3t})
-								</mrow>
-								<mrow>
-									\amp = 18e^{-3t} + 6e^{-3t} - 24e^{-3t}
-								</mrow>
-								<mrow>
-									\amp = 0
-								</mrow>
-							</md>
-							Therefore, the differential equation must be <m>y'' - y' - 12y = 0</m>.
 						</p>
 					</solution>
-					<answer>
-						<p>
-							<m>0</m>
-						</p>
-					</answer>
+					<answer><p><m>y = 2x^2 + \dfrac{C}{x^2}</m></p></answer>
 				</exercise>
 
-				<exercise label="di-warm-ups-ww-02">
-					<title>🕸️ <m>\ y(t) = 3\sin(t^2)</m></title>
-					<webwork xml:id="di-warm-ups-ww-2-id">
-						<description>Find the hidden right-hand side.</description>
-						<pg-code>
-							Context()->variables->add(y => 'Real');
-							Context()->variables->add(t => 'Real');
-							#$y = Formula("3*sin(t^2)");
-							#$yp = $y->D('t');
-							#$ypp = $yp->D('t');
-							#$rhs = Formula("$yp - t*$ypp");
-							$rhs = Formula("12*t^3*sin(t^2)");
-						</pg-code>
-						<statement><p><m>y' - ty'' =</m> <var name="$rhs" width="10" /></p></statement>
-					</webwork>
+				<exercise>
+					<statement><p><m>\dfrac{d}{dx}\left[e^x y\right] = e^x</m></p></statement>
 					<solution>
 						<p>
-							Find <m>y'</m> and <m>y''</m>:
+							Integrate both sides with respect to <m>x</m>:
 							<md>
-								<mrow>	y	\amp = 3\sin(t^2) </mrow>
-								<mrow>	y' 	\amp = 3\cos(t^2) \cdot 2t = 6t\cos(t^2) </mrow>
-								<mrow>	y'' \amp = 6\cos(t^2) - 6t\sin(t^2)(2t)	= 6\cos(t^2) - 12t^2\sin(t^2) </mrow>
+								<mrow>e^x y \amp = \int e^x\,dx = e^x + C</mrow>
+								<mrow>y \amp = 1 + Ce^{-x}</mrow>
 							</md>
-							and plug them in:
-							<md>
-								<mrow> 												
-									y' - ty''
-									\amp = 6t\cos(t^2) - t\left( 6\cos(t^2) - 12t^2\sin(t^2) \right)																
-								</mrow>
-								<mrow>
-									\amp = \cancel{6t\cos(t^2)} - \cancel{6t\cos(t^2)} + 12t^3\sin(t^2)
-								</mrow>
-								<mrow>
-									\amp = 12t^3\sin(t^2)
-								</mrow>
-							</md>
-							Therefore, the differential equation must be <m>y' - ty'' =  12t^3\sin(t^2)</m>.
 						</p>
 					</solution>
-					<answer>
-						<p>
-							<m>12t^3\sin(t^2)</m>
-						</p>
-					</answer>
+					<answer><p><m>y = 1 + Ce^{-x}</m></p></answer>
 				</exercise>
 			</exercisegroup>
 


### PR DESCRIPTION
Implements audit task **H10** — removing duplicated exercises, restoring chapter-appropriate scope, and reserving the practice/end-of-chapter tiers for genuinely new content. Five distinct duplication clusters were mapped (via parallel investigation) across chapters 0–3 and 11, then fixed.

## What this changes

**Chapter 11** (`71fdedc`) — the eleven consecutive drills all titled "Select the Inverse" were *distinct* problems, so each gets a descriptive title reflecting the form it tests. Along the way:
- `ltm-drill-06` was mislabeled — it asks for a *forward* transform of `e^{3t}` — retitled "Select the Forward Transform".
- The composite drill `Y(s)=4/((s-2)^2+16)+2/(s+7)^5` had its first answer block copy-pasted from another exercise (wrong expression and result). Corrected to `e^{2t}sin(4t)`, with a CAS regression guard.
- (The audit's "derivation printed twice" erratum for this chapter was already resolved by the earlier H1 commit `6be8ad7`; nothing remained to remove.)

**Chapters 2 ↔ 3** (`4625117`) — Chapter 3 (Direct Integration) carried four *live* second-order drills (verify-a-solution and find-the-hidden-RHS), out of scope for a first-order chapter, and duplicated (commented out) in Chapter 2.
- **Chapter 2**: activate the Practice Drills subsection and merge the worked solutions from the Chapter 3 copies into `solns-drills-02/-03/-04`, so the verify-a-solution drills live (complete) in the chapter about solutions. Also removed the duplicated IVP-verification exercise from that set.
- **Chapter 3**: replace the out-of-scope block with new first-order direct-integration drills — a "Select the General Solution" multiple-choice group (`dy/dx = f(x)`, distractors targeting common integration slips) and an "Integrate a Completed Derivative" short-answer group. Every new answer is CAS-verified and guarded.

**Chapters 0 & 1** (`be342aa`) — five end-of-chapter exercises reproduced a reading checkpoint verbatim. Each is rewritten as a fresh variant that tests the same skill with new content (derivative-notation T/F, unknown-function MC, coefficient MC, order MC, and a new 3×3 linear/nonlinear grid), leaving the in-context checkpoints and the four near-verbatim variants untouched. Every affected exercise's **shared solution/answer key** is re-synced to match.

## Verification

- **Every new or corrected printed answer is CAS-verified** and added to the `verify-worked-math` regression registry — **96/96 checks pass**.
- Source validation passes (well-formedness, id uniqueness, placeholder baseline).
- New/changed content mini-builds to HTML cleanly; every linear/nonlinear classification in the new grid was re-checked by hand.
- No cross-references point at the removed Chapter 3 exercises; the in-context checkpoints in `sec-*.ptx` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vhHaJjo1fdpi2TBj7VMCc

---
_Generated by [Claude Code](https://claude.ai/code/session_018vhHaJjo1fdpi2TBj7VMCc)_