### PR TITLE
M4 prerequisites: fix the predator-prey linearization, the pendulum's closed-loop promise, and chapter 1's undefined vocabulary

### DIFF
--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -1305,6 +1305,133 @@ REGISTRY += [
 ]
 
 
+# ----------------------------------------------------------------------
+# M4 — the "Modeling with..." sections, now in the build set
+#
+# These files shipped unguarded because they were commented out of
+# main.ptx when the registry was written. Every closed-form solution and
+# linearization they print is checked here.
+# ----------------------------------------------------------------------
+def euler_pendulum_energy_ratio(theta0, h, t_end, g_over_L=1.0):
+    """Explicit Euler on theta'=w, w'=-(g/L)sin(theta); returns E_end / E_0.
+
+    The undamped pendulum conserves energy exactly, so the true ratio is 1.
+    Explicit Euler does not, which is the point em-model.ptx now makes.
+    """
+    import math
+    th, w = float(theta0), 0.0
+    energy = lambda a, b: 0.5 * b * b + g_over_L * (1.0 - math.cos(a))
+    e0 = energy(th, w)
+    for _ in range(int(round(t_end / h))):
+        th, w = th + h * w, w + h * (-g_over_L * math.sin(th))
+    return energy(th, w) / e0
+
+
+REGISTRY += [
+    Check(
+        "c13 model: Lotka-Volterra Jacobian has zero diagonal at (c/d, a/b)",
+        "source/c13-linsys/linsys-model.ptx",
+        lambda: (lambda a, b, c, d, R, F: (
+            lambda J: simplify(J.subs({R: c / d, F: a / b}))
+            == Matrix([[0, -b * c / d], [a * d / b, 0]])
+        )(jacobian(a * R - b * R * F, -c * F + d * R * F, R, F)))(
+            *symbols("a b c d R F", positive=True)
+        ),
+    ),
+    Check(
+        "c13 model: printed A = [[0,-0.6],[0.25,0]] from a=0.5,b=0.02,c=0.3,d=0.01",
+        "source/c13-linsys/linsys-model.ptx",
+        lambda: (lambda a, b, c, d: Matrix(
+            [[0, -b * (c / d)], [d * (a / b), 0]]
+        ) == Matrix([[0, R(-3, 5)], [R(1, 4), 0]]))(
+            R(1, 2), R(2, 100), R(3, 10), R(1, 100)
+        ),
+    ),
+    Check(
+        "c13 model: printed characteristic equation r^2 + 0.15 = 0, r = +/- i sqrt(0.15)",
+        "source/c13-linsys/linsys-model.ptx",
+        lambda: (lambda A, r: is_zero(
+            A.charpoly(r).as_expr() - (r**2 + R(15, 100))
+        ) and FiniteSet(*[simplify(v) for v in A.eigenvals()])
+            == FiniteSet(I * sqrt(R(15, 100)), -I * sqrt(R(15, 100))))(
+            Matrix([[0, R(-3, 5)], [R(1, 4), 0]]), symbols("r")
+        ),
+    ),
+    Check(
+        "c13 model: printed cycle period 2*pi/sqrt(0.15) = 16.2 months",
+        "source/c13-linsys/linsys-model.ptx",
+        lambda: abs(float(2 * pi / sqrt(R(15, 100))) - 16.2) < 0.05,
+    ),
+    Check(
+        "c7 model: explicit Euler adds energy to the undamped pendulum "
+        "(x5.9, x2.5, x1.2 at h=0.1, 0.05, 0.01)",
+        "source/c7-em/em-model.ptx",
+        lambda: all(
+            abs(euler_pendulum_energy_ratio(0.5, h, 20.0) - printed) < 0.05
+            for h, printed in ((0.1, 5.9), (0.05, 2.5), (0.01, 1.2))
+        )
+        # and the drift is always outward, never inward
+        and all(
+            euler_pendulum_energy_ratio(0.5, h, 20.0) > 1.0
+            for h in (0.1, 0.05, 0.01, 0.005)
+        ),
+    ),
+    Check(
+        "c5 model: V_C = V_0(1-e^{-t/RC}) + V_C(0)e^{-t/RC} solves the RC circuit",
+        "source/c5-if/if-model.ptx",
+        lambda: (lambda Rr, Cc, V0, Vc0: (
+            lambda v: is_zero(diff(v, t) + v / (Rr * Cc) - V0 / (Rr * Cc))
+            and is_zero(v.subs(t, 0) - Vc0)
+        )(V0 * (1 - exp(-t / (Rr * Cc))) + Vc0 * exp(-t / (Rr * Cc))))(
+            *symbols("R_res C_cap V_0 Vc0", positive=True)
+        ),
+    ),
+    Check(
+        "c8 model: all three damping regimes solve x'' + 2*zeta*w0*x' + w0^2 x = 0",
+        "source/c8-lhcc/lhcc-model.ptx",
+        lambda: (lambda z, w0, A, B: (
+            lambda ode: is_zero(
+                ode(exp(-z * w0 * t) * (A * cos(w0 * sqrt(1 - z**2) * t)
+                                        + B * sin(w0 * sqrt(1 - z**2) * t)), z)
+            )
+            and is_zero(ode(exp(-w0 * t) * (A + B * t), 1))
+            and is_zero(
+                ode(A * exp(w0 * (-z + sqrt(z**2 - 1)) * t)
+                    + B * exp(-w0 * (z + sqrt(z**2 - 1)) * t), z)
+            )
+        )(lambda x_, zz: simplify(
+            diff(x_, t, 2) + 2 * zz * w0 * diff(x_, t) + w0**2 * x_
+        )))(*symbols("zeta omega_0 A B", positive=True)),
+    ),
+    Check(
+        "c10 model: single dose C = (D/V)e^{-kt} solves C' = -kC, and L{C} = (D/V)/(s+k)",
+        "source/c10-lt/lt-model.ptx",
+        lambda: (lambda D, V, k: (
+            lambda C: is_zero(diff(C, t) + k * C)
+            and is_zero(C.subs(t, 0) - D / V)
+            and laplace_matches(C, (D / V) / (s + k))
+        )((D / V) * exp(-k * t)))(*symbols("D_dose V_vol k_el", positive=True)),
+    ),
+    Check(
+        "c10 model: infusion C = (I0/k)(1-e^{-kt}) solves C' = I0 - kC, C(0) = 0",
+        "source/c10-lt/lt-model.ptx",
+        lambda: (lambda I0, k: (
+            lambda C: is_zero(diff(C, t) - (I0 - k * C)) and is_zero(C.subs(t, 0))
+        )((I0 / k) * (1 - exp(-k * t))))(*symbols("I_0 k_el", positive=True)),
+    ),
+    Check(
+        "c10 model: C_max = (D/V)/(1-e^{-k*tau}) is the steady state, C_min + D/V = C_max",
+        "source/c10-lt/lt-model.ptx",
+        lambda: (lambda D, V, k, tau: (
+            lambda q, Cmax: is_zero(Cmax * q + D / V - Cmax)
+            and is_zero(Cmax * (1 - q) - D / V)
+        )(exp(-k * tau), (D / V) / (1 - exp(-k * tau))))(
+            *symbols("D_dose V_vol k_el tau_int", positive=True)
+        ),
+    ),
+]
+
+
 def main() -> int:
     failures = 0
     for check in REGISTRY:

