### PR TITLE
Sweep build-integrity defects: placeholders, stray markers, empty captions

### DIFF
--- a/processing-tools/validate-source/placeholder-baseline.json
+++ b/processing-tools/validate-source/placeholder-baseline.json
@@ -7,10 +7,10 @@
  "source/aa-bookends/back-matter.ptx": 4,
  "source/c12-ltp/sec-unit-step-variants.ptx": 0,
  "source/c13-linsys/sec-qualitative-methods-systems.ptx": 0,
- "source/c14-nlinsys/sec-nonlinear-systems.ptx": 3,
- "source/c5-if/sec-finding-the-integrating-factor.ptx": 3,
- "source/c6-qm/sec-logistical-models.ptx": 1,
- "source/c6-qm/sec-parameter-analysis.ptx": 1,
+ "source/c14-nlinsys/sec-nonlinear-systems.ptx": 2,
+ "source/c5-if/sec-finding-the-integrating-factor.ptx": 0,
+ "source/c6-qm/sec-logistical-models.ptx": 0,
+ "source/c6-qm/sec-parameter-analysis.ptx": 0,
  "source/c7-em/sec-euler-method.ptx": 0,
- "source/main.ptx": 3
+ "source/main.ptx": 0
 }

--- a/source/aa-bookends/front-matter.ptx
+++ b/source/aa-bookends/front-matter.ptx
@@ -36,16 +36,6 @@
 			<holder>Geoffrey W. Cox, Ph.D.</holder>
 		</copyright>
 
-		<!-- <credit>
-			<title>PISS</title>
-			<author>
-				<personname>Geoffrey W. Cox, Ph.D.</personname>
-				<department>Applied Mathematics</department>
-				<institution>Virginia Military Institute</institution>
-				<email>coxgeoff@vmi.edu</email>
-			</author>
-			
-		</credit> -->
 
 		<support>
 			<ul>

--- a/source/c10-lt/sec-common-transforms.ptx
+++ b/source/c10-lt/sec-common-transforms.ptx
@@ -133,11 +133,6 @@
 
 		<p>
 			This integral converges when <m>s \gt 0</m> and leads to our first Laplace transform rule:
-			<!-- <md>
-				<mrow xml:id="lt-L1">
-					\text{L}_1:\quad\lap{1} = \frac{1}{s}, \quad s \gt 0
-				</mrow>.
-			</md> -->
 		</p>
 
 		<assemblage xml:id="lap-L1">

--- a/source/c12-ltp/exercises-ltp.ptx
+++ b/source/c12-ltp/exercises-ltp.ptx
@@ -1964,7 +1964,7 @@
 					<paragraphs>
 						<title>Step 3 — Back to the Time Domain</title>
 						<p>
-						Each exponential factor in <m>Y(s)</m> corresponds to a shifted version of <m>f(t)</m> multiplied by the appropriate step function using <xref ref="lt-L11" text="custom">L<m>_11</m></xref>.
+						Each exponential factor in <m>Y(s)</m> corresponds to a shifted version of <m>f(t)</m> multiplied by the appropriate step function using <xref ref="lt-L11" text="custom">L<m>_{11}</m></xref>.
 						</p>
 
 						<me>

--- a/source/c13-linsys/exercises-linsys.ptx
+++ b/source/c13-linsys/exercises-linsys.ptx
@@ -1095,7 +1095,7 @@
 					<p>
 						Suppose compartments A and B are filled with fluids and are separated by a permeable membrane. The figure is a compartmental representation of the exterior and interior of a cell.  Suppose, too, that a nutrient necessary for cell growth passes through the membrane.
 						<figure xml:id="concentration-membrane">
-							<caption></caption>
+							<caption>A two-compartment model of a cell: compartments <m>A</m> and <m>B</m> separated by a permeable membrane through which the nutrient passes.</caption>
 							<image width="50%" source="./figures/concentration.png">
 								<shortdescription>A two-compartment diagram of a cell's interior and exterior separated by a permeable membrane, through which a nutrient passes between the two compartments.</shortdescription>
 							</image>

--- a/source/c14-nlinsys/sec-nonlinear-systems.ptx
+++ b/source/c14-nlinsys/sec-nonlinear-systems.ptx
@@ -10,7 +10,7 @@
   Full license text: https://creativecommons.org/licenses/by-sa/4.0/legalcode
   Recommended attribution: "Exploring Differential Equations" by Geoffrey Cox, licensed CC BY-SA 4.0.
 -->
