### PR TITLE
Add alt-text descriptions to all figures and interactives (accessibility)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,8 +26,11 @@ jobs:
             - name: Validate PreTeXt source (well-formedness, ids, placeholders)
               run: python3 processing-tools/validate-source/validate_source.py
 
-            - name: Install SymPy
-              run: pip install sympy
+            - name: Install SymPy and lxml
+              run: pip install sympy lxml
 
             - name: Verify worked mathematics
               run: python3 processing-tools/verify-worked-math/verify_worked_math.py
+
+            - name: Check image/interactive descriptions (accessibility)
+              run: python3 processing-tools/check-descriptions/check_descriptions.py

--- a/processing-tools/check-descriptions/check_descriptions.py
+++ b/processing-tools/check-descriptions/check_descriptions.py
@@ -28,21 +28,29 @@ DESC_TAGS = {"shortdescription", "description"}
 
 
 def reachable_files(start):
-    """Return the ordered set of .ptx files reachable via xi:include from start."""
+    """Return the ordered list of .ptx files reachable via xi:include from start.
+
+    Only ``.ptx`` includes are traversed and counted; ``parse="text"`` includes
+    (``.tex``/``.txt``/Sage code) are skipped so they don't inflate the count.
+    A missing or XML-invalid ``.ptx`` is a hard error, not a silent skip, so the
+    lint can't under-report coverage for a file it failed to read.
+    """
     seen, order, stack = set(), [], [start.resolve()]
     while stack:
         f = stack.pop()
-        if f in seen or not f.exists():
+        if f in seen or f.suffix != ".ptx":
             continue
         seen.add(f)
-        order.append(f)
+        if not f.exists():
+            raise SystemExit(f"error: xi:include target not found: {f}")
         try:
             tree = etree.parse(str(f))
-        except etree.XMLSyntaxError:
-            continue
+        except etree.XMLSyntaxError as e:
+            raise SystemExit(f"error: cannot parse {f}: {e}")
+        order.append(f)
         for inc in tree.iter(XI):
             href = inc.get("href")
-            if href:
+            if href and (f.parent / href).suffix == ".ptx":
                 stack.append((f.parent / href).resolve())
     return order
 

--- a/processing-tools/check-descriptions/check_descriptions.py
+++ b/processing-tools/check-descriptions/check_descriptions.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Accessibility lint: every image and interactive must carry a description.
+
+Walks the build set reachable from ``source/main.ptx`` and flags any
+``<image>`` or ``<interactive>`` that lacks alt text. An element counts as
+described when it has a child ``<shortdescription>`` or ``<description>``, or
+is explicitly marked ``decorative="yes"`` (images only). This keeps the book's
+figures accessible (WCAG/508) and prevents regressions once coverage is met.
+
+Usage
+-----
+    python3 processing-tools/check-descriptions/check_descriptions.py
+    python3 processing-tools/check-descriptions/check_descriptions.py --list   # print every offender
+
+Exit status is non-zero when any reachable image/interactive is undescribed.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from lxml import etree
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAIN = REPO_ROOT / "source" / "main.ptx"
+XI = "{http://www.w3.org/2001/XInclude}include"
+DESC_TAGS = {"shortdescription", "description"}
+
+
+def reachable_files(start):
+    """Return the ordered set of .ptx files reachable via xi:include from start."""
+    seen, order, stack = set(), [], [start.resolve()]
+    while stack:
+        f = stack.pop()
+        if f in seen or not f.exists():
+            continue
+        seen.add(f)
+        order.append(f)
+        try:
+            tree = etree.parse(str(f))
+        except etree.XMLSyntaxError:
+            continue
+        for inc in tree.iter(XI):
+            href = inc.get("href")
+            if href:
+                stack.append((f.parent / href).resolve())
+    return order
+
+
+def has_description(el):
+    return any(child.tag in DESC_TAGS for child in el)
+
+
+def check_file(path):
+    """Yield (lineno, kind, detail) for each undescribed image/interactive."""
+    try:
+        tree = etree.parse(str(path))
+    except etree.XMLSyntaxError:
+        return
+    for el in tree.iter("image"):
+        if el.get("decorative") == "yes" or has_description(el):
+            continue
+        src = el.get("source") or "(latex-image)"
+        yield el.sourceline, "image", src
+    for el in tree.iter("interactive"):
+        if has_description(el):
+            continue
+        yield el.sourceline, "interactive", el.get("xml:id") or el.get("source") or ""
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Lint images/interactives for alt text.")
+    ap.add_argument("--list", action="store_true", help="print every offender (file:line)")
+    args = ap.parse_args()
+
+    files = reachable_files(MAIN)
+    n_img = n_int = off_img = off_int = 0
+    offenders = []
+    for f in files:
+        try:
+            tree = etree.parse(str(f))
+        except etree.XMLSyntaxError:
+            continue
+        n_img += sum(1 for _ in tree.iter("image"))
+        n_int += sum(1 for _ in tree.iter("interactive"))
+        for lineno, kind, detail in check_file(f):
+            offenders.append((f.relative_to(REPO_ROOT), lineno, kind, detail))
+            if kind == "image":
+                off_img += 1
+            else:
+                off_int += 1
+
+    print(f"build set: {len(files)} files reachable from source/main.ptx")
+    print(f"images:       {n_img - off_img}/{n_img} described")
+    print(f"interactives: {n_int - off_int}/{n_int} described")
+
+    if offenders:
+        if args.list:
+            print("\nundescribed:")
+            for rel, line, kind, detail in offenders:
+                print(f"  {rel}:{line}  {kind}  {detail}")
+        print(f"\nFAIL: {len(offenders)} image/interactive element(s) lack a description.")
+        print("Add a <shortdescription> (and optionally <description>), or decorative=\"yes\" for purely decorative images.")
+        return 1
+
+    print("\nall images and interactives are described.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/processing-tools/validate-source/placeholder-baseline.json
+++ b/processing-tools/validate-source/placeholder-baseline.json
@@ -5,12 +5,12 @@
  "source/aa-bookends/a1-algebra/O-interrelated-functions.ptx": 2,
  "source/aa-bookends/a1-algebra/P-units-mass-balance.ptx": 2,
  "source/aa-bookends/back-matter.ptx": 4,
- "source/c12-ltp/sec-unit-step-variants.ptx": 3,
- "source/c13-linsys/sec-qualitative-methods-systems.ptx": 2,
+ "source/c12-ltp/sec-unit-step-variants.ptx": 0,
+ "source/c13-linsys/sec-qualitative-methods-systems.ptx": 0,
  "source/c14-nlinsys/sec-nonlinear-systems.ptx": 3,
  "source/c5-if/sec-finding-the-integrating-factor.ptx": 3,
  "source/c6-qm/sec-logistical-models.ptx": 1,
  "source/c6-qm/sec-parameter-analysis.ptx": 1,
- "source/c7-em/sec-euler-method.ptx": 1,
+ "source/c7-em/sec-euler-method.ptx": 0,
  "source/main.ptx": 3
 }

