### PR TITLE
M6: Preview exact, Bernoulli, and substitution methods

### DIFF
--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -1270,7 +1270,11 @@ REGISTRY += [
         ))(symbols("v")),
     ),
     Check(
-        "c5 preview drill 1a: y' + y/x = x y^2 is Bernoulli (n=2), y = 1/(Cx - x^2)",
+        # The drill only asks which method fits, so the book does not print a
+        # solution here. This guards the choice of equation: it really is a
+        # Bernoulli (n=2) with a clean closed form, which is why it was picked
+        # over one whose solution needs an exponential integral.
+        "c5 preview drill 1a equation is a solvable Bernoulli, n=2 (solution not printed)",
         "source/c5-if/review-first-order-methods.ptx",
         lambda: (lambda yb: is_zero(diff(yb, x) + yb / x - x * yb**2))(
             1 / (C1 * x - x**2)

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -132,6 +132,16 @@ def rounds_to(value, printed, places) -> bool:
     return round(R(value) * scale) == round(R(printed) * scale)
 
 
+def is_exact_equation(M, N, v1, v2) -> bool:
+    """The equation M + N y' = 0 passes the exactness test dM/dy = dN/dx."""
+    return is_zero(diff(M, v2) - diff(N, v1))
+
+
+def is_potential_for(F, M, N, v1, v2) -> bool:
+    """F is a potential function for M + N y' = 0, i.e. F_x = M and F_y = N."""
+    return is_zero(diff(F, v1) - M) and is_zero(diff(F, v2) - N)
+
+
 def step_count(span, h) -> int:
     """Steps needed to cover ``span`` with step size ``h``.
 
@@ -1223,6 +1233,70 @@ REGISTRY += [
         "source/c7-em/sec-euler-accuracy.ptx",
         lambda: rounds_to(em_error(heun, 2).evalf(30), R(23834, 1000000), 6)
         and rounds_to(em_error(euler, 16).evalf(30), R(24656, 1000000), 6),
+    ),
+]
+
+
+# ----------------------------------------------------------------------
+# M6 — first-order unit, "Preview: Other Tools You May Meet"
+#
+# The three previewed methods are not taught, but every solution the
+# preview prints is still a claim the book makes, so each is verified.
+# ----------------------------------------------------------------------
+REGISTRY += [
+    Check(
+        "c5 preview exact: (2xy+3)+(x^2-1)y'=0 is exact, F = x^2 y + 3x - y",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: is_exact_equation(2 * x * y + 3, x**2 - 1, x, y)
+        and is_potential_for(x**2 * y + 3 * x - y, 2 * x * y + 3, x**2 - 1, x, y),
+    ),
+    Check(
+        "c5 preview Bernoulli: y = 1/(x+1+Ce^x) solves y' + y = x y^2",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (lambda yb: is_zero(diff(yb, x) + yb - x * yb**2))(
+            1 / (x + 1 + C1 * exp(x))
+        ),
+    ),
+    Check(
+        "c5 preview Bernoulli: substitution v = 1/y turns y'+y=xy^2 into v'-v=-x",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (lambda v: is_zero(simplify(diff(v, x) - v + x)))(x + 1 + C1 * exp(x)),
+    ),
+    Check(
+        "c5 preview ratio form: v=y/x turns y'=(y-x)/(y+x) into x v' = -(1+v^2)/(1+v)",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (lambda v: is_zero(
+            simplify(((v - 1) / (v + 1) - v) + (1 + v**2) / (1 + v))
+        ))(symbols("v")),
+    ),
+    Check(
+        "c5 preview drill 1a: y' + y/x = x y^2 is Bernoulli (n=2), y = 1/(Cx - x^2)",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (lambda yb: is_zero(diff(yb, x) + yb / x - x * yb**2))(
+            1 / (C1 * x - x**2)
+        ),
+    ),
+    Check(
+        "c5 preview drill 1b: y'=(x^2+y^2)/(xy) depends only on the ratio y/x",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: (lambda v: simplify(
+            ((x**2 + y**2) / (x * y)).subs(y, v * x)
+        ).free_symbols == {v})(symbols("v")),
+    ),
+    Check(
+        "c5 preview drill 1c: (3x^2+y)+(x-2y)y'=0 is exact, F = x^3 + xy - y^2",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: is_exact_equation(3 * x**2 + y, x - 2 * y, x, y)
+        and is_potential_for(x**3 + x * y - y**2, 3 * x**2 + y, x - 2 * y, x, y),
+    ),
+    Check(
+        "c5 preview drill 2: (A) exact with F = xy^2+x^2+y; (B) not exact",
+        "source/c5-if/review-first-order-methods.ptx",
+        lambda: is_exact_equation(y**2 + 2 * x, 2 * x * y + 1, x, y)
+        and is_potential_for(
+            x * y**2 + x**2 + y, y**2 + 2 * x, 2 * x * y + 1, x, y
+        )
+        and not is_exact_equation(y**2 + 2 * x, x * y + 1, x, y),
     ),
 ]
 

--- a/source/aa-bookends/glossary.ptx
+++ b/source/aa-bookends/glossary.ptx
@@ -583,8 +583,8 @@
     <p>
       A first-order equation written as <m>M(x,y) + N(x,y)\,y' = 0</m> is <term>exact</term> when
       <md>
-        \frac{\partial M}{\partial y} = \frac{\partial N}{\partial x},
-      </md>
+        \frac{\partial M}{\partial y} = \frac{\partial N}{\partial x}
+      </md>,
       which means the left side is already the derivative of a single function <m>F(x,y)</m>. Its solutions are then the level curves <m>F(x,y)=C</m>. Previewed in this book, not taught.
     </p>
   </gi>
@@ -594,8 +594,8 @@
     <p>
       A first-order equation that is linear except for a power of the unknown on the right:
       <md>
-        y' + P(x)\,y = Q(x)\,y^{n}, \qquad n \neq 0, 1 .
-      </md>
+        y' + P(x)\,y = Q(x)\,y^{n}, \qquad n \neq 0, 1
+      </md>.
       The substitution <m>v = y^{1-n}</m> converts it into a
       <xref ref="gi-first-order-linear-differential-equation" text="title"/>, solvable by the
       <xref ref="gi-integrating-factor-method" text="title"/>. Previewed in this book, not taught.
@@ -607,8 +607,8 @@
     <p>
       A first-order equation whose right side depends on <m>x</m> and <m>y</m> only through their ratio:
       <md>
-        \frac{dy}{dx} = F\left(\frac{y}{x}\right).
-      </md>
+        \frac{dy}{dx} = F\left(\frac{y}{x}\right)
+      </md>.
       The substitution <m>v = y/x</m> makes it <xref ref="gi-separable" text="custom">separable</xref>. Most references call these equations <term>homogeneous</term>, which collides with this book's use of that word for a
       <xref ref="gi-homogeneous-linear-differential-equation" text="custom">linear equation whose forcing term is zero</xref>; the two senses are unrelated. Previewed in this book, not taught.
     </p>

--- a/source/aa-bookends/glossary.ptx
+++ b/source/aa-bookends/glossary.ptx
@@ -576,6 +576,44 @@
     </tabular>
   </gi>
 
+  <!-- Previewed only (see "Preview: Other Tools You May Meet"); not taught in this book. -->
+
+  <gi xml:id="gi-exact-equation">
+    <title>exact equation</title>
+    <p>
+      A first-order equation written as <m>M(x,y) + N(x,y)\,y' = 0</m> is <term>exact</term> when
+      <md>
+        \frac{\partial M}{\partial y} = \frac{\partial N}{\partial x},
+      </md>
+      which means the left side is already the derivative of a single function <m>F(x,y)</m>. Its solutions are then the level curves <m>F(x,y)=C</m>. Previewed in this book, not taught.
+    </p>
+  </gi>
+
+  <gi xml:id="gi-bernoulli-equation">
+    <title>Bernoulli equation</title>
+    <p>
+      A first-order equation that is linear except for a power of the unknown on the right:
+      <md>
+        y' + P(x)\,y = Q(x)\,y^{n}, \qquad n \neq 0, 1 .
+      </md>
+      The substitution <m>v = y^{1-n}</m> converts it into a
+      <xref ref="gi-first-order-linear-differential-equation" text="title"/>, solvable by the
+      <xref ref="gi-integrating-factor-method" text="title"/>. Previewed in this book, not taught.
+    </p>
+  </gi>
+
+  <gi xml:id="gi-ratio-form-equation">
+    <title>ratio-form (homogeneous) first-order equation</title>
+    <p>
+      A first-order equation whose right side depends on <m>x</m> and <m>y</m> only through their ratio:
+      <md>
+        \frac{dy}{dx} = F\left(\frac{y}{x}\right).
+      </md>
+      The substitution <m>v = y/x</m> makes it <xref ref="gi-separable" text="custom">separable</xref>. Most references call these equations <term>homogeneous</term>, which collides with this book's use of that word for a
+      <xref ref="gi-homogeneous-linear-differential-equation" text="custom">linear equation whose forcing term is zero</xref>; the two senses are unrelated. Previewed in this book, not taught.
+    </p>
+  </gi>
+
   <!-- ============================================================ -->
   <!-- Qualitative Methods Terms                                    -->
   <!-- ============================================================ -->

--- a/source/c4-sov/exercises-sov.ptx
+++ b/source/c4-sov/exercises-sov.ptx
@@ -1926,7 +1926,7 @@
 					<statement><m>\dfrac{dy}{dx} = \frac{y-x}{y+x}</m></statement>
 					<solution>
 						<p>
-							This one is <em>not possible</em> with separation of variables: no algebra turns <m>\frac{y-x}{y+x}</m> into a product <m>f(x)\cdot g(y)</m> — the sum <m>y+x</m> in the denominator inseparably mixes the variables. (Equations like this can be solved with a substitution method not covered in this book.)
+							This one is <em>not possible</em> with separation of variables: no algebra turns <m>\frac{y-x}{y+x}</m> into a product <m>f(x)\cdot g(y)</m> — the sum <m>y+x</m> in the denominator inseparably mixes the variables. (Equations like this <em>can</em> be solved, but with a substitution that first turns them into separable ones — previewed in <xref ref="fo-review-other-methods" text="title"/>.)
 						</p>
 					</solution>
 					<answer><p>Not separable — no algebra puts <m>\frac{y-x}{y+x}</m> into the form <m>f(x)\cdot g(y)</m>.</p></answer>

--- a/source/c5-if/review-first-order-methods.ptx
+++ b/source/c5-if/review-first-order-methods.ptx
@@ -592,7 +592,7 @@
 				<choices randomize="yes">
 					<choice correct="yes">
 						<statement><p>Substitution <m>v = y/x</m>, which makes it separable.</p></statement>
-						<feedback><p>Dividing top and bottom by <m>x^2</m> gives <m>\ds\frac{1 + (y/x)^2}{y/x}</m> — a function of the ratio alone, which is the homogeneous shape.</p></feedback>
+						<feedback><p>Dividing top and bottom by <m>x^2</m> gives <m>\ds\frac{1 + (y/x)^2}{y/x}</m> — a function of the ratio alone, which is the ratio-form shape.</p></feedback>
 					</choice>
 					<choice correct="no">
 						<statement><p>Bernoulli, with <m>v = y^{-1}</m>.</p></statement>

--- a/source/c5-if/review-first-order-methods.ptx
+++ b/source/c5-if/review-first-order-methods.ptx
@@ -54,7 +54,7 @@
 				</li>
 				<li>
 					<p>
-						If an equation fails every test in the chart, that doesn't mean it's hopeless—it means none of our <em>formula</em> methods apply. The next two chapters build tools for exactly this situation: <xref ref="chpt-qualitative" text="custom">qualitative methods</xref> to describe how solutions behave, and <xref ref="chpt-eulers-method" text="custom">Euler's method</xref> to approximate them numerically.
+						If an equation fails every test in the chart, that doesn't mean it's hopeless—it means none of our <em>formula</em> methods apply. The next two chapters build tools for exactly this situation: <xref ref="chpt-qualitative" text="custom">qualitative methods</xref> to describe how solutions behave, and <xref ref="chpt-eulers-method" text="custom">Euler's method</xref> to approximate them numerically. A few standard formula methods that this book does not teach also live out there, and <xref ref="fo-review-other-methods" text="title"/> at the end of this review says where they fit.
 					</p>
 				</li>
 			</ul>
@@ -484,5 +484,191 @@
 				</answer>
 			</exercise>
 		</exercisegroup>
+	</exercises>
+
+	<exercises label="fo-review-other-methods">
+		<title>Preview: Other Tools You May Meet</title>
+
+		<p>
+			<idx><h>first-order methods</h><h>other</h></idx>
+			The flowchart's final <c>No</c> branch sends you to qualitative and numerical methods, and that is an honest answer — those are the tools <em>this book</em> builds. But a standard differential equations syllabus usually carries a few more formula methods, and you may meet them in another course, in a table of techniques, or in someone else's notes. This preview says where each one fits, so that none of them arrives as a surprise.
+		</p>
+
+		<p>
+			One reassuring pattern runs through all three. None is a new world with its own theory. Each recognizes a special <em>shape</em>, performs a single move, and hands the problem straight back to a method you already own.
+		</p>
+
+		<p>
+			<term>Exact equations.</term> Written as <m>M(x,y) + N(x,y)\,y' = 0</m>, the equation is called <term>exact</term> when
+			<md>
+				\frac{\partial M}{\partial y} = \frac{\partial N}{\partial x} .
+			</md>
+			That test is checking whether the left side is <em>already</em> the derivative of a single function <m>F(x,y)</m> — which should sound familiar, because it is this chapter's <q>completing the product rule</q> idea asked in two variables. There we multiplied by <m>\mu</m> to <em>make</em> the left side a single derivative; here we test whether it is one for free. When it is, the solutions are the level curves <m>F(x,y) = C</m>, and nothing needs solving at all — only antidifferentiating to rebuild <m>F</m>.
+		</p>
+
+		<p>
+			For instance, <m>(2xy + 3) + (x^2 - 1)\,y' = 0</m> passes the test, since <m>\partial M/\partial y = 2x = \partial N/\partial x</m>. Rebuilding <m>F</m> from <m>F_x = 2xy+3</m> and <m>F_y = x^2-1</m> gives <m>F = x^2 y + 3x - y</m>, so the solutions are
+			<md>
+				x^2 y + 3x - y = C .
+			</md>
+		</p>
+
+		<p>
+			<term>Bernoulli equations.</term> These look linear except for a power of <m>y</m> on the right:
+			<md>
+				y' + P(x)\,y = Q(x)\,y^{n}, \qquad n \neq 0, 1 .
+			</md>
+			The single move is the substitution <m>v = y^{1-n}</m>, which turns the equation into a <em>linear</em> equation in <m>v</m> — landing you back in the integrating factor method you just finished learning. For example, <m>y' + y = x y^2</m> has <m>n = 2</m>, so <m>v = y^{-1}</m> and the equation becomes <m>v' - v = -x</m>. The integrating factor <m>\mu = e^{-x}</m> gives <m>v = x + 1 + Ce^{x}</m>, so
+			<md>
+				y = \frac{1}{x + 1 + Ce^{x}} .
+			</md>
+		</p>
+
+		<p>
+			<term>Substitution for ratio-form equations.</term> When the right side depends on <m>x</m> and <m>y</m> only through their ratio,
+			<md>
+				\frac{dy}{dx} = F\left(\frac{y}{x}\right),
+			</md>
+			the move is <m>v = y/x</m>. Then <m>y = vx</m> and <m>y' = v + x v'</m>, and the equation becomes <em>separable</em> in <m>v</m> — back to <xref ref="chpt-separable-variables" text="title"/>. The equation <m>\dfrac{dy}{dx} = \dfrac{y-x}{y+x}</m> is one of these: dividing top and bottom by <m>x</m> turns the right side into <m>\dfrac{v-1}{v+1}</m>, and the substitution reduces the whole equation to
+			<md>
+				x\,\frac{dv}{dx} = -\frac{1 + v^2}{1 + v},
+			</md>
+			which separates.
+		</p>
+
+		<aside>
+			<title>A Familiar Face</title>
+			<p>
+				That last equation is the one from the separation-of-variables drills that we marked <q>not possible.</q> The verdict there was accurate and worth keeping: it genuinely is not separable <em>as written</em>. What it needed was not a cleverer algebra trick but a substitution that <em>makes</em> it separable — exactly the tool above.
+			</p>
+		</aside>
+
+		<aside>
+			<title>Two Meanings of <q>Homogeneous</q></title>
+			<p>
+				Most references call the ratio-form equations <term>homogeneous</term>, and you should be ready for that — but be careful, because this book already uses that word for something else. In <xref ref="chpt-homogeneous-eqns" text="title"/> and beyond, <em>homogeneous</em> means the <xref ref="gi-forcing-term-function" text="custom">forcing term</xref> is zero, as in <m>y'' - 3y' + 2y = 0</m>. The two senses are unrelated: one is about the shape of a first-order right side, the other about a missing term in a linear equation. When you meet the word, check which kind of equation is being discussed.
+			</p>
+		</aside>
+
+		<p>
+			None of these three is required anywhere in this book, and no exercise here will demand them. They are listed so the map is complete: when you meet <q>exact,</q> <q>Bernoulli,</q> or <q>use the substitution <m>v = y/x</m>,</q> you will recognize the shape being matched and know which of your own methods the problem is about to become.
+		</p>
+
+		<exercise label="fo-review-other-1">
+			<title>Which Tool Fits the Shape?</title>
+
+			<task label="fo-review-other-1a">
+				<statement>
+					<p>
+						Which preview method is designed for <m>\ds y' + \frac{y}{x} = x y^2</m>?
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement><p>Bernoulli, with the substitution <m>v = y^{-1}</m>.</p></statement>
+						<feedback><p>The equation is linear except for the <m>y^2</m> on the right, which is the Bernoulli shape with <m>n = 2</m>. Then <m>v = y^{1-2} = y^{-1}</m>.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>Exact, after checking <m>\partial M/\partial y = \partial N/\partial x</m>.</p></statement>
+						<feedback><p>The exactness test applies to equations arranged as <m>M + N y' = 0</m>. This one is in the standard linear layout, with a power of <m>y</m> spoiling it.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>Substitution <m>v = y/x</m>, because the right side is a function of <m>y/x</m>.</p></statement>
+						<feedback><p>Check that claim: <m>x y^2</m> is not a function of the ratio <m>y/x</m> alone — replacing <m>y</m> with <m>vx</m> leaves an <m>x</m> behind.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>The integrating factor method, unchanged.</p></statement>
+						<feedback><p>The integrating factor method needs a <em>linear</em> equation. The <m>y^2</m> disqualifies it — until the Bernoulli substitution removes it.</p></feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-other-1b">
+				<statement>
+					<p>
+						Which preview method is designed for <m>\ds y' = \frac{x^2 + y^2}{xy}</m>?
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement><p>Substitution <m>v = y/x</m>, which makes it separable.</p></statement>
+						<feedback><p>Dividing top and bottom by <m>x^2</m> gives <m>\ds\frac{1 + (y/x)^2}{y/x}</m> — a function of the ratio alone, which is the homogeneous shape.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>Bernoulli, with <m>v = y^{-1}</m>.</p></statement>
+						<feedback><p>Bernoulli needs the layout <m>y' + P(x)y = Q(x)y^n</m>. This right side is a single quotient mixing both variables, not that shape.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>Separation of variables, directly.</p></statement>
+						<feedback><p>No algebra splits <m>\ds\frac{x^2+y^2}{xy}</m> into <m>f(x)\cdot g(y)</m>. The substitution is what creates a separable equation.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>Direct integration.</p></statement>
+						<feedback><p>Direct integration needs the left side to already be a single derivative and the right side to depend on <m>x</m> alone.</p></feedback>
+					</choice>
+				</choices>
+			</task>
+
+			<task label="fo-review-other-1c">
+				<statement>
+					<p>
+						Apply the exactness test to <m>\left(3x^2 + y\right) + \left(x - 2y\right) y' = 0</m>. Is it exact?
+					</p>
+				</statement>
+				<choices randomize="yes">
+					<choice correct="yes">
+						<statement><p>Yes: <m>\partial M/\partial y = 1</m> and <m>\partial N/\partial x = 1</m>.</p></statement>
+						<feedback><p>Both partials equal <m>1</m>, so the left side is already a single derivative. Rebuilding <m>F</m> gives the solutions <m>x^3 + xy - y^2 = C</m>.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>No: <m>\partial M/\partial y = 6x</m> and <m>\partial N/\partial x = 1</m>.</p></statement>
+						<feedback><p><m>6x</m> is <m>\partial M/\partial x</m>. The test differentiates <m>M</m> with respect to <m>y</m>, holding <m>x</m> constant, which gives <m>1</m>.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>No: <m>\partial M/\partial y = 1</m> and <m>\partial N/\partial x = -2</m>.</p></statement>
+						<feedback><p><m>-2</m> comes from differentiating <m>N = x - 2y</m> with respect to <m>y</m>. The test needs <m>\partial N/\partial x</m>, which is <m>1</m>.</p></feedback>
+					</choice>
+					<choice correct="no">
+						<statement><p>The test does not apply until the equation is in standard linear form.</p></statement>
+						<feedback><p>The exactness test wants the <m>M + N y' = 0</m> arrangement, which is exactly how this equation is written.</p></feedback>
+					</choice>
+				</choices>
+			</task>
+		</exercise>
+
+		<exercise label="fo-review-other-2">
+			<title>One Test, Two Equations</title>
+			<statement>
+				<p>
+					Exactly one of these two equations is exact. Which one, and what is the test that separates them?
+					<md>
+						<mrow>\text{(A)} \quad \amp \left(y^2 + 2x\right) + \left(2xy + 1\right) y' = 0</mrow>
+						<mrow>\text{(B)} \quad \amp \left(y^2 + 2x\right) + \left(xy + 1\right) y' = 0</mrow>
+					</md>
+				</p>
+			</statement>
+			<solution>
+				<p>
+					The test compares <m>\partial M / \partial y</m> against <m>\partial N / \partial x</m>. Both equations share <m>M = y^2 + 2x</m>, so <m>\partial M/\partial y = 2y</m> in each case.
+				</p>
+				<p>
+					For (A), <m>N = 2xy + 1</m> gives <m>\partial N/\partial x = 2y</m>. The two agree, so (A) is exact.
+				</p>
+				<p>
+					For (B), <m>N = xy + 1</m> gives <m>\partial N/\partial x = y</m>, which does not match <m>2y</m>. So (B) is not exact — and no rearranging changes that, since the test is a property of the equation itself.
+				</p>
+				<p>
+					Since (A) passes, its left side is the derivative of a single function. Antidifferentiating <m>F_x = y^2 + 2x</m> gives <m>F = xy^2 + x^2 + g(y)</m>; matching <m>F_y = 2xy + g'(y)</m> against <m>N = 2xy + 1</m> forces <m>g(y) = y</m>. The solutions are the level curves
+					<md>
+						xy^2 + x^2 + y = C .
+					</md>
+				</p>
+			</solution>
+			<answer>
+				<p>
+					(A) is exact, since <m>\partial M/\partial y = \partial N/\partial x = 2y</m>; its solutions are <m>xy^2 + x^2 + y = C</m>. In (B), <m>\partial N/\partial x = y \neq 2y</m>.
+				</p>
+			</answer>
+		</exercise>
 	</exercises>
 </section>


### PR DESCRIPTION
Closes audit task **M6** (Rec 15). Exact equations, Bernoulli equations, and substitution methods are absent book-wide, so a student arriving from a standard syllabus has no way to place them. This adds the "other tools you may meet" pointer the audit asks for, at the end of the first-order unit.

## Where it goes and why it looks like this

The new block closes the mixed-review section — literally the end of the first-order unit — and mirrors the book's existing "Preview of a Future Method" device in c3: prose that situates the method, followed by light recognition exercises rather than a full treatment. The audit named that device explicitly, and it happens to be an `exercises` block, so the structure here is identical to what the file already contains.

All three methods get the same framing, because it is the honest one: **none is a new world with its own theory.** Each recognizes a shape, makes one move, and hands the problem back to a method the reader already owns.

| Method | The shape | The move | Lands on |
|---|---|---|---|
| **Exact** | `M + N y' = 0` with `∂M/∂y = ∂N/∂x` | rebuild `F` by antidifferentiating | nothing left to solve — solutions are `F(x,y) = C` |
| **Bernoulli** | `y' + P(x)y = Q(x)yⁿ` | substitute `v = y^(1−n)` | the integrating factor method |
| **Ratio-form** | `y' = F(y/x)` | substitute `v = y/x` | separation of variables |

The exact-equation entry ties back to this chapter directly: the exactness test is asking whether the left side is *already* a single derivative, which is the "complete the product rule" idea of ch. 5 asked in two variables. There we multiplied by `μ` to *make* it one; here we test whether it is one for free.

## Two things handled rather than inherited

**A dangling pointer now resolves.** The ratio-form example is deliberately `dy/dx = (y−x)/(y+x)` — the c4 drill the book marks "not possible" with separation of variables. That solution's parenthetical said such equations "can be solved with a substitution method not covered in this book," which pointed at nothing. It now points here. The verdict itself is unchanged and still correct: the equation genuinely is not separable *as written*; what it needed was a substitution that *makes* it separable.

**A name collision, flagged rather than propagated.** Most references call ratio-form equations **homogeneous** — which collides head-on with this book's use of that word for a linear equation whose forcing term is zero (`gi-homogeneous-linear-differential-equation`, and the whole of ch. 8). The preview leads with "ratio-form," and an aside names the collision explicitly so a reader meeting the standard term elsewhere is not misled. The glossary entry carries the same warning, and all three new glossary entries state plainly that the method is *previewed, not taught*, so the glossary does not imply coverage the book lacks.

## Verification

| Check | Result |
|---|---|
| `verify_worked_math.py` | **144/144** (136 existing + **8 new**) |
| `validate_source.py` | all parse · unique ids, 0 duplicated · 0 placeholder markers |
| `check_descriptions.py` | full coverage (no new images or interactives) |

The 8 new checks verify every solution the preview prints — both exactness tests *and* their potential functions (`F_x = M` and `F_y = N` checked directly), the Bernoulli solution and its `v`-substitution, the ratio-form reduction, and all three recognition drills. Cross-references all resolve; the 7 broken ones in the build set are pre-existing, in c8/c10/c11. Markup conformance: **0 novel constructs** across all three changed files.

## A correction to something I claimed on #210

On that PR I described the RELAX NG check as having caught "two real markup errors," one being list items wrapping paragraphs inside a paragraph-wrapped list. **That framing was wrong.** Checking properly while validating this change: the pattern appears **191 times across 25 shipping files**. PreTeXt 2.44.0 evidently accepts it and the `master` schema is simply stricter. The #210 edit was harmless — the unwrapped form is valid either way — but it was not a bug fix, and there is no latent problem class here worth chasing. Recording it so the earlier claim does not mislead anyone reading back through the audit trail.

The `hint`-inside-`statement` instance flagged on that PR is likewise a single pre-existing occurrence (`exercises-sov.ptx:772`, in a short-answer task). Left alone here as out of scope.

## Notes

- No new sections or exercises are *required* by this change; the preview explicitly says none of the three methods is needed anywhere in the book. The audit's "full sections optional" is deliberately not taken up.
- **Branch restarted from `main`** after #211 merged, so the force-push discarded only already-merged commits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvouB9AeGksUwTnJC4LdfA)_