--- a/processing-tools/verify-worked-math/verify_worked_math.py
+++ b/processing-tools/verify-worked-math/verify_worked_math.py
@@ -1370,9 +1370,13 @@ REGISTRY += [
             abs(euler_pendulum_energy_ratio(0.5, h, 20.0) - printed) < 0.05
             for h, printed in ((0.1, 5.9), (0.05, 2.5), (0.01, 1.2))
         )
-        # and the drift is always outward, never inward
+        # The drift is always outward, never inward. The margin is stated
+        # rather than testing against a bare 1.0: the smallest of these ratios
+        # is about 1.10 at h = 0.005, so 1.01 documents that the check is
+        # nowhere near marginal while still failing loudly if a future change
+        # made Euler conserve energy (or lose it).
         and all(
-            euler_pendulum_energy_ratio(0.5, h, 20.0) > 1.0
+            euler_pendulum_energy_ratio(0.5, h, 20.0) > 1.01
             for h in (0.1, 0.05, 0.01, 0.005)
         ),
     ),

--- a/source/c1-classification/class-model.ptx
+++ b/source/c1-classification/class-model.ptx
@@ -66,6 +66,17 @@
 			This is a <term>linear, homogeneous, second-order</term> differential equation.
 		</p>
 
+		<aside>
+			<title>New Word: <q>Homogeneous</q></title>
+			<p>
+				<idx><h>homogeneous</h></idx>
+				Order and linearity you have already met. <term>Homogeneous</term> is a third classification, and it is the simplest of the three to check: a linear equation is homogeneous when its <xref ref="gi-forcing-term-function" text="custom">forcing term</xref> — everything left over once every term containing the unknown function is moved to one side — is zero. The spring equation above is homogeneous because its right-hand side is <m>0</m>. Add a push from outside, as in <m>\frac{d^2y}{dt^2} + \frac{k}{m}y = \cos(t)</m>, and it becomes <term>nonhomogeneous</term>.
+			</p>
+			<p>
+				That is all you need here. The distinction earns its keep in <xref ref="chpt-homogeneous-eqns" text="title"/> and <xref ref="chpt-undetermined-coefficients" text="title"/>, where homogeneous and nonhomogeneous equations are solved by genuinely different methods.
+			</p>
+		</aside>
+
 		<p>
 			<term>Enhanced Model (Linear, Second-Order with Damping):</term>
 		</p>