--- a/source/aa-bookends/a3-quickref/c8-qref-uc.ptx
+++ b/source/aa-bookends/a3-quickref/c8-qref-uc.ptx
@@ -192,6 +192,7 @@
 				<caption>Comparison of a homogeneous equation (<em>left</em>) and a nonhomogeneous equation (<em>right</em>). In both, the solutions must simplify in a specific way when substituted into the equation.</caption>
 				<sidebyside widths="33% 33% 34%">
 					<image width="100%">
+						<shortdescription>Homogeneous operator diagram: the expression box double-prime minus 4 box prime plus 3 box equals 0, with three empty boxes each filled by an e-to-the-r-x-like function.</shortdescription>
 						<latex-image>
 						
 							\begin{tikzpicture}[join=round,rounded corners,&gt;=stealth,shorten &gt;=1pt,shorten &lt;=1pt,thick]
@@ -228,6 +229,7 @@
 						</latex-image>
 					</image>
 					<image width="100%">
+						<shortdescription>Nonhomogeneous operator diagram: box double-prime minus 4 box prime plus 3 box equals f of x, with three empty boxes each filled by an f-of-x-like function.</shortdescription>
 						<latex-image>
 						
 							\begin{tikzpicture}[join=round,rounded corners,&gt;=stealth,shorten &gt;=1pt,shorten &lt;=1pt,thick]
@@ -264,6 +266,7 @@
 						</latex-image>
 					</image>
 					<image width="100%">
+					<shortdescription>Coefficient-matching diagram: 3 A x plus the quantity negative 4 A plus 3 B equals 9 x plus 0, with the x-terms boxed together and the constant terms boxed together as matched pairs.</shortdescription>
 					<latex-image>
 					
 						\begin{tikzpicture}[join=round,rounded corners,&gt;=stealth,shorten &gt;=1pt,shorten &lt;=1pt,thick]

--- a/source/c10-lt/sec-lt-definition.ptx
+++ b/source/c10-lt/sec-lt-definition.ptx
@@ -181,6 +181,7 @@
 
 			<sidebyside widths="35% 5% 30%" margins="15% 15%" valign="middle">
 				<image width="50%">
+					<shortdescription>Graph of the exponential curve y equals e to the t on t-y axes, rising steeply for positive t and approaching 0 as t decreases.</shortdescription>
 					<latex-image>
 						\begin{tikzpicture}[samples=50]
 							% === colors ===

--- a/source/c12-ltp/exercises-ltp.ptx
+++ b/source/c12-ltp/exercises-ltp.ptx
@@ -725,6 +725,7 @@
 
 					<sidebyside width="75%">
 						<image width="100%">
+							<shortdescription>Graph of p of t equals negative 2 times u of t minus 2: 0 for t less than 2, then dropping to the constant negative 2 for t at least 2.</shortdescription>
 							<latex-image>
 								<xi:include href="tikz-figs/neg-2-u-of-t-minus-2.tex" parse="text" />
 							</latex-image>
@@ -1061,6 +1062,7 @@
 							<figure xml:id="e-to-neg-tsqrd-plot">
 								<caption> Graph of <m>2e^{-\sfrac{t^2}{2}} \cdot (1 - u_{1}(t))</m> </caption>
 								<image>
+									<shortdescription>Graph of 2 e to the minus t squared over 2 times the quantity 1 minus u-sub-1 of t: the bell curve for t less than 1, switched off to 0 at t = 1.</shortdescription>
 									<latex-image>
 										<xi:include href="tikz-figs/e-to-neg-tsqrd-plot.tex" parse="text" />
 									</latex-image>

