### PR TITLE
H17: add reading checkpoints to the under-covered sections

### DIFF
--- a/source/c2-solns/sec-verifying-solns.ptx
+++ b/source/c2-solns/sec-verifying-solns.ptx
@@ -18,6 +18,31 @@
 		<xref ref="gi-verifying-a-solution" text="custom">Verifying</xref> that a given function is a solution to a differential equation amounts to showing that it <xref ref="gi-satisfies" text="custom">satisfies</xref> the equation. This typically involves taking any necessary derivatives of the function, substituting them into the equation, and simplifying both sides to determine whether they match. Here are some examples to illustrate this process.
 	</p>
 
+	<exercise label="verifying-solns-chkpt-1">
+		<title><e component="emoji">📖❓</e> What Verifying Means</title>
+		<statement>
+			<p>To <em>verify</em> that a given function is a solution of a differential equation, what do you do?</p>
+		</statement>
+		<choices randomize="yes">
+			<choice correct="yes">
+				<statement><p>Substitute the function (and any required derivatives) into the equation, then check that both sides simplify to the same thing.</p></statement>
+				<feedback><p>Correct — this is exactly what it means to satisfy the equation.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>Solve the differential equation from scratch and check whether you get the same function back.</p></statement>
+				<feedback><p>Verifying does not require solving; you only substitute and compare.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>Plug in a single value of the independent variable and confirm the two sides agree there.</p></statement>
+				<feedback><p>Agreement at one point is not enough; the two sides must match as functions.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>Confirm the function passes through the origin.</p></statement>
+				<feedback><p>Passing through the origin is unrelated to satisfying the equation.</p></feedback>
+			</choice>
+		</choices>
+	</exercise>
+
 	<example>
 		<statement>
 			<p>
@@ -67,6 +92,31 @@
 		</solution>
 	</example>
 
+	<exercise label="verifying-solns-chkpt-2">
+		<title><e component="emoji">📖❓</e> Does It Satisfy the Equation?</title>
+		<statement>
+			<p>Is <m>y = e^{-3x}</m> a solution of <m>y' + 3y = 0</m>?</p>
+		</statement>
+		<choices randomize="yes">
+			<choice correct="yes">
+				<statement><p>Yes — since <m>y' = -3e^{-3x}</m>, we get <m>y' + 3y = -3e^{-3x} + 3e^{-3x} = 0</m>, so both sides match.</p></statement>
+				<feedback><p>The derivative and substitution both check out, giving <m>0 = 0</m>.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>No — substituting gives <m>6e^{-3x}</m> on the left, not <m>0</m>.</p></statement>
+				<feedback><p>That uses the wrong derivative <m>y' = +3e^{-3x}</m>; the correct derivative is <m>-3e^{-3x}</m>.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>No — a solution must contain an arbitrary constant, and this one does not.</p></statement>
+				<feedback><p>A specific function with no constant can still satisfy the equation, as the earlier examples show.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>Yes, but only at <m>x = 0</m>.</p></statement>
+				<feedback><p>The two sides must agree for all <m>x</m>, and here they do.</p></feedback>
+			</choice>
+		</choices>
+	</exercise>
+
 	<p>
 		As you will soon learn, differential equations have many solutions and all of them share a common form, as the next example shows.
 	</p>
@@ -98,6 +148,31 @@
 			</p>
 		</solution>
 	</example>
+
+	<exercise label="verifying-solns-chkpt-3">
+		<title><e component="emoji">📖❓</e> Why the General Form Works</title>
+		<statement>
+			<p>In the example verifying that <m>y = c\,e^{2x}</m> solves <m>y' - 2y = 0</m>, why does checking the general form show that <m>y = e^{2x}</m>, <m>y = -5e^{2x}</m>, <m>y = \pi e^{2x}</m>, and <m>y = 0</m> are all solutions?</p>
+		</statement>
+		<choices randomize="yes">
+			<choice correct="yes">
+				<statement><p>Each of those is <m>y = c\,e^{2x}</m> for a particular constant (<m>c = 1, -5, \pi, 0</m>), so verifying the general form verifies all of them at once.</p></statement>
+				<feedback><p>One verification of the parameterized form covers every choice of the constant.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>Because every solution of any differential equation is an exponential function.</p></statement>
+				<feedback><p>Not true in general; other examples in this section have polynomial and logarithmic solutions.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>Because a differential equation can have at most four solutions.</p></statement>
+				<feedback><p>Differential equations typically have infinitely many solutions.</p></feedback>
+			</choice>
+			<choice>
+				<statement><p>Because the constant <m>c</m> must equal <m>1</m>.</p></statement>
+				<feedback><p>The verification holds for <em>any</em> constant <m>c</m>, not just <m>c = 1</m>.</p></feedback>
+			</choice>
+		</choices>
+	</exercise>
 
 	<p>
 		As you saw in the previous example, solutions can differ by a constant. Some solutions even involve multiple constants, as the next example shows.