-<section label="NEEDS-A-LABEL"> <title>Nonlinear Systems</title>
+<section label="nonlinear-systems"> <title>Nonlinear Systems</title>
     <p>
         <xref provisional="FUTURE-WORK"/>
     </p>

--- a/source/c3-di/exercises-di.ptx
+++ b/source/c3-di/exercises-di.ptx
@@ -889,7 +889,7 @@
 				The problem is that most equations do not start in this form. Instead, they start in another form and, after some algebra, are put into this convenient form and solved. The process of rewriting an equation in this way forms the basis of another technique, the integrating factor method. The question we want to answer here is <q>what type of equations can be written in this form?</q>
 			</p>
 
-			<exercise label="di-piss-medium"><title>Give the equation that can be rewritten in the form <m>\ds\left[x^7 y \right]^{\prime} = e^x</m></title>
+			<exercise label="di-rewrite-x7y-medium"><title>Give the equation that can be rewritten in the form <m>\ds\left[x^7 y \right]^{\prime} = e^x</m></title>
 
 					<statement>
 						<p>

--- a/source/c5-if/sec-finding-the-integrating-factor.ptx
+++ b/source/c5-if/sec-finding-the-integrating-factor.ptx
@@ -540,7 +540,7 @@
 			</task>
 
 			<task label="if-integrating-factor-cyu-3">
-				<title><e component="emoji">📖❓</e> Find the Integrating Factor (WebWorK Here For Mathquill?)</title>
+				<title><e component="emoji">📖❓</e> Find the Integrating Factor</title>
 				<statement>
 					<p>
 						The integrating factor for the equation
@@ -587,7 +587,7 @@
 			</task>
 
 			<task label="if-integrating-factor-cyu-4">
-				<title><e component="emoji">📖❓</e> Fill-In the Integrating Factor 1 (WebWorK Here For Mathquill?)</title>
+				<title><e component="emoji">📖❓</e> Fill-In the Integrating Factor 1</title>
 				<statement>
 					<p>
 						Rewrite the differential equation
@@ -672,7 +672,7 @@
 			</task>
 
 			<task label="if-integrating-factor-cyu-5">
-				<title><e component="emoji">📖❓</e> Fill-In the Integrating Factor 2 (WebWorK Here For Mathquill?)</title>
+				<title><e component="emoji">📖❓</e> Fill-In the Integrating Factor 2</title>
 				<statement>
 					<p>
 						Rewrite the differential equation

--- a/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
+++ b/source/c6-qm/sec-classifying-equilibrium-solutions.ptx
@@ -476,7 +476,7 @@
 						\end{tikzpicture}
 					</latex-image>
 				</image>
-				<caption></caption>
+				<caption>Slope field for <m>y' = 1 - y^2</m>.</caption>
 			</figure>
 			<p/>
 			<figure>
@@ -603,7 +603,7 @@
 						\end{tikzpicture}
 					</latex-image>
 				</image>
-				<caption></caption>
+				<caption>The slope field for <m>y' = 1 - y^2</m> shown alongside the graph of <m>f(y) = 1 - y^2</m>.</caption>
 			</figure>
 		</sidebyside>
 

--- a/source/c6-qm/sec-logistical-models.ptx
+++ b/source/c6-qm/sec-logistical-models.ptx
@@ -13,12 +13,6 @@
 <section label="logistical-models"> 
 	<title>Logistic Models</title>
 	
-	<introduction>
-		<p>
-			<xref provisional="IN PROGRESS"/>
-		</p>
-	</introduction>
-
 	<subsection label="the-logistical-model"><title>The Logistic Model</title>
 		<p>
 			<idx><h>logistic model</h></idx>

--- a/source/c6-qm/sec-parameter-analysis.ptx
+++ b/source/c6-qm/sec-parameter-analysis.ptx
@@ -16,10 +16,6 @@
 	<introduction>
 
 		<p>