--- a/source/c12-ltp/sec-piecewise-functions.ptx
+++ b/source/c12-ltp/sec-piecewise-functions.ptx
@@ -42,6 +42,7 @@
 			</p>
 			<p>
 				<image>
+					<shortdescription>Graph of the piecewise function g of t: sine t for t less than 0, 2 e to the minus t for t between 0 and 2, and the constant 1.5 for t at least 2.</shortdescription>
 					<latex-image>
 						\begin{tikzpicture}[domain=-5:6, samples=100, scale=0.45]
 							% === colors ===
@@ -182,6 +183,7 @@
 			<sidebyside widths="29% 29% 29%" margins="1% 1%" valign="bottom">
 				<figure xml:id="intro-piecewise-function-piece1"><caption><m>{\DLBb \sin t\ \big(1 - u_0(t)\big)}</m></caption>
 					<image width="100%">
+						<shortdescription>Graph of sine t times the quantity 1 minus u-sub-0 of t: the sine curve for t less than 0 and 0 for t at least 0, the first piece of g of t.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[domain=-5:6, samples=100, scale=0.4]
 		
@@ -249,6 +251,7 @@
 				</figure>
 				<figure xml:id="intro-piecewise-function-piece2"><caption><m>{\DLGa 2e^{-t}\ \big(u_0(t) - u_2(t)\big)}</m></caption>
 					<image width="100%">
+						<shortdescription>Graph of 2 e to the minus t times the quantity u-sub-0 of t minus u-sub-2 of t: the decaying exponential on the window from 0 to 2 and 0 elsewhere.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[domain=-5:6, samples=100, scale=0.4]
 		
@@ -322,6 +325,7 @@
 				</figure>
 				<figure xml:id="intro-piecewise-function-piece3"><caption><m>{\DLO 1.5\ u_2(t)}</m></caption>
 					<image width="100%">
+						<shortdescription>Graph of 1.5 times u-sub-2 of t: 0 for t less than 2 and the constant 1.5 for t at least 2, the third piece of g of t.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[domain=-5:6, samples=100, scale=0.4]
 								% === colors ===
@@ -603,6 +607,7 @@
 					<sidebyside width="90%" margins="0%">
 						<figure xml:id="tsqrd-off-then-on-at-pi-over-2"><caption> Graph of <m>\sin (t) \cdot u_{\sfrac{\pi}{2}}(t)</m> </caption>
 							<image>
+								<shortdescription>Graph of sine t times u-sub-pi-over-2 of t: 0, or OFF, until t equals pi over 2, where sine t switches on for t at least pi over 2.</shortdescription>
 								<latex-image>
 									\begin{tikzpicture}[samples=200, scale=0.7]
 										% === colors ===

--- a/source/c12-ltp/sec-unit-step-functions.ptx
+++ b/source/c12-ltp/sec-unit-step-functions.ptx
@@ -111,6 +111,7 @@
 					<p/>
 					<p>
 						<image>
+							<shortdescription>Graph of the unit step function u of t: 0, or OFF, for t less than 0, jumping up to 1, or ON, at t = 0 and staying there.</shortdescription>
 							<latex-image>
 								\begin{tikzpicture}[samples=100, scale=0.5]
 			
@@ -231,6 +232,7 @@
 					<sidebyside width="40%" margin="5%">
 						<p>
 							<image>
+								<shortdescription>Graph of the parabola g of t equals one-fifth t squared minus 1, drawn as a full upward-opening parabola for all t.</shortdescription>
 								<latex-image>
 									\begin{tikzpicture}[samples=200, scale=0.65]
 										% === colors ===
@@ -272,6 +274,7 @@
 						</p>
 						<p>
 							<image>
+								<shortdescription>Graph of g of t times u of t: 0 for t less than 0, then the parabola one-fifth t squared minus 1 switched on at t = 0.</shortdescription>
 								<latex-image>
 									\begin{tikzpicture}[samples=200, scale=0.65]
 										% === colors ===

--- a/source/c12-ltp/sec-unit-step-variants.ptx
+++ b/source/c12-ltp/sec-unit-step-variants.ptx
@@ -85,6 +85,7 @@
 				<p/>
 				<p>
 					<image>
+						<shortdescription>Graph of the shifted unit step function u-sub-c of t: 0, or OFF, for t less than c and 1, or ON, for t at least c, with the jump marked at t = c.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[samples=100, scale=0.45]
 								% === colors ===
@@ -182,9 +183,12 @@
 						code/jsxgraph/jsx-core/piecewise.js
 						code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-2.js"
 				>
+					<description>
+						<p>An interactive plot of the parabola one-fifth t squared minus 1 multiplied by the shifted unit step u-sub-c of t; the reader drags the switch point c along the t-axis and hovers over the labels to highlight each graph and see how c turns the parabola on and off.</p>
+					</description>
 					<slate xml:id="unit-step-2-plot1" surface="jsxboard" aspect="5:2" />
 					<static>
-						<image source="code/jsxgraph/img-labels/t.png" width="70%"> Need to Add </image>
+						<image source="code/jsxgraph/img-labels/t.png" width="70%" decorative="yes"/>
 					</static>
 				</interactive>
 			</sidebyside>
@@ -354,6 +358,7 @@
 				<p/>
 				<p>
 					<image>