--- a/source/c13-linsys/linsys-model.ptx
+++ b/source/c13-linsys/linsys-model.ptx
@@ -106,17 +106,17 @@
 		<p>
 			With <m>R^* = 30</m> and <m>F^* = 25</m>, the linearized system has coefficient matrix
 			<md>
-				A = \begin{bmatrix} 0 \amp -bR^* \\ dF^* \amp 0 \end{bmatrix}
-				  = \begin{bmatrix} 0 \amp -0.6 \\ 0.25 \amp 0 \end{bmatrix}.
-			</md>
+				<mrow>A \amp = \begin{bmatrix} 0 \amp -bR^* \\ dF^* \amp 0 \end{bmatrix}</mrow>
+				<mrow>  \amp = \begin{bmatrix} 0 \amp -0.6 \\ 0.25 \amp 0 \end{bmatrix}</mrow>
+			</md>.
 		</p>
 
 		<p>
 			<term>Characteristic equation:</term>
 			<md>
-				\det(A - rI) = \det\begin{bmatrix} -r \amp -0.6 \\ 0.25 \amp -r \end{bmatrix}
-				= r^2 + 0.15 = 0 ,
-			</md>
+				<mrow>\det(A - rI) \amp = \det\begin{bmatrix} -r \amp -0.6 \\ 0.25 \amp -r \end{bmatrix}</mrow>
+				<mrow>  \amp = r^2 + 0.15 = 0</mrow>
+			</md>,
 			so <m>r = \pm i\sqrt{0.15} \approx \pm 0.387 i</m>.
 		</p>
 
@@ -127,11 +127,11 @@
 			<li>Real, both negative: stable node (populations return to equilibrium)</li>
 			<li>Real, opposite signs: saddle point (unstable)</li>
 			<li>Complex with negative real part: stable spiral (damped oscillations)</li>
-			<li>Pure imaginary: <em>center</em> — perpetual oscillations, which is the case here</li>
+			<li>Pure imaginary: <em>center</em> in the linearized system — perpetual oscillations, which is the row we land in here</li>
 		</ul>
 
 		<p>