-			<xref provisional="IN PROGRESS"/>
-		</p>
-
-		<p>
 			<idx><h>parameter</h></idx>
 			<idx><h>parameter analysis</h></idx>
 			Many mathematical models include one or more <term>parameters</term>—constants that represent things like birth rates, drug dosage, resource limits, or physical constants. These parameters aren't just placeholders—they often control the <em>qualitative behavior</em> of the system. Small changes in a parameter's value can cause major shifts in the solution's behavior. Understanding those changes is the goal of <term>parameter analysis</term>.

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -478,7 +478,7 @@
 							</ul>
 							</p>
 					</li>
-					<li>The terms that are included in the general solution depend on the characteristic root type, as summarized in -COMMENTED-
+					<li>The terms that are included in the general solution depend on the characteristic root type, as summarized in
 						<xref ref="lhcc-contribution-to-general-solution"/>.
 					</li>
 					<li>If the characteristic polynomial factors easily, use algebraic techniques like grouping, factoring by common terms, or recognizing patterns such as difference of squares or cubes.</li>
@@ -821,10 +821,6 @@
 			<title>Nonlinear Systems</title>
 
 			<introduction>
-				<p>
-					<xref provisional="FUTURE-WORK"/>
-				</p>
-
 				<p>
 					Linear systems give us a structured, predictable world—but the real world is rarely that neat. Most systems in nature are <em>nonlinear</em>: predator-prey populations affect each other in complex ways, economic models spiral or stabilize depending on feedback loops, and mechanical systems exhibit unexpected behavior when forces become too large.
 				</p>


### PR DESCRIPTION
## Summary

Clears the draft/placeholder markers and structural cruft that render as **visible defects** in the built book — audit task **M1 (Rec 4)**. Small, surgical edits across 12 files (+15 / −44).

## What changed

- **Provisional-xref placeholders** removed from three *in-build* introductions where a leftover `<xref provisional=…/>` sat right before the real intro prose: the `nonlinear-systems` chapter intro (`main.ptx`), `c6-qm/sec-parameter-analysis.ptx`, and `c6-qm/sec-logistical-models.ptx`. The real prose is untouched.
- **`-COMMENTED-`** stray literal deleted from the Ch. 8 outcomes list in `main.ptx` — the sentence now flows into the valid `<xref>` it preceded.
- **`label="NEEDS-A-LABEL"`** in the Ch. 14 section replaced with `label="nonlinear-systems"`.
- **`(WebWorK Here For Mathquill?)`** internal note stripped from three student-facing titles in `c5-if/sec-finding-the-integrating-factor.ptx`.
- **Commented-out `PISS` credit block** deleted from `front-matter.ptx`; the `di-piss-medium` exercise label renamed to `di-rewrite-x7y-medium` (no other references).
- **Three empty `<caption>`s filled**: the cell-membrane figure (`exercises-linsys.ptx`) and the two equilibrium slope-field panels (`sec-classifying-equilibrium-solutions.ptx`).
- **Dead commented `<md>` block removed** in `sec-common-transforms.ptx` — it still carried a stale duplicate `xml:id="lt-L1"` (the live copy in the assemblage is kept; `validate_source` already reports 0 duplicate ids).
- **Subscript rendering bug** fixed: `L<m>_11</m>` → `L<m>_{11}</m>` in `exercises-ltp.ptx` (was rendering as "L₁1").
- `placeholder-baseline.json` tightened for the five files whose marker counts dropped.

## Verification

- `validate_source.py` → all checks pass (138/138 parse, 0 duplicate ids, placeholder ratchet green).
- `verify_worked_math.py` (SymPy) → 97/97 (no math semantics touched).
- `xmllint --xinclude source/main.ptx` assembles cleanly.
- Confirmed only intended lines changed (one file, `front-matter.ptx`, is CRLF; its edit was done at the byte level to avoid line-ending churn).

## Intentionally left for their own tasks

- **Ch. 14 stub** (`sec-nonlinear-systems.ptx`) still has its `FUTURE-WORK` marker and empty body — that content is owned by the separate *"build out Chapter 14"* task (M3). This PR only fixes its label.
- The **not-built** `a1-algebra` stub sections (`K/M/N/O/P`) and the **dev-only** master variants (`main-dev.ptx`, `back-matter-dev.ptx`) still contain provisional markers, but they aren't in the production build set and are slated for the archive/asset-prune tasks (L2/M2). Left untouched to keep this PR scoped to the shipped book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018vhHaJjo1fdpi2TBj7VMCc)_