+						<shortdescription>Graph of the reversed unit step 1 minus u-sub-c of t: 1, or ON, for t less than c and 0, or OFF, for t at least c, with the drop marked at t = c.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[samples=100, scale=0.45]
 			
@@ -444,6 +449,7 @@
 					<p/>
 					<p>
 						<image>
+							<shortdescription>Graph of h of t equals 2 e to the minus 0.5 t squared times the quantity 1 minus u-sub-1 of t: the bell curve for t less than 1, switched off to 0 at t = 1.</shortdescription>
 							<latex-image>
 								\begin{tikzpicture}[domain=-3:3, samples=200, scale=0.5]
 
@@ -717,6 +723,7 @@
 				<p/>
 				<p>
           <image>
+            <shortdescription>Graph of the windowed step u-sub-c of t minus u-sub-d of t: 0 outside the interval and 1 on c to d, labeled OFF, ON, OFF, here with c = 2 and d = 5.</shortdescription>
             <latex-image>
               \begin{tikzpicture}[samples=100, scale=0.45]
 
@@ -801,6 +808,9 @@
 								code/jsxgraph/jsx-core/piecewise.js
 								code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-uc-ud.js"
 						>
+							<description>
+								<p>An interactive with three stacked plots; the reader drags the switch points c and d along the t-axis to see how u-sub-c of t and u-sub-d of t combine so that their difference forms an ON-window between c and d.</p>
+							</description>
 							<sidebyside width="100%" margins="0% 0%">
 								<stack>
 									<slate xml:id="unit-step-uc-ud-plot1" surface="jsxboard" aspect="2.8:1" />
@@ -809,7 +819,7 @@
 								</stack>
 							</sidebyside>
 							<static>
-								<image source="code/jsxgraph/img-labels/t.png" width="70%"> Need to Add </image>
+								<image source="code/jsxgraph/img-labels/t.png" width="70%" decorative="yes"/>
 							</static>
 						</interactive>
 					</sidebyside>
@@ -896,6 +906,7 @@
 
 				<sidebyside width="60%" margin="20%">
 					<image>
+						<shortdescription>Graph of g of t equals the quantity sine t plus 2 times the quantity u-sub-pi-over-2 of t minus u-sub-2pi of t: 0 outside the interval from pi over 2 to 2 pi and the raised sine curve on that window.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[samples=200, scale=0.6]
 
@@ -1013,11 +1024,14 @@
 						code/jsxgraph/jsx-core/piecewise.js
 						code/jsxgraph/jsx-core/utils.js code/jsxgraph/unit-step-interactives/unit-step-sine-plus-2-uc-ud.js"
 				>
+					<description>
+						<p>An interactive plot of the quantity sine t plus 2 multiplied by the window u-sub-c of t minus u-sub-d of t; the reader drags c and d along the t-axis and hovers over the labels to watch the windowed sine burst change width.</p>
+					</description>
 					<sidebyside width="100%">
 						<slate xml:id="unit-step-sine-plus-2-uc-ud-plot1" surface="jsxboard" aspect="2.1:1" />
 					</sidebyside>
 					<static>
-						<image source="code/jsxgraph/img-labels/t.png" width="70%"> Need to Add </image>
+						<image source="code/jsxgraph/img-labels/t.png" width="70%" decorative="yes"/>
 					</static>
 				</interactive>
 			</sidebyside>

--- a/source/c13-linsys/exercises-linsys.ptx
+++ b/source/c13-linsys/exercises-linsys.ptx
@@ -1096,7 +1096,9 @@
 						Suppose compartments A and B are filled with fluids and are separated by a permeable membrane. The figure is a compartmental representation of the exterior and interior of a cell.  Suppose, too, that a nutrient necessary for cell growth passes through the membrane.
 						<figure xml:id="concentration-membrane">
 							<caption></caption>
-							<image width="50%" source="./figures/concentration.png"/>
+							<image width="50%" source="./figures/concentration.png">
+								<shortdescription>A two-compartment diagram of a cell's interior and exterior separated by a permeable membrane, through which a nutrient passes between the two compartments.</shortdescription>
+							</image>
 						</figure>
 						A model for the amounts <m>x(t)</m> and <m>y(t)</m> of the nutrient in compartments A and B, respectively, at time <m>t</m> is given by the linear system of differential equations:
 						<md>

--- a/source/c13-linsys/sec-introduction-to-systems.ptx
+++ b/source/c13-linsys/sec-introduction-to-systems.ptx
@@ -141,6 +141,7 @@
 				<figure xml:id="fig-uncoupled-phase-plane">
 					<caption>Solution trajectories in the phase plane for the uncoupled system <m>x' = -x</m>, <m>y' = -2y</m>. Arrows indicate the direction of motion as time increases.</caption>
 					<image width="50%">
+						<shortdescription>Two decaying exponential solution curves, x of t equals 0.6 e to the minus t and y of t equals 1.2 e to the minus 2t, plotted against time t.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}
 

--- a/source/c13-linsys/sec-qualitative-methods-systems.ptx
+++ b/source/c13-linsys/sec-qualitative-methods-systems.ptx
@@ -96,9 +96,12 @@
 						dark-mode-enabled="yes"
 						source="code/jsxgraph/visualizing-systems/phase-plane-slopefield.js"
 					>
