### PR TITLE
Add a README inventorying the processing-tools scripts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ This repository contains *Exploring Differential Equations*, an open-access, stu
 - `source/` — modular textbook source. Most authoring work happens here.
 - `publication/` — publication and Runestone configuration.
 - `assets/` — custom JavaScript, CSS/SCSS, images, data, and interactive assets.
-- `processing-tools/` — scripts for TTS, audits, conversion, refactoring, and post-processing.
+- `processing-tools/` — scripts for TTS, audits, conversion, refactoring, and post-processing. See `processing-tools/README.md` for what each tool does and how to run it.
 - `.github/instructions/` — path-specific Copilot instructions.
 - `.github/ai-docs/` — task guides, skills, and prompt templates for human-initiated AI work.
 

--- a/processing-tools/README.md
+++ b/processing-tools/README.md
@@ -16,7 +16,7 @@ when you need them.
 | [`check-descriptions/`](#check-descriptions) | Accessibility: every image and interactive must be described | `python3 processing-tools/check-descriptions/check_descriptions.py` | `lxml` |
 | [`audit-status/`](#audit-status) | Reports which audit tasks are done, and refreshes the report's status table | `python3 processing-tools/audit-status/audit_status.py` | — |
 | [`tts/`](#tts) | Strips PreTeXt down to narration-ready text, plus the audit/render prompt pack | `python3 processing-tools/tts/preprocess_ptx_for_tts.py SRC DST` | `lxml` |
-| [`post-process-html/`](#post-process-html) | Applies find/replace rules to built HTML | `python3 processing-tools/post-process-html/postprocess_html.py replacements.json DIR` | — |
+| [`post-process-html/`](#post-process-html) | Applies find/replace rules to built HTML | `python3 processing-tools/post-process-html/postprocess_html.py processing-tools/replacements.json DIR` | — |
 | [`book-db-sync/`](#book-db-sync) | Two-way sync between section files and a SQLite database | `python3 processing-tools/book-db-sync/book_db_sync.py {init,pull,push,sync}` | — |
 | [`merge-sections-to-single-ptx.py`](#merge-sections-to-single-ptx) | Flattens `xi:include`s into one file | `python3 processing-tools/merge-sections-to-single-ptx.py` (interactive) | — |
 | [`latex2pretext-tools/`](#latex2pretext-tools) | The LaTeX → PreTeXt conversion toolchain | notebooks, run by hand | Jupyter, `tkinter` |
@@ -203,15 +203,19 @@ python3 processing-tools/merge-sections-to-single-ptx.py
 
 ### latex2pretext-tools
 
-The toolchain used to convert this book's earlier LaTeX source into PreTeXt.
+The toolchain used to convert this book's earlier LaTeX source into PreTeXt. All
+four files live in `latex2pretext-tools/`:
 
-- `latex_to_pretext_parsing_tools.py` — a library of ~30 parsing helpers
-  (sections, examples, lists, tables, display math, `verbatim`, indentation and
-  `<p>`-tag repair). It has no `__main__`; the notebooks import it.
-- `latex_to_pretext_parser.ipynb` — the main conversion run.
-- `Create-Specific-Sections.ipynb` — converts selected sections rather than a
-  whole book.
-- `Debugging_Script.ipynb` — a scratch notebook for inspecting conversion output.
+- [`latex_to_pretext_parsing_tools.py`](latex2pretext-tools/latex_to_pretext_parsing_tools.py)
+  — a library of ~30 parsing helpers (sections, examples, lists, tables, display
+  math, `verbatim`, indentation and `<p>`-tag repair). It has no `__main__`; the
+  notebooks import it.
+- [`latex_to_pretext_parser.ipynb`](latex2pretext-tools/latex_to_pretext_parser.ipynb)
+  — the main conversion run.
+- [`Create-Specific-Sections.ipynb`](latex2pretext-tools/Create-Specific-Sections.ipynb)
+  — converts selected sections rather than a whole book.
+- [`Debugging_Script.ipynb`](latex2pretext-tools/Debugging_Script.ipynb)
+  — a scratch notebook for inspecting conversion output.
 
 The notebooks use `tkinter` file dialogs to pick input, so they need a desktop
 session. This is migration tooling rather than part of the routine authoring

--- a/processing-tools/README.md
+++ b/processing-tools/README.md
@@ -1,0 +1,240 @@
+# processing-tools
+
+Helper scripts for the *Exploring Differential Equations* PreTeXt source. Nothing
+here is part of the book itself — these tools check the source, transform it, or
+support workflows around it.
+
+Three of them run automatically on every pull request. The rest are run by hand,
+when you need them.
+
+## Quick reference
+
+| Tool | What it does | Run it with | Needs |
+|---|---|---|---|
+| [`validate-source/`](#validate-source) | Fast source gate: XML well-formedness, duplicate ids, placeholder ratchet | `python3 processing-tools/validate-source/validate_source.py` | — |
+| [`verify-worked-math/`](#verify-worked-math) | Re-derives every printed answer with SymPy | `python3 processing-tools/verify-worked-math/verify_worked_math.py` | `sympy` |
+| [`check-descriptions/`](#check-descriptions) | Accessibility: every image and interactive must be described | `python3 processing-tools/check-descriptions/check_descriptions.py` | `lxml` |
+| [`audit-status/`](#audit-status) | Reports which audit tasks are done, and refreshes the report's status table | `python3 processing-tools/audit-status/audit_status.py` | — |
+| [`tts/`](#tts) | Strips PreTeXt down to narration-ready text, plus the audit/render prompt pack | `python3 processing-tools/tts/preprocess_ptx_for_tts.py SRC DST` | `lxml` |
+| [`post-process-html/`](#post-process-html) | Applies find/replace rules to built HTML | `python3 processing-tools/post-process-html/postprocess_html.py replacements.json DIR` | — |
+| [`book-db-sync/`](#book-db-sync) | Two-way sync between section files and a SQLite database | `python3 processing-tools/book-db-sync/book_db_sync.py {init,pull,push,sync}` | — |
+| [`merge-sections-to-single-ptx.py`](#merge-sections-to-single-ptx) | Flattens `xi:include`s into one file | `python3 processing-tools/merge-sections-to-single-ptx.py` (interactive) | — |
+| [`latex2pretext-tools/`](#latex2pretext-tools) | The LaTeX → PreTeXt conversion toolchain | notebooks, run by hand | Jupyter, `tkinter` |
+
+"Needs" lists third-party packages only; everything else is Python standard
+library. Install the two that matter with `pip install sympy lxml`.
+
+---
+
+## The CI gates
+
+These three run on every pull request via
+[`.github/workflows/validate.yml`](../.github/workflows/validate.yml). They take
+seconds, need no PreTeXt build, and each exits nonzero on failure. Run them
+locally before pushing and CI will rarely surprise you.
+
+### validate-source
+
+`validate-source/validate_source.py` — three static checks over the source tree:
+
+1. **Well-formedness** — every `source/**/*.ptx` must parse as XML.
+2. **Unique ids** — no `xml:id` or `label` value may be defined twice within the
+   `main.ptx` build set. PreTeXt treats the two attributes as one namespace, so
+   reusing a string across them is a duplicate. Ids inside XML comments are
+   ignored, as the builder ignores them too.
+3. **Placeholder ratchet** — counts of draft markers (`provisional` xrefs,
+   `NEEDS-A-LABEL`, `Need to Add`, `FUTURE-WORK`, …) are compared per file
+   against `placeholder-baseline.json`. New markers fail. Removing markers only
+   prints a reminder to tighten the baseline, so the ratchet can never loosen.
+
+Checks 2 and 3 run on the files reachable from `source/main.ptx`, so the stranded
+dev and parts variants cannot cause false duplicates. Check 1 runs on every
+`.ptx` file.
+
+Takes no arguments. Standard library only.
+
+### verify-worked-math
+
+`verify-worked-math/verify_worked_math.py` — re-derives printed mathematics with
+SymPy and compares against what the book actually says. Each check names the
+source file it guards, so a failure points at the exact spot where the book
+disagrees with the mathematics.
+
+The registry is curated by hand and currently holds over 140 checks covering worked
+examples, answer keys, interactive widgets' "correct" options, Laplace
+transforms, Euler and Heun steps, equilibria, Jacobians, and eigenvalues. It was
+seeded from the July 2026 audit's errata table so that fixed errors stay fixed.
+
+Adding a check: append a `Check` to `REGISTRY`. Prefer verifying the *printed*
+final answer — the thing a student reads — rather than an intermediate step.
+
+Takes no arguments. Needs `sympy`. See
+[`verify-worked-math/README.md`](verify-worked-math/README.md) for details.
+
+### check-descriptions
+
+`check-descriptions/check_descriptions.py` — every `<image>` and `<interactive>`
+in the build set must carry a `<shortdescription>` or `<description>`, or be
+marked `decorative="yes"`. This is the accessibility (WCAG/508) gate; the book
+went from zero coverage to complete, and this keeps it there.
+
+Pass `--list` to print the described elements rather than just the summary.
+Needs `lxml`.
+
+---
+
+## Author tools
+
+Not wired into CI. Run these when the task calls for them.
+
+### audit-status
+
+`audit-status/audit_status.py` — reports the completion status of every task in
+`reports/2026-07-textbook-audit.md` by cross-referencing git history. A task
+counts as done when a commit merged into the target branch tags that task's id
+in its subject line, in either shape seen in this repo's history:
+
+```
+H2: Rebuild partial-fractions appendix ... (#189)     # id at the start
+Fix confirmed mathematical errata ... (H1) (#187)     # id in parentheses
+```
+
+Running it with no arguments prints the table *and* rewrites the `AUDIT-STATUS`
+block near the top of the report, so the report always shows current status. It
+is idempotent.
+
+```sh
+python3 processing-tools/audit-status/audit_status.py           # print + refresh the report
+python3 processing-tools/audit-status/audit_status.py --print   # print only, don't touch the report
+python3 processing-tools/audit-status/audit_status.py --ref main
+```
+
+A short `UNTAGGED_COMPLETIONS` map covers the handful of tasks whose merge commit
+omitted the task id. Entries there are verified, not asserted — a task is only
+credited when the named pull request actually appears in the ref being matched
+against. Keep it small: new work should tag its id in the subject.
+
+### tts
+
+`tts/preprocess_ptx_for_tts.py` — turns `.ptx` files into narration-ready text.
+It drops tags that make no sense read aloud (exercises, figures, tables, images),
+strips `label` / `xml:id` attributes and emoji, and keeps the pacing structure
+(`<p>`, `<aside>`, sectioning) along with `<m>` / `<md>` math.
+
+```sh
+python3 processing-tools/tts/preprocess_ptx_for_tts.py SRC_FOLDER DST_FOLDER
+```
+
+Processes a folder non-recursively. Several flags adjust what survives
+(`--keep-xref`, `--no-strip-emojis`, `--keep-label-attr`, and others — see
+`--help`). Needs `lxml`.
+
+The rest of `tts/` is not code. The `UPL_*` and `PST_*` markdown files are a
+prompt pack: a documented, repeatable process for auditing PreTeXt source and
+rendering narration scripts, built around one authoritative ruleset plus
+per-mode deltas. [`tts/README.md`](tts/README.md) is the guide to that workflow
+and is the place to start.
+
+Generated narration output is deliberately not committed — `.gitignore` covers
+`processing-tools/tts/processed-ptx-to-txt/*.txt`.
+
+### post-process-html
+
+`post-process-html/postprocess_html.py` — applies a JSON list of find/replace
+rules to every HTML file in a directory, for fixes easier to make after the
+PreTeXt build than inside the source.
+
+```sh
+python3 processing-tools/post-process-html/postprocess_html.py \
+    processing-tools/replacements.json path/to/html-output
+```
+
+Rules live in [`replacements.json`](replacements.json) at the folder root. Each
+is `{"find": ..., "replace": ..., "regex": true|false}`; regex patterns are
+compiled up front so a bad pattern fails before any file is touched. The two
+current rules strip a redundant "Checkpoint N." span and tidy the 🎧 Listen
+aside title.
+
+`post-process-html/post-pretext-html-script.ipynb` is a notebook doing the same
+job interactively.
+
+### book-db-sync
+
+`book-db-sync/book_db_sync.py` — mirrors the book's section files into a SQLite
+database and back, for authors who would rather edit in a database than in a
+tree of XML files.
+
+```sh
+python3 processing-tools/book-db-sync/book_db_sync.py init
+python3 processing-tools/book-db-sync/book_db_sync.py pull    # source -> db
+python3 processing-tools/book-db-sync/book_db_sync.py push    # db -> source
+python3 processing-tools/book-db-sync/book_db_sync.py sync    # both, with conflict detection
+```
+
+`main.ptx` is treated as the canonical table of contents. Each side stores a
+SHA-256 fingerprint, so `sync` can tell a one-sided edit from a genuine
+conflict; resolve those explicitly with `--prefer source` or `--prefer db`.
+Other flags: `--db`, `--source-root`, `--main`.
+
+Standard library only. `.db` files are gitignored, so the database never lands in
+the repository. See [`book-db-sync/README.md`](book-db-sync/README.md) for the
+schema.
+
+### merge-sections-to-single-ptx
+
+`merge-sections-to-single-ptx.py` — the inverse of the book's modular layout.
+It resolves `xi:include` tags recursively and writes one flat `.ptx` file, which
+is useful when a tool wants the whole book as a single document. A missing
+include becomes an XML comment rather than a hard failure, so the output still
+parses.
+
+Run it with no arguments; it scans for candidate main files and prompts for the
+one to flatten and the output name:
+
+```sh
+python3 processing-tools/merge-sections-to-single-ptx.py
+```
+
+> **Note.** This is the one script here that is interactive rather than
+> `argparse`-driven, which puts it at odds with the convention in
+> [`.github/instructions/processing-tools.instructions.md`](../.github/instructions/processing-tools.instructions.md).
+> It cannot be scripted or run in CI as written. Worth converting to flags if it
+> ever needs to be automated.
+
+### latex2pretext-tools
+
+The toolchain used to convert this book's earlier LaTeX source into PreTeXt.
+
+- `latex_to_pretext_parsing_tools.py` — a library of ~30 parsing helpers
+  (sections, examples, lists, tables, display math, `verbatim`, indentation and
+  `<p>`-tag repair). It has no `__main__`; the notebooks import it.
+- `latex_to_pretext_parser.ipynb` — the main conversion run.
+- `Create-Specific-Sections.ipynb` — converts selected sections rather than a
+  whole book.
+- `Debugging_Script.ipynb` — a scratch notebook for inspecting conversion output.
+
+The notebooks use `tkinter` file dialogs to pick input, so they need a desktop
+session. This is migration tooling rather than part of the routine authoring
+workflow: the book is already PreTeXt, and these are kept for reference and for
+any future LaTeX material.
+
+---
+
+## Conventions
+
+When adding or editing a tool, follow
+[`.github/instructions/processing-tools.instructions.md`](../.github/instructions/processing-tools.instructions.md).
+In short: prefer small testable changes; use `argparse`, `pathlib`, and explicit
+UTF-8; validate inputs before writing anything; print a summary of what changed;
+fail safely on duplicate output paths, missing files, and invalid XML; preserve
+source formatting in PreTeXt transformations; and include a verification command
+when behavior changes.
+
+Two habits are worth keeping specifically for the checkers:
+
+- **Fail loudly rather than plausibly.** A validation tool that silently returns
+  a wrong number is worse than one that crashes, because the wrong number looks
+  like a pass. Raise on impossible input and let the caller report it.
+- **Name what a check actually guards.** A check's label should describe the
+  claim it verifies, so a failure sends the reader to the right place instead of
+  hunting for something the book never printed.


### PR DESCRIPTION
`processing-tools/` holds nine scripts, four notebooks, a prompt pack, and three sub-READMEs, with no index tying them together. Three of the scripts gate every pull request; the rest are run by hand. Nothing said which was which, what any of them needed installed, or how to invoke them.

This adds `processing-tools/README.md`.

## What's in it

A quick-reference table first, then the tools grouped by **whether CI runs them** — which turned out to be the most useful organizing split, since it separates "run this before pushing" from "run this when the task calls for it."

| | Tool | Purpose |
|---|---|---|
| **CI gates** | `validate-source/` | XML well-formedness, duplicate ids, placeholder ratchet |
| | `verify-worked-math/` | re-derives every printed answer with SymPy |
| | `check-descriptions/` | every image and interactive must be described |
| **Author tools** | `audit-status/` | which audit tasks are done; refreshes the report's status table |
| | `tts/` | narration-ready text, plus the audit/render prompt pack |
| | `post-process-html/` | find/replace rules over built HTML |
| | `book-db-sync/` | two-way sync between section files and SQLite |
| | `merge-sections-to-single-ptx.py` | flattens `xi:include`s into one file |
| | `latex2pretext-tools/` | the LaTeX → PreTeXt conversion toolchain |

Each entry says what the tool does, how to run it, and what it needs installed. The three tools that already have their own README — `book-db-sync`, `verify-worked-math`, `tts` — are summarized and linked rather than duplicated, so there's one place to update when they change.

## Everything here was checked, not transcribed

Documentation drifts when it's written from docstrings, so I verified against the code instead:

- **`--help` run on all five argparse scripts**; all five succeed. The two with no CLI were run to confirm they exit 0.
- **Dependencies from walking the import graph**, not from reading `import` lines by eye: `lxml` for two tools, `sympy` for one, everything else standard library.
- **Numeric claims read out of the source** — registry size, parsing-helper count, replacement-rule count, `book-db-sync` subcommands. (The draft said "~150 checks"; the actual count is 144, so it now says "over 140," which is true and won't go stale downward.)
- **Every relative link and in-page anchor resolves**, and **every `.py` and `.ipynb` in the folder is covered** — both checked programmatically.

No source files are touched, and the three gates still pass (144/144 math checks, source valid, descriptions complete).

## Two things surfaced while writing it

Recorded in the README rather than fixed here, since both are judgment calls beyond a documentation change:

- **`merge-sections-to-single-ptx.py` drives itself with `input()` prompts instead of `argparse`**, which conflicts with the folder's own convention in `.github/instructions/processing-tools.instructions.md` and means it can't be scripted or run in CI as written. Flagged inline with a note that it's worth converting if it ever needs automating.
- **`latex2pretext-tools/` is migration tooling** — the book is already PreTeXt — and its notebooks use `tkinter` file dialogs, so they want a desktop session. Described as kept-for-reference rather than as part of the routine workflow. Happy to be corrected if it's still in active use.

## Also

The repository map in `.github/copilot-instructions.md` now points at the new README, so the one-line description there has somewhere to lead.

The Conventions section defers to `.github/instructions/processing-tools.instructions.md` rather than restating it, and adds two habits that came out of this session's reviews: fail loudly rather than plausibly (a checker that silently returns a wrong number is worse than one that crashes), and name what a check actually guards (so a failure sends the reader to the right place).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvouB9AeGksUwTnJC4LdfA)_