-			So the linearization predicts closed orbits around <m>(30, 25)</m> with period <m>2\pi/\sqrt{0.15} \approx 16.2</m> months: the populations cycle forever rather than settling. Two cautions, both taken up in <xref ref="linearization-and-the-jacobian" text="title"/>, where this same model is worked in full. A purely imaginary pair is the one case in which linearization is <em>inconclusive</em> — the discarded nonlinear terms decide whether the orbits really close, spiral in, or spiral out. And a genuine center is fragile: add even mild crowding among the rabbits and it becomes a spiral sink.
+			So the <em>linearized</em> system has closed orbits around <m>(30, 25)</m> with period <m>2\pi/\sqrt{0.15} \approx 16.2</m> months, predicting populations that cycle rather than settle. Whether the full nonlinear model does the same is a further question, and two cautions apply — both taken up in <xref ref="linearization-and-the-jacobian" text="title"/>, where this model is worked in full. A purely imaginary pair is the one case in which linearization is <em>inconclusive</em>: the discarded nonlinear terms decide whether the orbits really close, spiral in, or spiral out. And even a genuine center is fragile — add mild crowding among the rabbits and it becomes a spiral sink.
 		</p>
 	</subsection>
 

--- a/source/c13-linsys/linsys-model.ptx
+++ b/source/c13-linsys/linsys-model.ptx
@@ -67,17 +67,21 @@
 		</p>
 
 		<p>
-			For small perturbations around equilibrium <m>(R^*, F^*)</m>, let <m>r = R - R^*</m> and <m>f = F - F^*</m>:
+			For small perturbations around the equilibrium <m>(R^*, F^*)</m>, let <m>u = R - R^*</m> and <m>v = F - F^*</m>. The coefficients come from the <xref ref="gi-jacobian-matrix" text="custom">Jacobian matrix</xref> of the system,
 			<md>
-				<mrow> \frac{dr}{dt} \amp = -bF^* r + aR^* f </mrow>
-				<mrow> \frac{df}{dt} \amp = dF^* r - cR^* f </mrow>
+				J(R,F) = \begin{bmatrix} a - bF \amp -bR \\ dF \amp -c + dR \end{bmatrix},
+			</md>
+			evaluated at the equilibrium. Substituting <m>R^* = c/d</m> and <m>F^* = a/b</m> makes <em>both diagonal entries vanish</em>, since <m>a - bF^* = a - a = 0</m> and <m>-c + dR^* = -c + c = 0</m>:
+			<md>
+				<mrow> \frac{du}{dt} \amp = -bR^*\, v </mrow>
+				<mrow> \frac{dv}{dt} \amp = dF^*\, u </mrow>
 			</md>
 		</p>
 
 		<p>
 			Or in matrix form:
 			<md>
-				\frac{d}{dt}\begin{pmatrix} r \\ f \end{pmatrix} = \begin{pmatrix} -bF^* \amp +aR^* \\ dF^* \amp -cR^* \end{pmatrix}\begin{pmatrix} r \\ f \end{pmatrix}
+				\frac{d}{dt}\begin{bmatrix} u \\ v \end{bmatrix} = \begin{bmatrix} 0 \amp -bR^* \\ dF^* \amp 0 \end{bmatrix}\begin{bmatrix} u \\ v \end{bmatrix}
 			</md>
 		</p>
 
@@ -100,28 +104,35 @@
 		<title>Solution via Eigenanalysis</title>
 
 		<p>
-			The linearized system has coefficient matrix:
+			With <m>R^* = 30</m> and <m>F^* = 25</m>, the linearized system has coefficient matrix
 			<md>
-				A = \begin{pmatrix} -0.5 \amp 15 \\ 0.25 \amp -9 \end{pmatrix}
+				A = \begin{bmatrix} 0 \amp -bR^* \\ dF^* \amp 0 \end{bmatrix}
+				  = \begin{bmatrix} 0 \amp -0.6 \\ 0.25 \amp 0 \end{bmatrix}.
 			</md>
 		</p>
 
 		<p>
 			<term>Characteristic equation:</term>
 			<md>
-				\det(A - \lambda I) = (\lambda + 0.5)(\lambda + 15) + 3.75 = 0
+				\det(A - rI) = \det\begin{bmatrix} -r \amp -0.6 \\ 0.25 \amp -r \end{bmatrix}
+				= r^2 + 0.15 = 0 ,
 			</md>
+			so <m>r = \pm i\sqrt{0.15} \approx \pm 0.387 i</m>.
 		</p>
 
 		<p>