+						<description>
+							<p>An interactive direction field in the x-y phase plane for a linear system, drawing an arrow at each grid point to show the direction of motion there.</p>
+						</description>
 						<slate xml:id="phase-plane-slopefield-plot1" surface="jsxboard" aspect="1:1" />
 						<static>
-							<image source="code/jsxgraph/img-labels/t.png" width="70%"> Need to Add </image>
+							<image source="code/jsxgraph/img-labels/t.png" width="70%" decorative="yes"/>
 						</static>
 					</interactive>
 				</sidebyside>
@@ -112,13 +115,16 @@
 				dark-mode-enabled="yes"
 				source="code/jsxgraph/visualizing-systems/phase-plane-w-timeplot-6.js"
 			>
+				<description>
+					<p>An interactive figure pairing a phase-plane direction field on the left with a time plot on the right, so the trajectory in the x-y plane can be compared with the curves of x of t and y of t against time t.</p>
+				</description>
 				<sidebyside widths="49% 2% 49%">
 					<slate xml:id="phase-plane-w-timeplot-6-plot1" surface="jsxboard" aspect="49:50" />
 					<p/>
 					<slate xml:id="phase-plane-w-timeplot-6-plot2" surface="jsxboard" aspect="49:50" />
 				</sidebyside>
 				<static>
-					<image source="code/jsxgraph/img-labels/t.png" width="100%"> Need to Add </image>
+					<image source="code/jsxgraph/img-labels/t.png" width="100%" decorative="yes"/>
 				</static>
 			</interactive>
 		</figure>

--- a/source/c2-solns/sec-visualizing-solns.ptx
+++ b/source/c2-solns/sec-visualizing-solns.ptx
@@ -52,7 +52,7 @@
 						source="code/initial-condition.js"
 					>
 						<description>
-							<p>A phase-plane display of the solution family y equals c times e to the x squared plus 3 drawn as green curves; the reader drags an initial-condition point along the y-axis to highlight the matching particular solution, shown in blue, of dy dx equals 2xy minus 6x.</p>
+							<p>A phase-plane display of the solution family y equals 3 plus c times e to the x squared, drawn as green curves; the reader drags an initial-condition point along the y-axis to highlight the matching particular solution, shown in blue, of dy dx equals 2xy minus 6x.</p>
 						</description>
 						<slate xml:id="interactive-drag-ic-slate" surface="jsxboard"/>
 					</interactive>

--- a/source/c2-solns/sec-visualizing-solns.ptx
+++ b/source/c2-solns/sec-visualizing-solns.ptx
@@ -51,6 +51,9 @@
 						platform="jsxgraph" 
 						source="code/initial-condition.js"
 					>
+						<description>
+							<p>A phase-plane display of the solution family y equals c times e to the x squared plus 3 drawn as green curves; the reader drags an initial-condition point along the y-axis to highlight the matching particular solution, shown in blue, of dy dx equals 2xy minus 6x.</p>
+						</description>
 						<slate xml:id="interactive-drag-ic-slate" surface="jsxboard"/>
 					</interactive>
 				</p>

--- a/source/c5-if/review-first-order-methods.ptx
+++ b/source/c5-if/review-first-order-methods.ptx
@@ -32,6 +32,7 @@
 						dark-mode-enabled="yes"
 						source="code/jsxgraph/method-flowchart/method-flowchart.js"
 					>
+						<shortdescription>A decision-tree flowchart for choosing a first-order solution method; the reader answers Yes or No at each highlighted question and the chosen path highlights in green.</shortdescription>
 						<slate xml:id="method-flowchart-plot1" surface="jsxboard" aspect="1.31:1" />
 						<instructions>
 							<p>

--- a/source/c6-qm/sec-autonomous-equations.ptx
+++ b/source/c6-qm/sec-autonomous-equations.ptx
@@ -50,6 +50,7 @@
 			<sidebyside widths="38.5% 3.5% 36%" margins="11% 11%" valign="top">
 				<figure xml:id="changing-constant-slopes">
 					<image>
+						<shortdescription>Slope field for y-prime equals y squared minus 1 with a highlighted vertical strip where slopes rotate as y changes and horizontal strips where slopes stay fixed across t.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[declare function={f(\x,\y)=(\y)^2-1;}, scale=0.8]
 
@@ -146,6 +147,7 @@
 				<p/>
 				<figure xml:id="horizontal-solution-symmetry">
 					<image>
+						<shortdescription>Slope field for y-prime equals y squared minus 1 overlaid with several magenta solution curves that are horizontal shifts of one another.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[declare function={f(\x,\y)=(\y)^2-1;}, scale=0.8]
 

--- a/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
+++ b/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
@@ -70,6 +70,7 @@
 			<caption>Slope Field (left) and Phase Line (right) for <m>y'= 1 - y^2</m></caption>
 			<sidebyside widths="50% 1.05% 8.95%" valign="top" margins="20% 20%">
 				<image>
+					<shortdescription>Slope field for y-prime equals 1 minus y squared, shaded green where the slope is positive (between y = -1 and y = 1) and red where it is negative.</shortdescription>
 					<latex-image>
 						\begin{tikzpicture}[declare function={f(\x,\y) = (1-\y) * (1+\y);}, scale=0.95]
 
@@ -147,6 +148,10 @@
 				</image>
 				<p/>
 				<image>