--- a/source/c7-em/sec-euler-method.ptx
+++ b/source/c7-em/sec-euler-method.ptx
@@ -27,6 +27,31 @@
 			Before writing any formulas, it helps to <em>see</em> what Euler's method feels like. Think of Euler's method like crossing a landscape with only a compass. You know where you start. At each step, you check your direction (the slope from the differential equation), take a small stride that way, then check again. That back-and-forth of <q>step, check, adjust</q> is the rhythm of the method.
     </p>
 
+		<exercise label="eulers-method-chkpt-2">
+			<title><e component="emoji">📖❓</e> One Step of Euler's Method</title>
+			<statement>
+				<p>In the <q>step, check, adjust</q> rhythm just described, what does a single step of Euler's method do?</p>
+			</statement>
+			<choices randomize="yes">
+				<choice correct="yes">
+					<statement><p>It checks the current slope (from the differential equation), takes a small stride in that direction, then re-checks the slope at the new point.</p></statement>
+					<feedback><p>This is exactly the <q>check direction, stride, check again</q> rhythm.</p></feedback>
+				</choice>
+				<choice>
+					<statement><p>It follows the exact solution curve to the next point, so no error is introduced.</p></statement>
+					<feedback><p>Each step moves along a straight line, not the true curve, which is why error can accumulate.</p></feedback>
+				</choice>
+				<choice>
+					<statement><p>It uses the slope at the destination point rather than at the current point.</p></statement>
+					<feedback><p>The slope is always taken at the current point before stepping.</p></feedback>
+				</choice>
+				<choice>
+					<statement><p>It advances all the way to the final <m>t</m>-value in a single stride.</p></statement>
+					<feedback><p>One step advances by only <m>h</m>; you repeat the step to cross the interval.</p></feedback>
+				</choice>
+			</choices>
+		</exercise>
+
 		<paragraphs>
 			<title>The Goal</title>
 			
@@ -383,6 +408,31 @@
 			<p>
 				Despite being based on a relatively simple idea, Euler's method reveals something profound: with nothing more than a starting point and slope formula, you can approximate a solution that no closed-form equation could describe.
 			</p>
+
+		<exercise label="eulers-method-chkpt-3">
+			<title><e component="emoji">📖❓</e> One Euler Update</title>
+			<statement>
+				<p>For the initial value problem <m>y' = y + t</m>, <m>y(0) = 1</m> with step size <m>h = 0.5</m>, the update rule is <m>y_{k+1} = y_k + h\,f(t_k, y_k)</m> with <m>f(t, y) = y + t</m>. What is <m>y_1</m>, the approximation at <m>t = 0.5</m>?</p>
+			</statement>
+			<choices randomize="yes">
+				<choice correct="yes">
+					<statement><p><m>1.5</m></p></statement>
+					<feedback><p><m>y_1 = 1 + 0.5\,(1 + 0) = 1.5</m>.</p></feedback>
+				</choice>
+				<choice>
+					<statement><p><m>2.0</m></p></statement>
+					<feedback><p>This forgets to multiply the slope by <m>h</m>: it computes <m>1 + (1+0)</m> instead of <m>1 + 0.5\,(1+0)</m>.</p></feedback>
+				</choice>
+				<choice>
+					<statement><p><m>1.0</m></p></statement>
+					<feedback><p>This uses only <m>t</m> for the slope, <m>1 + 0.5(0)</m>, instead of <m>f = y + t = 1</m>.</p></feedback>
+				</choice>
+				<choice>
+					<statement><p><m>0.5</m></p></statement>
+					<feedback><p>This reports the change <m>h\,f = 0.5</m> rather than the new value <m>y_0 + h\,f</m>.</p></feedback>
+				</choice>
+			</choices>
+		</exercise>
 	</subsection>
 
 	<subsection label="eulers-method-examples">
@@ -653,6 +703,31 @@
 				</p>
 			</solution>
 		</example>