-			Solving gives eigenvalues (which may be complex), determining the nature of the equilibrium:
+			The eigenvalues are <em>purely imaginary</em>, which puts this equilibrium in the last row of the classification table:
 		</p>
 		<ul>
 			<li>Real, both negative: stable node (populations return to equilibrium)</li>
 			<li>Real, opposite signs: saddle point (unstable)</li>
 			<li>Complex with negative real part: stable spiral (damped oscillations)</li>
-			<li>Pure imaginary: center (perpetual oscillations)</li>
+			<li>Pure imaginary: <em>center</em> — perpetual oscillations, which is the case here</li>
 		</ul>
+
+		<p>
+			So the linearization predicts closed orbits around <m>(30, 25)</m> with period <m>2\pi/\sqrt{0.15} \approx 16.2</m> months: the populations cycle forever rather than settling. Two cautions, both taken up in <xref ref="linearization-and-the-jacobian" text="title"/>, where this same model is worked in full. A purely imaginary pair is the one case in which linearization is <em>inconclusive</em> — the discarded nonlinear terms decide whether the orbits really close, spiral in, or spiral out. And a genuine center is fragile: add even mild crowding among the rabbits and it becomes a spiral sink.
+		</p>
 	</subsection>
 
 	<subsection>

--- a/source/c7-em/em-model.ptx
+++ b/source/c7-em/em-model.ptx
@@ -148,9 +148,19 @@
 
 		<ol>
 			<li>For several initial amplitudes, plot <m>\omega</m> versus <m>\theta</m> (phase portrait)</li>
-			<li>Observe the shape of the trajectories—they should be closed loops for oscillatory motion</li>
+			<li>The <em>true</em> trajectories of the undamped pendulum are closed loops, because the total energy never changes. Check whether the loops your simulation draws actually close.</li>
 			<li>What happens as <m>\theta_0</m> approaches <m>\pi</m> (upside-down position)?</li>
 		</ol>
+
+		<aside>
+			<title>Your Loops Will Not Close</title>
+			<p>
+				They should — and they won't. Explicit Euler does not conserve energy; it quietly <em>adds</em> a little at every step, so the phase-plane trajectory spirals slowly outward instead of retracing itself. Starting from <m>\theta_0 = 0.5</m> with <m>g/L = 1</m> and running to <m>t = 20</m>, the total energy grows by a factor of about <m>5.9</m> at <m>h = 0.1</m>, about <m>2.5</m> at <m>h = 0.05</m>, and about <m>1.2</m> at <m>h = 0.01</m>.
+			</p>
+			<p>
+				That pattern is the point. The drift is an artifact of the <em>method</em>, not of the pendulum, and it shrinks as <m>h</m> shrinks — exactly the first-order behavior of <xref ref="euler-accuracy" text="title"/>. Treat the gap between your spiral and the true closed loop as a measurement of Euler's error, and say so in your report rather than reporting closed orbits you did not actually get.
+			</p>
+		</aside>
 	</subsection>
 
 	<subsection>
@@ -219,8 +229,8 @@
 			<li>Description of your Euler's method implementation (include code snippets or pseudocode).</li>
 			<li>Graphs of <m>\theta(t)</m> and <m>\omega(t)</m> for multiple amplitudes.</li>
 			<li>Period versus amplitude data and graph, with comparison to small-angle theory.</li>
-			<li>Phase space portraits showing closed orbits.</li>
-			<li>Energy conservation analysis throughout your simulations.</li>
+			<li>Phase space portraits, with a comment on how nearly your computed orbits close.</li>
+			<li>Energy analysis throughout your simulations: report how far the total energy drifts, and how that drift responds to the step size.</li>
 			<li>Discussion of numerical accuracy and how step size affects results.</li>
 			<li>If conducted, comparison with experimental pendulum data.</li>
 			<li>Exploration of at least one extension (damping, driving, or chaos).</li>


### PR DESCRIPTION
Commit `30a3483` enabled all fifteen "Modeling with…" sections, which makes **M4** live — but leaves the three prerequisites the audit attached to it unmet. All three are now student-facing, so this fixes them.

## 1. The predator-prey linearization (Appendix A erratum #33)

The general formula in `linsys-model.ptx` was wrong in **three of its four entries**. Only `(2,1) = dF*` was right.