+					<shortdescription>Vertical phase line for y-prime equals 1 minus y squared, with equilibria at y = -1 and y = 1 and arrows showing y = 1 as a sink and y = -1 as a source.</shortdescription>
+					<description>
+						<p>A single vertical y-axis marks equilibria at y = -1 and y = 1 as solid dots. Flow arrows point up between the two equilibria and down above y = 1 and below y = -1, so solutions converge on y = 1 (a sink) and diverge from y = -1 (a source).</p>
+					</description>
 					<latex-image>
 						\begin{tikzpicture}[declare function={f(\x,\y) = (1-\y) * (1+\y);}, scale=0.7]
 
@@ -253,6 +258,7 @@
 					</p>
 					<p>
 						<image>
+							<shortdescription>Vertical phase line for y-prime equals y squared minus 4y, with equilibria at y = 0 (a sink) and y = 4 (a source); arrows converge on y = 0.</shortdescription>
 							<latex-image>
 								\begin{tikzpicture}[declare function={f(\x,\y) = \y * (\y-4);}, scale=0.2]
 
@@ -322,6 +328,10 @@
 					<p>Phase Line</p>
 					<p><me>\rightarrow</me></p>
 					<image width="100%">
+						<shortdescription>Generic vertical phase line with three equilibria: the top point is a sink, the middle a source, and the bottom semi-stable.</shortdescription>
+						<description>
+							<p>Three solid dots sit on a vertical line. Arrows point toward the top dot from both sides (a sink), away from the middle dot on both sides (a source), and toward the bottom dot from above but away below (semi-stable). No numeric labels are shown; the points are referred to as A, B, and C in the exercise.</p>
+						</description>
 						<latex-image>
 							\begin{tikzpicture}[scale=0.5]
 								\draw[very thick] (0,-2) -- (0,2);
@@ -387,6 +397,7 @@
 		<sidebyside widths="40% 2% 58%">
 			<figure xml:id="linearization-figure">
 				<image>
+					<shortdescription>Slope field for y-prime equals 1 minus y squared, shaded by the sign of the slope, showing convergence toward y = 1 and divergence from y = -1.</shortdescription>
 					<latex-image>
 						\begin{tikzpicture}[declare function={f(\x,\y) = (1-\y) * (1+\y);}, scale=0.7]
 
@@ -470,6 +481,10 @@
 			<p/>
 			<figure>
 				<image>
+					<shortdescription>The slope field for y-prime equals 1 minus y squared shown in perspective beside the graph of f of y, a downward parabola, linking the sign of f to the sink and source.</shortdescription>
+					<description>
+						<p>A two-panel perspective figure. The vertical panel is the slope field for y-prime equals 1 minus y squared, with the equilibrium at y = 1 labeled a sink and y = -1 labeled a source. The horizontal panel plots f of y equals 1 minus y squared as a downward-opening parabola, drawn solid where f is positive and dashed where negative, showing f increasing through the source and decreasing through the sink.</p>
+					</description>
 					<latex-image>
 						\begin{tikzpicture}[declare function={f(\x,\y) = (1-\y) * (1+\y);}, scale=0.8] 
 

--- a/source/c6-qm/sec-equilibrium-solutions.ptx
+++ b/source/c6-qm/sec-equilibrium-solutions.ptx
@@ -37,6 +37,7 @@
 		<figure xml:id="slope-field-1-ysqrd">
 			<sidebyside widths="50%" margins="5% 5%" valign="middle">
 				<image width="100%">
+					<shortdescription>Slope field for y-prime equals 1 minus y squared, with horizontal, zero-slope segments along y = -1 and y = 1.</shortdescription>
 					<latex-image>
 						\begin{tikzpicture}[declare function={f(\x,\y) = 1 - \y*\y;}, scale=0.8]
 
@@ -135,6 +136,7 @@
 				</p>
 				<sidebyside widths="50%" margin="25%" valign="middle">
 					<image>
+						<shortdescription>Slope field of an autonomous equation with horizontal, zero-slope segments marking equilibria along y = -1.5 and y = 2.</shortdescription>
 						<latex-image>
 							\begin{tikzpicture}[declare function={f(\x,\y) = (2-\y) * (1.5+\y);}, scale=0.6]
 

--- a/source/c6-qm/sec-parameter-analysis.ptx
+++ b/source/c6-qm/sec-parameter-analysis.ptx
@@ -106,6 +106,10 @@
 		<figure xml:id="saddle-node-bifurcation-diagram">
 			<caption>Bifurcation diagram for <m>\frac{dx}{dt} = \mu - x^2</m></caption>
 			<image width="40%">
+				<shortdescription>Saddle-node bifurcation diagram for x-prime equals mu minus x squared: a sideways parabola with a solid stable upper branch and a dashed unstable lower branch meeting at mu = 0.</shortdescription>
+				<description>
+					<p>The horizontal axis is mu and the vertical axis is x. The stable branch x equals plus the square root of mu is solid and the unstable branch x equals minus the square root of mu is dashed, both existing only for mu at least 0 and meeting at the origin, where a vertical dotted line marks the bifurcation. A legend labels the solid curve Stable and the dashed curve Unstable.</p>
+				</description>
 				<latex-image>
 					\begin{tikzpicture}[scale=1]
 						% Axes

--- a/source/c6-qm/sec-slope-fields.ptx
+++ b/source/c6-qm/sec-slope-fields.ptx
@@ -145,6 +145,7 @@
 				<row><cell><m> ( 1 ,  1 ) </m></cell><cell><m>  1-( 1)= 0 </m></cell></row>
 			</tabular>
 			<image>