+
+		<exercise label="eulers-method-chkpt-4">
+			<title><e component="emoji">📖❓</e> Effect of Step Size</title>
+			<statement>
+				<p>In Example 2 (<m>y' + 4ty = 0</m>) the true value is <m>y(0.5) \approx 0.6065</m>. Euler's method gave <m>\approx 0.6529</m> with <m>h = 0.1</m> and <m>\approx 0.6069</m> with <m>h = 0.001</m>. What does this illustrate?</p>
+			</statement>
+			<choices randomize="yes">
+				<choice correct="yes">
+					<statement><p>Decreasing the step size <m>h</m> generally makes the approximation more accurate.</p></statement>
+					<feedback><p>The smaller step (<m>0.6069</m>) lands much closer to the true value (<m>0.6065</m>).</p></feedback>
+				</choice>
+				<choice>
+					<statement><p>Increasing the step size <m>h</m> generally makes the approximation more accurate.</p></statement>
+					<feedback><p>The larger step <m>h = 0.1</m> gave the worse estimate (<m>0.6529</m>).</p></feedback>
+				</choice>
+				<choice>
+					<statement><p>The step size has no effect on accuracy.</p></statement>
+					<feedback><p>The two step sizes gave clearly different errors.</p></feedback>
+				</choice>
+				<choice>
+					<statement><p>Euler's method returns the exact value regardless of step size.</p></statement>
+					<feedback><p>Even <m>h = 0.001</m> is only an approximation, not exact.</p></feedback>
+				</choice>
+			</choices>
+		</exercise>
 
 		<p>
 			Euler's method runs on an intuitive idea: use the slope at each point to <q>predict</q> the next point. It's simple, but that simplicity is its strength. This method is often the first stepping stone into the world of <xref ref="gi-numerical-method" text="custom">numerical methods</xref>, and the same <q>predict, step, repeat</q> pattern forms the backbone of many other techniques.


### PR DESCRIPTION
Addresses audit task **H17 — Complete reading checkpoints in uncovered sections**.

## Finding: the audit's "bare sections" list is largely stale

The July audit listed all of ch0 (4 sections), ch1 (3), ch4 (4), plus `sec-verifying-solns` and `sec-euler-method` as barest. Re-counting the **current** state (post the merged H12 markup work) shows most of those already carry `📖❓` reading checkpoints:

- **8 of the listed sections already have 2–3 `📖❓` checkpoints** (e.g. `sec-order`, `sec-linearity`, `sec-showing-separability`, `sec-sov-*`). Adding more would push the early chapters past chs 8–12 density.
- **3 sections** (`sec-terms-coeffs`, `sec-linear-terms`, `sec-separable-form`) have check-your-understanding comprehension exercises (`components-cyu-*`, `order-linearity-cyu-*`, `sov-form-cyu-*`) that are simply **untitled**, so they lack the `📖❓` title cue and don't register — an H12 markup residue, not a density gap. Flagged below rather than changed here.
- **2 sections were genuinely thin** — the ones the audit names specifically — and are fixed in this PR.

## Checkpoints added

**`sec-verifying-solns`** (had zero checkpoints) — 3 new:
- *What Verifying Means* — the substitute-and-compare definition.
- *Does It Satisfy the Equation?* — check `y = e^{-3x}` against `y' + 3y = 0` (distractor built from the mis-signed derivative).
- *Why the General Form Works* — verifying `y = c e^{2x}` covers all its special cases at once.

**`sec-euler-method`** (the chapter's central section; had one cardsort) — 3 new:
- *One Step of Euler's Method* — the step/check/adjust rhythm.
- *One Euler Update* — numeric: `y' = y+t`, `y(0)=1`, `h=0.5` → `y_1 = 1.5` (distractors = dropped-`h`, slope-from-`t`-only, increment-only).
- *Effect of Step Size* — using the section's own Example 2 numbers (`0.6529` at `h=0.1`, `0.6069` at `h=0.001`, true `0.6065`).

All follow the book's existing `📖❓` multiple-choice pattern with per-choice feedback, and each sits after the paragraph/example it checks.

## Verification

- **Every computation CAS-verified (SymPy):** `y=e^{-3x} ⇒ y'+3y=0` (and the `6e^{-3x}` distractor); `y=c e^{2x} ⇒ y'-2y=0`; the Euler update `y_1=1.5` with all three distractor values; `e^{-0.5}≈0.6065`. The Example-2 numbers are quoted directly from the section text.
- `validate_source`: 138/138 parse, build set 97, **1555 unique ids, 0 duplicated**.
- Book **assembles offline** (`xmllint --xinclude`); checkpoint placement checked against the PreTeXt 2.39 schema (`<exercise>`/`<choices>` in the correct block positions — checkpoints inside worked examples go after `</example>`).

## Residual (out of scope, for your call)

`sec-terms-coeffs`, `sec-linear-terms`, `sec-separable-form` have comprehension checkpoints that lack a `📖❓` title. Giving them titles (an H12-style cue fix) would make them register as covered without adding content — happy to do that in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018vhHaJjo1fdpi2TBj7VMCc)_