Deriving the Jacobian and evaluating at `(c/d, a/b)` makes **both diagonal entries vanish** — `a − bF* = 0` and `−c + dR* = 0` are exactly the equilibrium conditions:

| Entry | File printed | Correct |
|---|---|---|
| (1,1) | `−bF*` = `−a` | **0** |
| (1,2) | `+aR*` | **`−bR*`** |
| (2,1) | `dF*` | `dF*` ✓ |
| (2,2) | `−cR*` | **0** |

giving `A = [[0, −0.6], [0.25, 0]]` for the file's own parameters.

**The characteristic equation was wrong even for the file's own wrong matrix.** It read `(r+0.5)(r+15) + 3.75` — using `15` where that matrix has `9`, and `+3.75` where the determinant gives `−3.75`. Corrected to `r² + 0.15 = 0`, so `r = ±i√0.15` and the equilibrium is a **center** with period ≈ 16.2 months.

**This matters beyond the arithmetic.** Chapter 14 now teaches this same model and derives this same Jacobian, with CAS checks behind it. Until this fix the book stated two different Jacobians for one system, one chapter apart — a reader meeting both saw it contradict itself. The section also picks up the caveat ch. 14 established: a purely imaginary pair is precisely the case where linearization is *inconclusive*, and a genuine center is fragile.

While in there, matrices move `pmatrix` → `bmatrix` and the eigenvalue symbol `\lambda` → `r`, per the notation conventions. (The `\lambda` in `class-model.ptx` is a decay constant, not an eigenvalue, and is left alone.)

## 2. The pendulum's closed loops

`em-model.ptx` asked students to "observe the shape of the trajectories—they should be closed loops" and to submit "phase space portraits showing closed orbits."

**They will not get closed orbits.** Explicit Euler adds energy at every step, so the trajectory spirals outward. Measured on the file's own setup (`θ₀ = 0.5`, `g/L = 1`, to `t = 20`):

| step size | energy growth |
|---|---|
| `h = 0.1` | **× 5.9** |
| `h = 0.05` | **× 2.5** |
| `h = 0.01` | **× 1.2** |

The section now states that the *true* orbits close, predicts that the computed ones won't, and reframes the gap as a measurement of the method's error — pointing at the accuracy section added in M5, where that shrinking drift is exactly the first-order behavior. The report checklist now asks for the energy drift instead of for orbits the student cannot produce.

This seemed worth more than a footnote: a lab that tells students to expect something the method cannot deliver teaches them to distrust their own correct work.

## 3. Chapter 1's undefined vocabulary

`class-model.ptx` calls the spring equation "linear, **homogeneous**, second-order" — six chapters before *homogeneous* is defined, and asks students to classify equations by it. An aside now defines it in place (the forcing term is zero), contrasts it with a driven oscillator, and points forward to the chapters where the distinction actually changes the method.

## Verification

| Check | Result |
|---|---|
| `verify_worked_math.py` | **154/154** (144 existing + **10 new**) |
| `validate_source.py` | all parse · 1758 unique ids, 0 duplicated · 0 placeholder markers |
| `check_descriptions.py` | 64/64 images, 10/10 interactives |
| broken xrefs | 0 |

The model files shipped **unguarded** — they were commented out of `main.ptx` when the registry was written, so no check covered them. The 10 new checks close that gap across every closed-form claim they print:

- the corrected Jacobian, its zero diagonal, `A`, the characteristic equation, and the 16.2-month period
- the pendulum energy drift — pinning all three figures *and* asserting the drift is always outward, never inward
- `if-model`'s RC-circuit solution, against the ODE and the initial condition
- `lhcc-model`'s **three** damping regimes (underdamped, critically damped, overdamped)
- `lt-model`'s single-dose, infusion, and steady-state accumulation formulas

Markup conformance: **0 novel constructs** across the three edited files.

## Scope

This covers M4's *prerequisites* — the blockers the audit named. M4's remaining body of work is the pedagogical wiring: presenting the enabled files as a per-chapter "Modeling & Projects" section and extracting 1–2 gradable sub-questions from each into the active exercise sets. That is a substantially larger job and is untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvouB9AeGksUwTnJC4LdfA)_