+				<shortdescription>Small slope field for y-prime equals y minus t on a three-by-three grid of points at t = -1, 0, 1 and y = -1, 0, 1.</shortdescription>
 				<latex-image>
 					\begin{tikzpicture}[declare function={f(\x,\y)=\y-\x;}, scale=0.4]
 
@@ -235,6 +236,7 @@
 		<sidebyside widths="44%" margins="28% 28%" valign="middle">
 			<figure xml:id="y-t-slope-field-16x16">
 				<image>
+					<shortdescription>Dense slope field for y-prime equals y minus t over t and y from -4 to 4, with one solution curve through the point (0, one-half) traced in magenta.</shortdescription>
 					<latex-image>
 						\begin{tikzpicture}[declare function={f(\x,\y)=\y-\x;}, scale=0.4]
 

--- a/source/c7-em/sec-euler-intro-thinking-in-steps.ptx
+++ b/source/c7-em/sec-euler-intro-thinking-in-steps.ptx
@@ -157,6 +157,7 @@
 				<p/>
 				<figure xml:id="multiple-rise-run-a"><caption>Rise <m>3</m>, run <m>2</m></caption>
 					<image>
+						<shortdescription>A line of slope three-halves through (1, 1) and (3, 4), with a vertical rise arrow labeled 3 and a horizontal run arrow labeled 2.</shortdescription>
 						<latex-image>
 							% === User Defined Parameters ===
 							\def\run{2} \def\rise{3} \def\yint{-0.5}	% slope rise/run, yintercept
@@ -222,6 +223,7 @@
 				<p/>
 				<figure xml:id="multiple-rise-run-b"><caption>Rise <m>\frac32</m>, run <m>1</m></caption>
 					<image>
+						<shortdescription>The same slope-three-halves line through (1, 1) and (2, five-halves), with a rise arrow labeled 3/2 over a run arrow labeled 1.</shortdescription>
 						<latex-image>
 							% === User Defined Parameters ===
 							\def\run{1} \def\rise{1.5} \def\yint{-0.5}	% slope rise/run, yintercept
@@ -287,6 +289,7 @@
 				<p/>
 				<figure xml:id="multiple-rise-run-c"><caption>Rise <m>m h</m>, run <m>h</m></caption>
 					<image>
+						<shortdescription>The same line drawn as a general Euler step from (t-zero, y-zero) to (t-one, y-one), with the vertical rise labeled three-halves times h and the horizontal run labeled h.</shortdescription>
 						<latex-image>
 							% === User Defined Parameters ===
 							\def\run{2} \def\rise{3} \def\yint{-0.5}	% slope rise/run, yintercept

--- a/source/c7-em/sec-euler-method.ptx
+++ b/source/c7-em/sec-euler-method.ptx
@@ -140,6 +140,7 @@
 					</p>
 					<p>
 						<image width="100%">
+							<shortdescription>On t-y axes, the four Euler's-method points (0, -2), (0.5, -3), (1, -3), and (1.5, -1.5), each with a short arrow showing its slope of -2, 0, and 3.</shortdescription>
 							<latex-image>
 									\begin{tikzpicture}[samples=50]
 				
@@ -221,11 +222,14 @@
 					dark-mode-enabled="yes"
 					source="code/jsxgraph/eulers-method/euler-ivp-tool.js"
 				>
+					<description>
+						<p>An interactive t-y plot where the reader starts at the initial point and repeatedly clicks to place each next Euler point one step (h = 0.5) along the displayed slope direction; correct clicks become green points joined by segments, incorrect clicks appear as red circles, and a Reset button restarts the walk.</p>
+					</description>
 					<sidebyside width="100%">
 						<slate xml:id="euler-ivp-tool-plot1" surface="jsxboard" aspect="1.6:1" />
 					</sidebyside>
 					<static>
-						<image source="code/jsxgraph/img-labels/t.png" width="100%"> Need to Add </image>
+						<image source="code/jsxgraph/img-labels/t.png" width="100%" decorative="yes"/>
 					</static>
 				</interactive>
 			</sidebyside>
@@ -495,6 +499,7 @@
 					</caption>
 
 					<image xml:id="sageplot-euler-approximation">
+						<shortdescription>A red exact-solution curve for y-prime equals t plus y with four green Euler-approximation points at t = 0, 0.5, 1, and 1.5 sitting just below it.</shortdescription>
 
 						<sageplot variant="2d">
 							y = lambda x : (1/8)*exp(x)-x-1

--- a/source/c7-em/sec-euler-method.ptx
+++ b/source/c7-em/sec-euler-method.ptx
@@ -140,7 +140,7 @@
 					</p>
 					<p>
 						<image width="100%">
-							<shortdescription>On t-y axes, the four Euler's-method points (0, -2), (0.5, -3), (1, -3), and (1.5, -1.5), each with a short arrow showing its slope of -2, 0, and 3.</shortdescription>
+							<shortdescription>On t-y axes, the four Euler's-method points (0, -2), (0.5, -3), (1, -3), and (1.5, -1.5); the first three carry a short arrow showing the slope used to reach the next point (slopes -2, 0, and 3).</shortdescription>
 							<latex-image>
 									\begin{tikzpicture}[samples=50]
 				

--- a/source/c7-em/sec-what-is-a-numerical-solution.ptx
+++ b/source/c7-em/sec-what-is-a-numerical-solution.ptx
@@ -100,6 +100,7 @@
 			<p/>
 			<p>
 				<image>
+					<shortdescription>The smooth exponential curve y equals e to the t on t-y axes, with dashed lines marking the exact value y approximately 1.916 at t = 0.65.</shortdescription>
 					<latex-image>
 						\begin{tikzpicture}[samples=50]
 
@@ -176,6 +177,7 @@
 			</p>
 			<p>
 				<image>
+					<shortdescription>Open-circle points approximating the solution of y-prime equals y, y(0) = 1 at successive t-values, showing the numerical solution as discrete dots rather than a curve.</shortdescription>
 					<latex-image>
 						\begin{tikzpicture}[samples=50]
 	

--- a/source/c8-lhcc/sec-solving-higher-order-lhcc-eqns.ptx
+++ b/source/c8-lhcc/sec-solving-higher-order-lhcc-eqns.ptx
@@ -273,6 +273,9 @@
 					</p>
 				</proof>
 				<interactive xml:id="poly-factor" platform="sage" width="96%" aspect="1.9:1">
+					<description>
+						<p>An interactive Sage cell in which the reader types a polynomial in r and evaluates it to see the factored form and approximate rational roots, used here to factor a characteristic equation.</p>
+					</description>
 					<slate surface="sage">
 						<xi:include href="sage-factoring-tool.txt" parse="text" />
 					</slate>

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -606,6 +606,9 @@
 									dark-mode-enabled="yes"
 									source="code/slideshow/slideshow.js"
 									width="100%" aspect="1.52:1">
+									<description>
+										<p>An animated slideshow that walks step by step through the Laplace transform method roadmap: the forward transform, algebra in the Laplace domain, and the inverse transform, advancing one stage each time the reader presses Next.</p>
+									</description>
 									<slate xml:id="lt-slideshow-canvas" surface="canvas" width="100%" aspect="1.52:1" />
 								</interactive>
 							</cell>


### PR DESCRIPTION
## Summary

Adds screen-reader alt text to **every image and interactive in the build set** so the book meets WCAG/508 alt-text requirements, and adds a CI lint that keeps coverage from regressing. Before this change, 0 of 47 images and 0 of 10 interactives carried any description.

Each description was written from the figure's **actual TikZ / pgfplots / Sage source** (and the surrounding prose), not from the caption — a screen-reader user gets a description of what the figure shows, which the visible caption often does not restate.

## What changed

**Images (47)** — each gains a `<shortdescription>` (plain-text, math rendered as words). A few complex figures (phase lines, the saddle-node bifurcation diagram, the linearization panel) also get a longer `<description>`.

**Interactives (10)** — each gains a `<description>` describing what is plotted and what the reader can manipulate. Where an `<instructions>` block already carries the full detail (the "Which Method?" flowchart), a concise `<shortdescription>` is used instead to avoid duplication.

**Placeholder cleanup** — the 6 `code/jsxgraph/img-labels/t.png` "Need to Add" axis-label fallbacks inside interactive `<static>` blocks are marked `decorative="yes"`. The real content now lives in each parent interactive's description, so no information is lost, and the invalid placeholder text is gone.

## Tooling

- **New lint** `processing-tools/check-descriptions/check_descriptions.py` walks the `main.ptx` build set and exits non-zero if any reachable image/interactive lacks a description (`decorative="yes"` images are exempt). `--list` prints every offender as `file:line`.
- **CI**: wired the lint into the *Validate Source* workflow (adds `lxml` to the install step).
- Tightened `placeholder-baseline.json` to `0` for the three files whose "Need to Add" markers were removed.

## Verification

- `check_descriptions.py` → **47/47 images and 10/10 interactives described**.
- `validate_source.py` → all checks pass (well-formedness, ids, placeholder ratchet).
- `verify_worked_math.py` (SymPy) → 97/97 (unchanged — no math touched).
- `xmllint --xinclude source/main.ptx` assembles cleanly.
- The new `<shortdescription>`/`<description>` markup was validated against the PreTeXt RNG that defines `image`/`interactive`/`slate`; it produces **zero** schema errors.

## Notes for the author

A few things surfaced while reading the figure source that are **out of scope here** but worth a look:

1. **`sec-qualitative-methods-systems.ptx`** — the prose for the `phase-plane-slopefield` interactive says the system is `x' = x + y, y' = -x + y`, but `phase-plane-slopefield.js` implements `dx = -x, dy = -y + 2x`. The alt text deliberately does **not** name the equations to avoid endorsing a mismatch.
2. **`sec-euler-method.ptx`** — the `euler-ivp-tool` prose says the tool explores `y' = y + t, y(0) = 1`, but the JS hard-codes `y' = 6t + y, y(0) = -2`. The interactive's description is written to avoid naming the IVP.
3. **`sec-introduction-to-systems.ptx`** (image ~143) — the figure caption calls it a "phase plane," but the TikZ plots `x(t)` and `y(t)` against time `t` (a time-domain plot).
4. The 6 `<static>` t.png fallbacks are placeholder axis-label glyphs; ideally they'd become real static snapshots of each interactive. Marked decorative for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018vhHaJjo1fdpi2TBj7VMCc)_